### PR TITLE
Simplify global group definitions in init.sql

### DIFF
--- a/sql/privacy/init.sql
+++ b/sql/privacy/init.sql
@@ -57,9 +57,9 @@ CREATE UNIQUE INDEX skdb_groups_users_unique ON skdb_groups_users(groupID);
 -------------------------------------------------------------------------------
 
 INSERT INTO skdb_groups VALUES
-  ('read-only', NULL, 'root', 'root'),
-  ('read-write', NULL, 'root', 'root'),
-  ('write-only', NULL, 'root', 'root')
+  ('read-only', NULL, 'root', 'read-only'),
+  ('read-write', NULL, 'root', 'read-only'),
+  ('write-only', NULL, 'root', 'read-only')
 ;
 
 INSERT INTO skdb_group_permissions VALUES
@@ -67,7 +67,3 @@ INSERT INTO skdb_group_permissions VALUES
        ('write-only', NULL, skdb_permission('w'), 'read-only'),
        ('read-write', NULL, skdb_permission('rw'), 'read-only')
 ;
-
-UPDATE skdb_groups SET skdb_access='read-only'
-       WHERE groupID IN ('read-only', 'write-only', 'read-write');
-

--- a/sql/privacy/init.sql
+++ b/sql/privacy/init.sql
@@ -53,48 +53,21 @@ CREATE UNIQUE INDEX skdb_groups_users_unique ON skdb_groups_users(groupID);
 
 -------------------------------------------------------------------------------
 -- Some default groups
+-- (globally-visible) groups granting global privileges matching their groupID
 -------------------------------------------------------------------------------
 
--- First let's create read-only-root, it's a group where everybody can
--- read but nothing else.
-
-INSERT INTO skdb_groups
-  VALUES ('read-only-root', NULL, 'root', 'root')
+INSERT INTO skdb_groups VALUES
+  ('read-only', NULL, 'root', 'root'),
+  ('read-write', NULL, 'root', 'root'),
+  ('write-only', NULL, 'root', 'root')
 ;
 
-INSERT INTO skdb_group_permissions
-  VALUES ('read-only-root', NULL, skdb_permission('r'), 'root')
+INSERT INTO skdb_group_permissions VALUES
+       ('read-only', NULL, skdb_permission('r'), 'read-only'),
+       ('write-only', NULL, skdb_permission('w'), 'read-only'),
+       ('read-write', NULL, skdb_permission('rw'), 'read-only')
 ;
 
--- read-only is visible by everyone, but only the root can change the
--- permissions (which should never happen).
+UPDATE skdb_groups SET skdb_access='read-only'
+       WHERE groupID IN ('read-only', 'write-only', 'read-write');
 
-INSERT INTO skdb_groups
-  VALUES ('read-only', NULL, 'read-only-root', 'root')
-;
-
-INSERT INTO skdb_group_permissions
-  VALUES ('read-only', NULL, skdb_permission('r'), 'read-only-root')
-;
-
--- write-only is visible by everyone, but only the root can change the
--- permissions (which should never happen).
-
-INSERT INTO skdb_groups
-  VALUES ('write-only', NULL, 'read-only-root', 'root')
-;
-
-INSERT INTO skdb_group_permissions
-  VALUES ('write-only', NULL, skdb_permission('di'), 'read-only-root')
-;
-
--- read-write is visible by everyone, but only the root can change the
--- permissions (which should never happen).
-
-INSERT INTO skdb_groups
-  VALUES ('read-write', NULL, 'read-only-root', 'root')
-;
-
-INSERT INTO skdb_group_permissions
-  VALUES ('read-write', NULL, skdb_permission('dir'), 'read-only-root')
-;

--- a/sql/test_replication_resets.sh
+++ b/sql/test_replication_resets.sh
@@ -114,7 +114,7 @@ EOF
     assert_line_count "$SERVER_TAIL" 'keep' 0
     # and that the server is at 69 and we sent up at 10
     assert_line_count "$SERVER_TAIL" 'test_with_access 10' 1
-    assert_line_count "$SERVER_TAIL" ':69' 1
+    assert_line_count "$SERVER_TAIL" ':58' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value and the erase
@@ -159,7 +159,7 @@ EOF
     assert_line_count "$SERVER_TAIL" 'new' 1
     # sanity check the tick value - it's important for later - we're at 69 they're at 10
     assert_line_count "$SERVER_TAIL" 'test 10' 1
