### PR TITLE
propagate skfs->skdb renaming to docker files, docs, etc.

### DIFF
--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -17,7 +17,7 @@ dockerbuild () {
 
 dockerbuild skiplabs/skdb-base .
 dockerbuild skiplabs/skdb-dev-server sql/server/dev
-[[ -f $USER/Dockerfile ]] && dockerbuild $USER-skfs $USER
+[[ -f $USER/Dockerfile ]] && dockerbuild $USER-skdb $USER
 
 git restore .dockerignore
 

--- a/ide/emacs/skip-flycheck.el
+++ b/ide/emacs/skip-flycheck.el
@@ -3,7 +3,7 @@
 ;; Author: Lucas Hosseini <lucas@skiplabs.io>
 ;; Keywords: skip
 ;; Package-Requires: ((flycheck) (skip))
-;; URL: https://github.com/skiplabs/skfs
+;; URL: https://github.com/skiplabs/skdb
 
 ;;; Commentary:
 

--- a/ide/emacs/skip-formatter.el
+++ b/ide/emacs/skip-formatter.el
@@ -3,13 +3,13 @@
 ;; Author: Benno Stein <benno@skiplabs.io>
 ;; Maintainer: Benno Stein <benno@skiplabs.io>
 ;; Package-Requires: ((reformatter "0.7"))
-;; URL: https://github.com/skiplabs/skfs
+;; URL: https://github.com/skiplabs/skdb
 
 ;;; Defines a minor mode skip-format-on-save-mode
 ;;; (along with skip-format-buffer and skip-format-region functions)
 
 ;;; To enable by default, add this to your .emacs file:
-;;; (require 'skip-formatter "<path to skfs>/ide/emacs/skip-formatter.el")
+;;; (require 'skip-formatter "<path to skdb>/ide/emacs/skip-formatter.el")
 ;;; (add-hook 'skip-mode-hook 'skip-format-on-save-mode)
 
 ;;; Optionally, configure to run skfmt in a docker container by setting

--- a/ide/emacs/skip.el
+++ b/ide/emacs/skip.el
@@ -1,7 +1,7 @@
 ;;; skip.el --- Skip mode for GNU Emacs  -*- lexical-binding:t -*-
 
 ;; Package-Requires: ((derived) (cc-mode))
-;; URL: https://github.com/skiplabs/skfs
+;; URL: https://github.com/skiplabs/skdb
 
 ;;; Commentary:
 

--- a/sql/server/core/src/main/kotlin/core/StaticConfig.kt
+++ b/sql/server/core/src/main/kotlin/core/StaticConfig.kt
@@ -19,11 +19,11 @@ class UserConfig(
 ) {
   companion object {
     val SKDB_PORT = 8080
-    val SKDB = "/skfs/build/skdb"
-    val SKDB_INIT = "/skfs/build/init.sql"
+    val SKDB = "/skdb/build/skdb"
+    val SKDB_INIT = "/skdb/build/init.sql"
     val SKDB_DATABASES = "/var/db"
     val SKDB_ADD_CRED =
-        "cd /skfs/build/package && npx skdb-cli --add-cred --host ws://localhost:%d --db %s --access-key %s <<< \"%s\""
+        "cd /skdb/build/package && npx skdb-cli --add-cred --host ws://localhost:%d --db %s --access-key %s <<< \"%s\""
 
     private fun userConfigFile(): Optional<String> {
       var path = Paths.get("").toAbsolutePath()

--- a/sql/server/deploy/Dockerfile
+++ b/sql/server/deploy/Dockerfile
@@ -6,9 +6,9 @@
 # here - we can't reuse existing images that might be arm64
 FROM --platform=linux/amd64 skiplabs/skdb-base as skdb
 
-COPY . /skfs
+COPY . /skdb
 
-WORKDIR /skfs
+WORKDIR /skdb
 
 RUN make clean && make build/skdb && make build/init.sql
 
@@ -16,9 +16,9 @@ RUN make clean && make build/skdb && make build/init.sql
 # this is faster anyway
 FROM eclipse-temurin:20 as skgw
 
-COPY . /skfs
+COPY . /skdb
 
-WORKDIR /skfs/sql/server/skgw
+WORKDIR /skdb/sql/server/skgw
 RUN ../gradlew jar --no-daemon --console plain
 
 ################################################################################
@@ -27,10 +27,10 @@ RUN ../gradlew jar --no-daemon --console plain
 
 FROM --platform=linux/amd64 eclipse-temurin:20 as prod
 
-WORKDIR /skfs
+WORKDIR /skdb
 
-COPY --from=skdb /skfs/build ./build
-COPY --from=skgw /skfs/sql/server/skgw/build/libs/skgw.jar /skfs/build/server.jar
-COPY --from=skgw /skfs/sql/server/deploy/start_prod.sh /skfs/build/start.sh
+COPY --from=skdb /skdb/build ./build
+COPY --from=skgw /skdb/sql/server/skgw/build/libs/skgw.jar /skdb/build/server.jar
+COPY --from=skgw /skdb/sql/server/deploy/start_prod.sh /skdb/build/start.sh
 
-CMD /skfs/build/start.sh
+CMD /skdb/build/start.sh

--- a/sql/server/deploy/prod-build-push.sh
+++ b/sql/server/deploy/prod-build-push.sh
@@ -8,14 +8,14 @@ set -e
 # it's hideous. it will only work for gds and relies on his personal setup and access keys.
 # but better than no docs at all, right?
 
-cd ~/code/skfs || exit 1
+cd ~/code/skdb || exit 1
 
 find . -name state.db|xargs rm
 
 echo "Building skgw image"
 docker build -t skgw-deploy --progress=plain -f sql/server/deploy/Dockerfile .
 
-cd ~/code/skfs/sql/server/proxy || exit 1
+cd ~/code/skdb/sql/server/proxy || exit 1
 
 echo "Building nginx image"
 docker build -t nginx-deploy --progress=plain -f Dockerfile .
@@ -48,7 +48,7 @@ docker push 400962513797.dkr.ecr.us-east-1.amazonaws.com/nginx:latest
 # sudo /usr/bin/docker pull 400962513797.dkr.ecr.us-east-1.amazonaws.com/skdb:latest
 
 # port over any databases, here's an example
-# sudo docker exec -it -w /skfs -e INSIDE_EMACS=1 <CONTAINER> /bin/bash
+# sudo docker exec -it -w /skdb -e INSIDE_EMACS=1 <CONTAINER> /bin/bash
 # build/skdb dump --data /var/db/skdb_service_mgmt.db
 # sudo docker stop $(sudo docker ps -q)
 # sudo /usr/bin/docker run -it -p 8080:8080 -v /var/db:/var/db 400962513797.dkr.ecr.us-east-1.amazonaws.com/skdb:latest /bin/bash

--- a/sql/server/deploy/start_prod.sh
+++ b/sql/server/deploy/start_prod.sh
@@ -9,4 +9,4 @@
 # is a cold start
 mkdir -p /var/db || exit 1
 
-java -jar /skfs/build/server.jar "$@"
+java -jar /skdb/build/server.jar "$@"

--- a/sql/server/dev/Dockerfile
+++ b/sql/server/dev/Dockerfile
@@ -1,16 +1,16 @@
 FROM skiplabs/skdb-base as skdb
 
-COPY . /skfs
+COPY . /skdb
 
-WORKDIR /skfs
+WORKDIR /skdb
 
 RUN make clean && make -C compiler clean && make build/skdb && make build/init.sql
 
 FROM eclipse-temurin:20 as skgw
 
-COPY . /skfs
+COPY . /skdb
 
-WORKDIR /skfs/sql/server/dev
+WORKDIR /skdb/sql/server/dev
 RUN ../gradlew jar --no-daemon --console plain
 
 ################################################################################
@@ -19,10 +19,10 @@ RUN ../gradlew jar --no-daemon --console plain
 
 FROM eclipse-temurin:20 as dev
 
-WORKDIR /skfs
+WORKDIR /skdb
 
-COPY --from=skdb /skfs/build ./build
-COPY --from=skgw /skfs/sql/server/dev/build/libs/dev.jar /skfs/build/server.jar
-COPY --from=skgw /skfs/sql/server/dev/start_dev.sh /skfs/build/start.sh
+COPY --from=skdb /skdb/build ./build
+COPY --from=skgw /skdb/sql/server/dev/build/libs/dev.jar /skdb/build/server.jar
+COPY --from=skgw /skdb/sql/server/dev/start_dev.sh /skdb/build/start.sh
 
-ENTRYPOINT ["/skfs/build/start.sh"]
+ENTRYPOINT ["/skdb/build/start.sh"]

--- a/sql/server/dev/start_dev.sh
+++ b/sql/server/dev/start_dev.sh
@@ -9,4 +9,4 @@
 # is a cold start
 mkdir -p /var/db || exit 1
 
-java -jar /skfs/build/server.jar "$@"
+java -jar /skdb/build/server.jar "$@"

--- a/sql/test/replication/model.py
+++ b/sql/test/replication/model.py
@@ -8,8 +8,8 @@ import os
 import json
 import itertools
 
-SKDB = "/skfs/build/skdb"
-INITSQL = "/skfs/sql/privacy/init.sql"
+SKDB = "/skdb/build/skdb"
+INITSQL = "/skdb/sql/privacy/init.sql"
 
 def serialise(val):
   if isinstance(val, str):

--- a/sql/ts/README.md
+++ b/sql/ts/README.md
@@ -1,6 +1,6 @@
 # Instructions to build & run skdb-cli
 
-Relative to `/path/to/skfsrepo/sql/ts/` (i.e. the directory with this README
+Relative to `/path/to/skdb_repo/sql/ts/` (i.e. the directory with this README
 in):
 
 1. Build `sknpm` with `make -C ../.. build/sknpm`


### PR DESCRIPTION
I went through and did the skfs to skdb renaming where it refers to the root directory of the repo, including changing the workdir in some docker images and corresponding deployment scripts.

This will likely break some people's $USER-skfs dockerfiles and scripts in the short term, but seems better to do it sooner than later.