-    assert_line_count "$SERVER_TAIL" ':69' 1
+    assert_line_count "$SERVER_TAIL" ':58' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value but not the new,
@@ -254,12 +254,12 @@ test_resets_are_aggressively_nooped() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':72' 1
+    assert_line_count "$SERVER_TAIL" ':61' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test 72
+^test 61
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -268,7 +268,7 @@ test_resets_are_aggressively_nooped() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test 72
+^test 61
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -297,12 +297,12 @@ test_resets_are_aggressively_nooped_but_we_do_not_lose_an_update() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':72' 1
+    assert_line_count "$SERVER_TAIL" ':61' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test 72
+^test 61
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -311,7 +311,7 @@ test_resets_are_aggressively_nooped_but_we_do_not_lose_an_update() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test 72
+^test 61
 1	1,"bar","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"
@@ -341,12 +341,12 @@ test_resets_are_aggressively_nooped_but_we_do_not_lose_an_update2() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':72' 1
+    assert_line_count "$SERVER_TAIL" ':61' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test 72
+^test 61
 1	1,"bar","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"
@@ -355,7 +355,7 @@ test_resets_are_aggressively_nooped_but_we_do_not_lose_an_update2() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test 72
+^test 61
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -391,13 +391,13 @@ test_resets_no_op_repeat_count_logic() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':90' 1
+    assert_line_count "$SERVER_TAIL" ':79' 1
 
     # this is added concurrently and shouldn't be eligible
     $SKDB_BIN --data $SERVER_DB <<< "INSERT INTO test VALUES (2,'baz','GALL');"
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test 90
+^test 79
 7	0,"foo","GALL"
 0	1,"bar","GALL"
 2	2,"baz","GALL"
@@ -413,13 +413,13 @@ EOF
 
     $SKDB_BIN tail --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':98' 1
+    assert_line_count "$SERVER_TAIL" ':87' 1
 
     # this is added concurrently and shouldn't be eligible
     $SKDB_BIN --data $SERVER_DB <<< "INSERT INTO test VALUES (2,'baz','GALL');"
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test 98
+^test 87
 5	0,"foo","GALL"
 1	1,"bar","GALL"
 2	2,"baz","GALL"
@@ -467,9 +467,9 @@ EOF
     # just sanity check that U98 can see erase but not keep
     assert_line_count "$SERVER_TAIL" 'erase' 1
     assert_line_count "$SERVER_TAIL" 'keep' 0
-    # and that the server is at 69 and we sent up at 10
+    # and that the server is at 58 and we sent up at 10
     assert_line_count "$SERVER_TAIL" 'test_with_pk_with_access 10' 1
-    assert_line_count "$SERVER_TAIL" ':69' 1
+    assert_line_count "$SERVER_TAIL" ':58' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value and the erase
@@ -511,13 +511,13 @@ EOF
 
     # if we did replicate now we would get the new row
     assert_line_count "$SERVER_TAIL" 'new' 1
-    # sanity check the tick value - it's important for later - we're at 69 they're at 10
+    # sanity check the tick value - it's important for later - we're at 58 they're at 10
     assert_line_count "$SERVER_TAIL" 'test_with_pk 10' 1
-    assert_line_count "$SERVER_TAIL" ':69' 1
+    assert_line_count "$SERVER_TAIL" ':58' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value but not the new,
-    # because it hasn't seen this row yet: 35 < 69.
+    # because it hasn't seen this row yet: 35 < 58.
     $SKDB_BIN write-csv --data $SERVER_DB --source 1234 --user U98 > /dev/null << EOF
 ^test_with_pk 35
 1	1,"baz","GALL"
@@ -549,7 +549,7 @@ test_resets_are_aggressively_nooped_pk() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test_with_pk)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':72' 1
+    assert_line_count "$SERVER_TAIL" ':61' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
@@ -560,7 +560,7 @@ test_resets_are_aggressively_nooped_pk() {
 1	1,"bar","GALL"
 1	2,"baz","GALL"
 		
-:10 72
+:10 61
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
@@ -594,12 +594,12 @@ test_resets_are_aggressively_nooped_with_local_change_pk() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test_with_pk)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':72' 1
+    assert_line_count "$SERVER_TAIL" ':61' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test_with_pk 72
+^test_with_pk 61
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -608,7 +608,7 @@ test_resets_are_aggressively_nooped_with_local_change_pk() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test_with_pk 72
+^test_with_pk 61
 1	1,"bar","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"
@@ -638,12 +638,12 @@ test_resets_are_aggressively_nooped_with_local_change_pk_2() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test_with_pk)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':72' 1
+    assert_line_count "$SERVER_TAIL" ':61' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test_with_pk 72
+^test_with_pk 61
 1	1,"bar","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"
@@ -652,7 +652,7 @@ test_resets_are_aggressively_nooped_with_local_change_pk_2() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test_with_pk 73
+^test_with_pk 61
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -682,12 +682,12 @@ test_resets_conflicting_pk() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test_with_pk)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':72' 1
+    assert_line_count "$SERVER_TAIL" ':61' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test_with_pk 72
+^test_with_pk 61
 1	1,"win","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"
@@ -696,7 +696,7 @@ test_resets_conflicting_pk() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test_with_pk 72
+^test_with_pk 61
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -726,12 +726,12 @@ test_resets_conflicting_reversed_pk() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test_with_pk)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':72' 1
+    assert_line_count "$SERVER_TAIL" ':61' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test_with_pk 72
+^test_with_pk 61
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -740,7 +740,7 @@ test_resets_conflicting_reversed_pk() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test_with_pk 70
+^test_with_pk 59
 1	1,"win","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"

--- a/sql/test_replication_resets.sh
+++ b/sql/test_replication_resets.sh
@@ -112,9 +112,9 @@ EOF
     # just sanity check that U98 can see erase but not keep
     assert_line_count "$SERVER_TAIL" 'erase' 1
     assert_line_count "$SERVER_TAIL" 'keep' 0
-    # and that the server is at 69 and we sent up at 10
+    # and that the server is at 57 and we sent up at 10
     assert_line_count "$SERVER_TAIL" 'test_with_access 10' 1
-    assert_line_count "$SERVER_TAIL" ':58' 1
+    assert_line_count "$SERVER_TAIL" ':57' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value and the erase
@@ -159,7 +159,7 @@ EOF
     assert_line_count "$SERVER_TAIL" 'new' 1
     # sanity check the tick value - it's important for later - we're at 69 they're at 10
     assert_line_count "$SERVER_TAIL" 'test 10' 1
-    assert_line_count "$SERVER_TAIL" ':58' 1
+    assert_line_count "$SERVER_TAIL" ':57' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value but not the new,
@@ -254,12 +254,12 @@ test_resets_are_aggressively_nooped() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':61' 1
+    assert_line_count "$SERVER_TAIL" ':60' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test 61
+^test 60
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -268,7 +268,7 @@ test_resets_are_aggressively_nooped() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test 61
+^test 60
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -297,12 +297,12 @@ test_resets_are_aggressively_nooped_but_we_do_not_lose_an_update() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':61' 1
+    assert_line_count "$SERVER_TAIL" ':60' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test 61
+^test 60
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -311,7 +311,7 @@ test_resets_are_aggressively_nooped_but_we_do_not_lose_an_update() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test 61
+^test 60
 1	1,"bar","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"
@@ -341,12 +341,12 @@ test_resets_are_aggressively_nooped_but_we_do_not_lose_an_update2() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':61' 1
+    assert_line_count "$SERVER_TAIL" ':60' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test 61
+^test 60
 1	1,"bar","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"
@@ -355,7 +355,7 @@ test_resets_are_aggressively_nooped_but_we_do_not_lose_an_update2() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test 61
+^test 60
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -391,13 +391,13 @@ test_resets_no_op_repeat_count_logic() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':79' 1
+    assert_line_count "$SERVER_TAIL" ':78' 1
 
     # this is added concurrently and shouldn't be eligible
     $SKDB_BIN --data $SERVER_DB <<< "INSERT INTO test VALUES (2,'baz','GALL');"
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test 79
+^test 78
 7	0,"foo","GALL"
 0	1,"bar","GALL"
 2	2,"baz","GALL"
@@ -413,13 +413,13 @@ EOF
 
     $SKDB_BIN tail --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':87' 1
+    assert_line_count "$SERVER_TAIL" ':86' 1
 
     # this is added concurrently and shouldn't be eligible
     $SKDB_BIN --data $SERVER_DB <<< "INSERT INTO test VALUES (2,'baz','GALL');"
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test 87
+^test 86
 5	0,"foo","GALL"
 1	1,"bar","GALL"
 2	2,"baz","GALL"
@@ -467,16 +467,16 @@ EOF
     # just sanity check that U98 can see erase but not keep
     assert_line_count "$SERVER_TAIL" 'erase' 1
     assert_line_count "$SERVER_TAIL" 'keep' 0
-    # and that the server is at 58 and we sent up at 10
+    # and that the server is at 57 and we sent up at 10
     assert_line_count "$SERVER_TAIL" 'test_with_pk_with_access 10' 1
-    assert_line_count "$SERVER_TAIL" ':58' 1
+    assert_line_count "$SERVER_TAIL" ':57' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value and the erase
     # from U99. but not the keep, because it can't see this
     # row.
     $SKDB_BIN write-csv --data $SERVER_DB --source 1234 --user U98 > /dev/null << EOF
-^test_with_pk_with_access 67
+^test_with_pk_with_access 57
 1	1,"baz","G1"
 1	2,"quux","G1"
 		
@@ -511,13 +511,13 @@ EOF
 
     # if we did replicate now we would get the new row
     assert_line_count "$SERVER_TAIL" 'new' 1
-    # sanity check the tick value - it's important for later - we're at 58 they're at 10
+    # sanity check the tick value - it's important for later - we're at 57 they're at 10
     assert_line_count "$SERVER_TAIL" 'test_with_pk 10' 1
-    assert_line_count "$SERVER_TAIL" ':58' 1
+    assert_line_count "$SERVER_TAIL" ':57' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value but not the new,
-    # because it hasn't seen this row yet: 35 < 58.
+    # because it hasn't seen this row yet: 35 < 57.
     $SKDB_BIN write-csv --data $SERVER_DB --source 1234 --user U98 > /dev/null << EOF
 ^test_with_pk 35
 1	1,"baz","GALL"
@@ -549,7 +549,7 @@ test_resets_are_aggressively_nooped_pk() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test_with_pk)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':61' 1
+    assert_line_count "$SERVER_TAIL" ':60' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
@@ -560,7 +560,7 @@ test_resets_are_aggressively_nooped_pk() {
 1	1,"bar","GALL"
 1	2,"baz","GALL"
 		
-:10 61
+:10 60
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
@@ -594,12 +594,12 @@ test_resets_are_aggressively_nooped_with_local_change_pk() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test_with_pk)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':61' 1
+    assert_line_count "$SERVER_TAIL" ':60' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test_with_pk 61
+^test_with_pk 60
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -608,7 +608,7 @@ test_resets_are_aggressively_nooped_with_local_change_pk() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test_with_pk 61
+^test_with_pk 60
 1	1,"bar","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"
@@ -638,12 +638,12 @@ test_resets_are_aggressively_nooped_with_local_change_pk_2() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test_with_pk)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':61' 1
+    assert_line_count "$SERVER_TAIL" ':60' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test_with_pk 61
+^test_with_pk 60
 1	1,"bar","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"
@@ -652,7 +652,7 @@ test_resets_are_aggressively_nooped_with_local_change_pk_2() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test_with_pk 61
+^test_with_pk 60
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -682,12 +682,12 @@ test_resets_conflicting_pk() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test_with_pk)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':61' 1
+    assert_line_count "$SERVER_TAIL" ':60' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test_with_pk 61
+^test_with_pk 60
 1	1,"win","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"
@@ -696,7 +696,7 @@ test_resets_conflicting_pk() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test_with_pk 61
+^test_with_pk 60
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -726,12 +726,12 @@ test_resets_conflicting_reversed_pk() {
     server_session=$($SKDB_BIN subscribe --data $SERVER_DB --connect --ignore-source 1234 test_with_pk)
     $SKDB_BIN tail --user U98 --data $SERVER_DB --format=csv "$server_session" --since 0 > $SERVER_TAIL
     # we need to check the server tick so that the values provided in below resets are accurate
-    assert_line_count "$SERVER_TAIL" ':61' 1
+    assert_line_count "$SERVER_TAIL" ':60' 1
 
     # server crashes and two clients that are up to speed reconnect with resets
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 1 --user U98 > /dev/null << EOF
-^test_with_pk 61
+^test_with_pk 60
 1	0,"foo","GALL"
 1	1,"bar","GALL"
 1	2,"baz","GALL"
@@ -740,7 +740,7 @@ test_resets_conflicting_reversed_pk() {
 EOF
 
     $SKDB_BIN write-csv --data $SERVER_DB --source 2 --user U98 > /dev/null << EOF
-^test_with_pk 59
+^test_with_pk 58
 1	1,"win","GALL"
 1	2,"baz","GALL"
 1	3,"quux","GALL"

--- a/sql/ts/tests/apitests.ts
+++ b/sql/ts/tests/apitests.ts
@@ -111,13 +111,13 @@ async function testQueriesAgainstTheServer(skdb: SKDB) {
   const remote = (await skdb.connectedRemote())!;
 
   const groupGALL = await remote.exec(
-    "INSERT INTO skdb_groups VALUES ('GALL', NULL, 'root', 'read-only-root');",
+    "INSERT INTO skdb_groups VALUES ('GALL', NULL, 'root', 'read-only');",
     new Map(),
   );
   expect(groupGALL).toEqual([]);
 
   const groupPermissionsGALL = await remote.exec(
-    "INSERT INTO skdb_group_permissions VALUES ('GALL', NULL, skdb_permission('rw'), 'read-only-root');",
+    "INSERT INTO skdb_group_permissions VALUES ('GALL', NULL, skdb_permission('rw'), 'read-only');",
     new Map(),
   );
   expect(groupPermissionsGALL).toEqual([]);


### PR DESCRIPTION
With the new style of permission checking (i.e. checking admin privileges as a special-case on writes to  skdb_group_permissions) we don't need the indirections previously employed in `init.sql` anymore.

This should preserve the privacy checking semantics and make things much more straightforward to read/understand.