### PR TITLE
Reduce write-csv memory usage by introducing 'GC'

### DIFF
--- a/compiler/runtime/posix.c
+++ b/compiler/runtime/posix.c
@@ -296,8 +296,7 @@ void SKIP_posix_execvp(char *args_obj) {
 int64_t SKIP_posix_isatty(int64_t fd) {
   int rv = isatty((int)fd);
   if (rv == 0 && errno != ENOTTY) {
-    perror("isatty");
-    exit(EXIT_FAILURE);
+    return 0;     /* treat this call as best effort and assume not a tty */
   }
   return (char)rv;
 }

--- a/skfs/src/Context.sk
+++ b/skfs/src/Context.sk
@@ -1614,16 +1614,40 @@ fun withRegion<T>(
 }
 
 fun withRegionVoid<T>(f: () ~> void): void {
-  saved = newObstack();
-  f();
-  destroyObstack(saved);
+  optSaved: ?Obstack = None();
+  try {
+    !optSaved = Some(newObstack());
+    f();
+    destroyObstack(optSaved.fromSome());
+  } catch {
+  | exn ->
+    optSaved match {
+    | Some(saved) ->
+      cexn = destroyObstackWithValue(saved, List[exn]).getHead();
+      saveExn(cexn);
+      throw cexn
+    | _ -> throw exn
+    }
+  }
 }
 
 fun withRegionValue<T>(f: () ~> T): T {
-  saved = newObstack();
-  fresult = f();
-  copied = destroyObstackWithValue(saved, List[fresult]);
-  copied.getHead();
+  optSaved: ?Obstack = None();
+  try {
+    !optSaved = Some(newObstack());
+    fresult = f();
+    copied = destroyObstackWithValue(optSaved.fromSome(), List[fresult]);
+    copied.getHead();
+  } catch {
+  | exn ->
+    optSaved match {
+    | Some(saved) ->
+      cexn = destroyObstackWithValue(saved, List[exn]).getHead();
+      saveExn(cexn);
+      throw cexn
+    | _ -> throw exn
+    }
+  }
 }
 
 fun copyToParentObstack<T>(

--- a/skfs/src/Context.sk
+++ b/skfs/src/Context.sk
@@ -1713,7 +1713,6 @@ fun withRegionFoldRec<K, T>(
   value: T,
   fn: (?mutable Context, K, T) ~> T,
 ): T {
-  // TODO: use iterator size hint to go straight to a good number of levels
   valueInRegion = value;
   levels = 0;
   loop {

--- a/skfs/src/Context.sk
+++ b/skfs/src/Context.sk
@@ -1707,4 +1707,84 @@ fun withRegionFold<K, T>(
   }
 }
 
+fun withRegionFoldRec<K, T>(
+  contextOpt: ?mutable Context,
+  it: mutable Iterator<K>,
+  value: T,
+  fn: (?mutable Context, K, T) ~> T,
+): T {
+  // TODO: use iterator size hint to go straight to a good number of levels
+  valueInRegion = value;
+  levels = 0;
+  loop {
+    it.next() match {
+    | Some(val) ->
+      !valueInRegion = withRegionFoldRecHelp(
+        contextOpt,
+        val,
+        it,
+        valueInRegion,
+        fn,
+        levels,
+      )
+    | None() -> break valueInRegion
+    };
+    !levels = levels + 1;
+  }
+}
+
+fun withRegionFoldRecHelp<K, T>(
+  contextOpt: ?mutable Context,
+  first: K,
+  it: mutable Iterator<K>,
+  value: T,
+  fn: (?mutable Context, K, T) ~> T,
+  level: Int,
+): T {
+  optSaved: ?Obstack = None();
+  try {
+    !optSaved = Some(newObstack());
+    valueInRegion = fn(contextOpt, first, value);
+    i = 0;
+    loop {
+      it.next() match {
+      | Some(k) ->
+        if (level < 1) {
+          !valueInRegion = fn(contextOpt, k, valueInRegion);
+          if (i > 64) {
+            break void
+          }
+        } else {
+          !valueInRegion = withRegionFoldRecHelp(
+            contextOpt,
+            k,
+            it,
+            valueInRegion,
+            fn,
+            level - 1,
+          );
+          if (i > 8) {
+            break void
+          };
+        }
+      | _ -> break void
+      };
+      !i = i + 1;
+    };
+    optSaved match {
+    | Some(saved) -> copyToParentObstack(contextOpt, valueInRegion, saved)
+    | _ -> value
+    }
+  } catch {
+  | exn ->
+    optSaved match {
+    | Some(saved) ->
+      cexn = destroyObstackWithValue(saved, List[exn]).getHead();
+      saveExn(cexn);
+      throw cexn
+    | _ -> throw exn
+    }
+  }
+}
+
 module end;

--- a/skfs/src/Context.sk
+++ b/skfs/src/Context.sk
@@ -467,7 +467,7 @@ mutable class Context{
     }
   }
 
-  mutable fun replaceFromSaved(ctx: Context): void {
+  mutable fun replaceFromSaved(ctx: readonly Context): void {
     this.!toPurge = ctx.toPurge;
     this.!purgeLimit = ctx.purgeLimit;
     this.!pwd = ctx.pwd;

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -814,86 +814,92 @@ class EagerDir{
   }
 
   private fun flattenData(limit: Tick): FixedDataMap {
-    fixedIter = FixedDataMapIterator::create(this.fixedData.getIterAll());
-    data = mutable Vector[];
-    tombs = mutable Vector[];
-    lastOpt: ?(Tick, Source, Source, Key, Array<File>) = None();
+    withRegionValue(() ~> {
+      fixedIter = FixedDataMapIterator::create(this.fixedData.getIterAll());
+      data = Vector::mcreate(
+        this.fixedData.data.size() + 1.shl(this.data.data.getHeight()),
+      );
+      tombs = Vector::mcreate(
+        this.fixedData.tombs.size() + 1.shl(this.data.tombs.getHeight()),
+      );
+      lastOpt: ?(Tick, Source, Source, Key, Array<File>) = None();
 
-    addHelper = lastRow -> {
-      if (lastRow.i4.size() > 0 || lastRow.i0 > limit) {
-        if (lastRow.i4.size() > 0) {
-          data.push(
-            FixedRow(
-              lastRow.i3,
-              (lastRow.i1, lastRow.i4),
-              TickRange::create(lastRow.i0),
-            ),
-          );
-        } else {
-          tombs.push(
-            FixedRow(
-              lastRow.i3,
-              (lastRow.i1, lastRow.i2),
-              TickRange::create(lastRow.i0),
-            ),
-          );
+      addHelper = lastRow -> {
+        if (lastRow.i4.size() > 0 || lastRow.i0 > limit) {
+          if (lastRow.i4.size() > 0) {
+            data.push(
+              FixedRow(
+                lastRow.i3,
+                (lastRow.i1, lastRow.i4),
+                TickRange::create(lastRow.i0),
+              ),
+            );
+          } else {
+            tombs.push(
+              FixedRow(
+                lastRow.i3,
+                (lastRow.i1, lastRow.i2),
+                TickRange::create(lastRow.i0),
+              ),
+            );
+          }
         }
-      }
-    };
-
-    add = fixedRow -> {
-      lastOpt match {
-      | Some(
-        lastRow,
-      ) if (fixedRow.i3 != lastRow.i3 || fixedRow.i1 != lastRow.i1) ->
-        addHelper(lastRow)
-      | _ -> void
       };
-      !lastOpt = Some(fixedRow)
-    };
 
-    for (key => _ in this.data) {
-      while (!fixedIter.isEnd() && fixedIter.current().i3 < key) {
-        add(fixedIter.current());
-        fixedIter.next();
+      add = fixedRow -> {
+        lastOpt match {
+        | Some(
+          lastRow,
+        ) if (fixedRow.i3 != lastRow.i3 || fixedRow.i1 != lastRow.i1) ->
+          addHelper(lastRow)
+        | _ -> void
+        };
+        !lastOpt = Some(fixedRow)
       };
-      map = this.data.maybeGet(key).fromSome();
-      for (tickSource => values in map) {
-        (tick, source, writer) = tickSource;
-        while (
-          !fixedIter.isEnd() &&
-          fixedIter.current().i3 == key &&
-          fixedIter.current().i1 < source
-        ) {
+
+      for (key => _ in this.data) {
+        while (!fixedIter.isEnd() && fixedIter.current().i3 < key) {
           add(fixedIter.current());
           fixedIter.next();
         };
-        add((tick, source, writer, key, values));
-        while (
-          !fixedIter.isEnd() &&
-          fixedIter.current().i3 == key &&
-          fixedIter.current().i1 == source
-        ) {
+        map = this.data.maybeGet(key).fromSome();
+        for (tickSource => values in map) {
+          (tick, source, writer) = tickSource;
+          while (
+            !fixedIter.isEnd() &&
+            fixedIter.current().i3 == key &&
+            fixedIter.current().i1 < source
+          ) {
+            add(fixedIter.current());
+            fixedIter.next();
+          };
+          add((tick, source, writer, key, values));
+          while (
+            !fixedIter.isEnd() &&
+            fixedIter.current().i3 == key &&
+            fixedIter.current().i1 == source
+          ) {
+            fixedIter.next();
+          };
+        };
+        while (!fixedIter.isEnd() && fixedIter.current().i3 == key) {
+          add(fixedIter.current());
           fixedIter.next();
         };
       };
-      while (!fixedIter.isEnd() && fixedIter.current().i3 == key) {
+
+      while (!fixedIter.isEnd()) {
         add(fixedIter.current());
         fixedIter.next();
       };
-    };
 
-    while (!fixedIter.isEnd()) {
-      add(fixedIter.current());
-      fixedIter.next();
-    };
+      lastOpt match {
+      | None() -> void
+      | Some(lastRow) -> addHelper(lastRow)
+      };
 
-    lastOpt match {
-    | None() -> void
-    | Some(lastRow) -> addHelper(lastRow)
-    };
-
-    FixedDataMap::create(data, tombs)
+      FixedDataMap::create(data, tombs)
+    });
   }
 
   fun purge(context: mutable Context, limit: Tick): this {

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -857,12 +857,11 @@ class EagerDir{
         !lastOpt = Some(fixedRow)
       };
 
-      for (key => _ in this.data) {
+      for (key => map in this.data) {
         while (!fixedIter.isEnd() && fixedIter.current().i3 < key) {
           add(fixedIter.current());
           fixedIter.next();
         };
-        map = this.data.maybeGet(key).fromSome();
         for (tickSource => values in map) {
           (tick, source, writer) = tickSource;
           while (

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -104,8 +104,7 @@ class FixedDir<T: frozen> private {
   ): this {
     data.sortBy(row ~> (row.key, row.value.i0));
     result = data.toArray().clone();
-    cache = Array::mfill(result.size(), false);
-    _ = static::computeTags(cache, result, 0, result.size() - 1);
+    _ = static::computeTags(result, 0, result.size() - 1);
     FixedDir{data => result.chill()}
   }
 
@@ -155,7 +154,6 @@ class FixedDir<T: frozen> private {
   }
 
   static fun computeTags(
-    cache: mutable Array<Bool>,
     array: mutable Array<FixedRow<T>>,
     i: Int,
     j: Int,
@@ -166,11 +164,10 @@ class FixedDir<T: frozen> private {
     pivot = i + (j - i) / 2;
     elt = array[pivot];
     tag = elt.tag;
-    right = static::computeTags(cache, array, pivot + 1, j);
-    left = static::computeTags(cache, array, i, pivot - 1);
+    right = static::computeTags(array, pivot + 1, j);
+    left = static::computeTags(array, i, pivot - 1);
     !tag.max = max(tag.max, max(left.max, right.max));
     array![pivot] = elt with {tag};
-    cache![pivot] = true;
     tag
   }
 

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -102,10 +102,27 @@ class FixedDir<T: frozen> private {
   static fun create(
     data: mutable Vector<FixedRow<T>> = mutable Vector[],
   ): this {
-    data.sortBy(row ~> (row.key, row.value.i0));
-    result = data.toArray().clone();
-    _ = static::computeTags(result, 0, result.size() - 1);
-    FixedDir{data => result.chill()}
+    i = 0;
+    sz = data.size();
+    sorted = loop {
+      !i = i + 1;
+      if (i >= sz) break true;
+      keyComparison = data[i-1].key.compare(data[i].key);
+      keyComparison match {
+        | LT() -> continue;
+        | GT() -> break false;
+        | EQ() -> data[i-1].value.i0.compare(data[i].value.i0)
+      } match {
+        | LT() -> continue;
+        | EQ() -> continue;
+        | GT() -> break false;
+      };
+    };
+    if (!sorted) {
+      data.sortBy(row ~> (row.key, row.value.i0));
+    };
+    _ = static::computeTags(data, 0, data.size() - 1);
+    FixedDir{data => data.toArray()}
   }
 
   fun size(): Int {
@@ -154,7 +171,7 @@ class FixedDir<T: frozen> private {
   }
 
   static fun computeTags(
-    array: mutable Array<FixedRow<T>>,
+    array: mutable Vector<FixedRow<T>>,
     i: Int,
     j: Int,
   ): TickRange {

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -204,38 +204,37 @@ class FixedDir<T: frozen> private {
     result
   }
 
-  fun getKeyChangesAfterIter(
+  fun getKeyChangesAfter(
     after: Tick,
     key: Key,
     i: Int,
     j: Int,
-  ): mutable Iterator<(Tick, Source, T)> {
+    acc: mutable Vector<(Tick, Source, T)>,
+  ): void {
     if (i <= j) {
       pivot = i + (j - i) / 2;
       elt = this.data[pivot];
       tick = elt.tag;
       if (tick.max >= after) {
         if (key <= elt.key) {
-          for (item in this.getKeyChangesAfterIter(after, key, i, pivot - 1)) {
-            yield item
-          }
+          this.getKeyChangesAfter(after, key, i, pivot - 1, acc);
         };
         if (tick.current >= after) {
           if (elt.key.compare(key) is EQ()) {
-            yield ((tick.current, elt.value.i0, elt.value.i1));
+            acc.push((tick.current, elt.value.i0, elt.value.i1));
           }
         };
         if (key >= elt.key) {
-          for (item in this.getKeyChangesAfterIter(after, key, pivot + 1, j)) {
-            yield item
-          }
+          this.getKeyChangesAfter(after, key, pivot + 1, j, acc);
         }
       }
     }
   }
 
   fun getIterAfter(limit: Tick, key: Key): mutable Iterator<(Tick, Source, T)> {
-    this.getKeyChangesAfterIter(limit, key, 0, this.data.size() - 1)
+    acc = mutable Vector[];
+    this.getKeyChangesAfter(limit, key, 0, this.data.size() - 1, acc);
+    acc.iterator()
   }
 
   fun getTick(): ?Tick {

--- a/sql/server/test/soak_client.mjs
+++ b/sql/server/test/soak_client.mjs
@@ -203,13 +203,13 @@ const check_expectations = async function (skdb, client, latest_id) {
   // arrive as part of catching up.
   check_expectation(
     skdb,
-    `select client, value >= @latest_id as check
+    `select client, value >= @latest_id as test
      from no_pk_single_row
      where id = 0 and client = @client`,
     params,
     new SKDBTable({
       client: client,
-      check: 1,
+      test: 1,
     }),
     "no_pk_single_row",
   );
@@ -220,13 +220,13 @@ const check_expectations = async function (skdb, client, latest_id) {
   check_expectation(
     skdb,
     `select client >= @client as client_bound,
-            not (client = @client and value < @latest_id) as check
+            not (client = @client and value < @latest_id) as test
      from pk_single_row
      where id = 0`,
     params,
     new SKDBTable({
       client_bound: 1,
-      check: 1,
+      test: 1,
     }),
     "pk_single_row",
   );
@@ -271,12 +271,12 @@ const check_expectations = async function (skdb, client, latest_id) {
   // so it will not be removed.
   check_expectation(
     skdb,
-    `select NOT (@latest_id % 60 < 30 AND count(*) <> 1) as check
+    `select NOT (@latest_id % 60 < 30 AND count(*) <> 1) as test
      from pk_privacy_rw
      where client = @client`,
     params,
     new SKDBTable({
-      check: 1,
+      test: 1,
     }),
     "pk_privacy_rw",
   );

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -708,15 +708,7 @@ fun execWriteCsv(args: Cli.ParseResults, options: SKDB.Options): void {
 
   SKDB.runSql(options, context ~> {
     user = args.maybeGetString("user");
-    myReadLine = () -> {
-      buffer = mutable Vector[];
-      loop {
-        c = getChar();
-        if (c == '\n') return String::fromChars(buffer.toArray());
-        buffer.push(c);
-      }
-    };
-    SKCSV.replayDiff(context, myReadLine, user, source)
+    SKCSV.replayDiff(context, read_line, user, source)
   })
 }
 

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -350,7 +350,7 @@ fun applyDiffStrategy(
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
 
-    !dir = SKStore.withRegionFold(
+    !dir = SKStore.withRegionFoldRec(
       Some(newRoot),
       rows.iterator(),
       dir,

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -355,11 +355,12 @@ fun applyDiffStrategy(
       rows.iterator(),
       dir,
       (optContext, row, newDir) ~> {
+        ctx = optContext.fromSome();
         key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
         for ((tick, source, _) in newDir.unsafeGetDataIterWithoutTombs(key)) {
           if (tick.value < snapshot.default(0) || source.path() == writer) {
             !newDir = newDir.writeEntry(
-              optContext.fromSome(),
+              ctx,
               source.path(),
               writer,
               key,
@@ -370,13 +371,19 @@ fun applyDiffStrategy(
 
         if (row.repeat > 0) {
           !newDir = newDir.writeEntry(
-            optContext.fromSome(),
+            ctx,
             writer,
             writer,
             SKDB.RowKey(row, table.kinds),
             Array[row],
           );
         };
+
+        // update incrementally to keep memory usage down. this has a
+        // significant effect for large write sets and negligible
+        // impact on performance
+        ctx.setDir(newDir.dirName, newDir);
+        ctx.update();
 
         newDir
       },
@@ -476,12 +483,13 @@ fun applyDiffStrategy(
       rows.iterator(),
       dir,
       (optContext, row, newDir) ~> {
+        ctx = optContext.fromSome();
         if (row.repeat < 1) {
           key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
           for ((tick, source, _) in newDir.unsafeGetDataIterWithoutTombs(key)) {
             if (tick.value < snapshot.default(0) || source.path() == writer) {
               !newDir = newDir.writeEntry(
-                optContext.fromSome(),
+                ctx,
                 source.path(),
                 writer,
                 key,
@@ -495,13 +503,13 @@ fun applyDiffStrategy(
             snapshot.default(0),
             writer,
             primaryIdx,
-            optContext.fromSome(),
+            ctx,
             newDir,
             row,
           )) {
             (editKey, (editSrc, editWriter, editFiles)) = edit;
             !newDir = newDir.writeEntry(
-              optContext.fromSome(),
+              ctx,
               editSrc,
               editWriter,
               editKey,
@@ -509,6 +517,13 @@ fun applyDiffStrategy(
             );
           };
         };
+
+        // update incrementally to keep memory usage down. this has a
+        // significant effect for large write sets and negligible
+        // impact on performance
+        ctx.setDir(newDir.dirName, newDir);
+        ctx.update();
+
         newDir
       },
     );

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -567,6 +567,8 @@ fun parseTableChange(
   table: SKDB.DirDescr,
   line: String,
 ): Array<SKDB.RowValues> {
+  saved = SKStore.newObstack();
+
   if (line.startsWith("^") || line.startsWith(":") || line.startsWith("\t")) {
     invariant_violation("Not a table change")
   };
@@ -607,7 +609,7 @@ fun parseTableChange(
   cvalues = values.map(parseCSVValue);
   // empty params since no placeholders in skdb diff write-csv
   params: Map<String, P.Value> = Map[];
-  SKDB.computeInsert(
+  ret = SKDB.computeInsert(
     context,
     params,
     false,
@@ -617,6 +619,11 @@ fun parseTableChange(
     table,
     repeat,
   );
+
+  SKStore.destroyObstackWithValue(
+    saved,
+    List[ret]
+  ).getHead()
 }
 
 mutable class TableDiff(

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -390,8 +390,8 @@ fun applyDiffStrategy(
     );
 
     newRoot.setDir(dir.dirName, dir);
-    checkpointAndAck(newRoot, delta);
-    newRoot.update()
+    newRoot.update();
+    checkpointAndAck(newRoot, delta)
   });
 
   // resetRows - if the update is communicating the entire current
@@ -464,8 +464,8 @@ fun applyDiffStrategy(
     );
 
     newRoot.setDir(dir.dirName, dir);
-    checkpointAndAck(newRoot, delta);
-    newRoot.update()
+    newRoot.update();
+    checkpointAndAck(newRoot, delta)
   });
 
   // lwwRows - if there is a unique constraint on the table (e.g. a
@@ -529,8 +529,8 @@ fun applyDiffStrategy(
     );
 
     newRoot.setDir(dir.dirName, dir);
-    checkpointAndAck(newRoot, delta);
-    newRoot.update()
+    newRoot.update();
+    checkpointAndAck(newRoot, delta)
   });
 
   // lwwReset - if the update is communicating the entire current
@@ -586,8 +586,8 @@ fun applyDiffStrategy(
     );
 
     newRoot.setDir(dir.dirName, dir);
-    checkpointAndAck(newRoot, delta);
-    newRoot.update()
+    newRoot.update();
+    checkpointAndAck(newRoot, delta)
   });
 
   if (primaryIdx is Some _) {

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -350,16 +350,16 @@ fun applyDiffStrategy(
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
 
-    for (row in rows) {
-      (ctx, !dir) = {
-        saved = SKStore.newObstack();
-        newDir = dir;
-        tmpContext = newRoot.mclone();
+    !dir = SKStore.withRegionFold(
+      Some(newRoot),
+      rows.iterator(),
+      dir,
+      (optContext, row, newDir) ~> {
         key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
-        for ((tick, source, _) in dir.unsafeGetDataIterWithoutTombs(key)) {
+        for ((tick, source, _) in newDir.unsafeGetDataIterWithoutTombs(key)) {
           if (tick.value < snapshot.default(0) || source.path() == writer) {
             !newDir = newDir.writeEntry(
-              tmpContext,
+              optContext.fromSome(),
               source.path(),
               writer,
               key,
@@ -370,7 +370,7 @@ fun applyDiffStrategy(
 
         if (row.repeat > 0) {
           !newDir = newDir.writeEntry(
-            tmpContext,
+            optContext.fromSome(),
             writer,
             writer,
             SKDB.RowKey(row, table.kinds),
@@ -378,14 +378,9 @@ fun applyDiffStrategy(
           );
         };
 
-        SKStore.destroyObstackWithValue(
-          saved,
-          List[(tmpContext, newDir)],
-        ).getHead();
-      };
-
-      newRoot.replaceFromSaved(ctx);
-    };
+        newDir
+      },
+    );
 
     newRoot.setDir(dir.dirName, dir);
     checkpointAndAck(newRoot, delta);
@@ -405,14 +400,16 @@ fun applyDiffStrategy(
     isEligibleForTomb = (tick, source) ~>
       tick.value < snapshot.default(0) || source.path() == writer;
 
-    for (row in rows) {
-      (ctx, !dir) = {
-        saved = SKStore.newObstack();
-        newDir = dir;
-        tmpContext = newRoot.mclone();
+    !dir = SKStore.withRegionFold(
+      Some(newRoot),
+      rows.iterator(),
+      dir,
+      (optContext, row, newDir) ~> {
         key: SKStore.Key = SKDB.RowKey(row, table.kinds);
         keyRepeat = row.repeat;
-        for ((tick, source, files) in dir.unsafeGetDataIterWithoutTombs(key)) {
+        for ((tick, source, files) in newDir.unsafeGetDataIterWithoutTombs(
+          key,
+        )) {
           if (!isEligibleForTomb(tick, source)) {
             continue
           };
@@ -423,7 +420,7 @@ fun applyDiffStrategy(
 
           if (keyRepeat - srcRepeat < 0) {
             !newDir = newDir.writeEntry(
-              tmpContext,
+              optContext.fromSome(),
               source.path(),
               writer,
               key,
@@ -436,21 +433,16 @@ fun applyDiffStrategy(
 
         if (keyRepeat != 0) {
           !newDir = newDir.writeEntry(
-            tmpContext,
+            optContext.fromSome(),
             writer,
             writer,
             key,
             Array[row.setRepeat(keyRepeat)],
           );
         };
-
-        SKStore.destroyObstackWithValue(
-          saved,
-          List[(tmpContext, newDir)],
-        ).getHead();
-      };
-      newRoot.replaceFromSaved(ctx);
-    };
+        newDir
+      },
+    );
 
     !dir = dir.reset(
       newRoot,
@@ -479,18 +471,17 @@ fun applyDiffStrategy(
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
 
-    for (row in rows) {
-      (ctx, !dir) = {
-        saved = SKStore.newObstack();
-        newDir = dir;
-        tmpContext = newRoot.mclone();
-
+    !dir = SKStore.withRegionFold(
+      Some(newRoot),
+      rows.iterator(),
+      dir,
+      (optContext, row, newDir) ~> {
         if (row.repeat < 1) {
           key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
-          for ((tick, source, _) in dir.unsafeGetDataIterWithoutTombs(key)) {
+          for ((tick, source, _) in newDir.unsafeGetDataIterWithoutTombs(key)) {
             if (tick.value < snapshot.default(0) || source.path() == writer) {
               !newDir = newDir.writeEntry(
-                tmpContext,
+                optContext.fromSome(),
                 source.path(),
                 writer,
                 key,
@@ -504,13 +495,13 @@ fun applyDiffStrategy(
             snapshot.default(0),
             writer,
             primaryIdx,
-            tmpContext,
+            optContext.fromSome(),
             newDir,
             row,
           )) {
             (editKey, (editSrc, editWriter, editFiles)) = edit;
             !newDir = newDir.writeEntry(
-              tmpContext,
+              optContext.fromSome(),
               editSrc,
               editWriter,
               editKey,
@@ -518,15 +509,9 @@ fun applyDiffStrategy(
             );
           };
         };
-
-        SKStore.destroyObstackWithValue(
-          saved,
-          List[(tmpContext, newDir)],
-        ).getHead();
-      };
-
-      newRoot.replaceFromSaved(ctx);
-    };
+        newDir
+      },
+    );
 
     newRoot.setDir(dir.dirName, dir);
     checkpointAndAck(newRoot, delta);
@@ -542,25 +527,24 @@ fun applyDiffStrategy(
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
 
-    for (row in rows) {
-      (ctx, !dir) = {
-        saved = SKStore.newObstack();
-        newDir = dir;
-        tmpContext = newRoot.mclone();
-
+    !dir = SKStore.withRegionFold(
+      Some(newRoot),
+      rows.iterator(),
+      dir,
+      (optContext, row, newDir) ~> {
         if (row.repeat > 0) {
           for (edit in lwwEdits(
             table,
             snapshot.default(0),
             writer,
             primaryIdx,
-            tmpContext,
+            optContext.fromSome(),
             newDir,
             row,
           )) {
             (editKey, (editSrc, editWriter, editFiles)) = edit;
             !newDir = newDir.writeEntry(
-              tmpContext,
+              optContext.fromSome(),
               editSrc,
               editWriter,
               editKey,
@@ -568,15 +552,9 @@ fun applyDiffStrategy(
             );
           };
         };
-
-        SKStore.destroyObstackWithValue(
-          saved,
-          List[(tmpContext, newDir)],
-        ).getHead();
-      };
-
-      newRoot.replaceFromSaved(ctx);
-    };
+        newDir
+      },
+    );
 
     !dir = dir.reset(
       newRoot,

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -478,7 +478,7 @@ fun applyDiffStrategy(
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
 
-    !dir = SKStore.withRegionFold(
+    !dir = SKStore.withRegionFoldRec(
       Some(newRoot),
       rows.iterator(),
       dir,

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -203,23 +203,23 @@ fun lwwEdits(
   snapshot: Int,
   writer: SKStore.Path,
   primaryIdxOpt: ?Int,
-  context: mutable SKStore.Context,
+  context: readonly SKStore.Context,
   dir: SKStore.EagerDir,
   row: SKDB.RowValues,
 ): mutable Iterator<
   (SKStore.Key, (SKStore.Path, SKStore.Path, Array<SKStore.File>)),
 > {
-  !context = context.mclone();
+  mcontext = context.mclone();
   primaryIdx = primaryIdxOpt match {
   | None() -> invariant_violation("Using LWW without a primary key.")
   | Some(p) -> p
   };
   indexEntry = SKDB.makeIndexEntry(table.name, primaryIdx);
-  indexTable = SKDB.getIndexByColNbr(context);
-  indexes = indexTable.unsafeGetArray(context, indexEntry);
+  indexTable = SKDB.getIndexByColNbr(mcontext);
+  indexes = indexTable.unsafeGetArray(mcontext, indexEntry);
   invariant(indexes.size() > 0);
   index = indexes[0];
-  indexDir = context.unsafeGetEagerDir(index.dirName);
+  indexDir = mcontext.unsafeGetEagerDir(index.dirName);
   primaryKey = row.getValue(primaryIdx);
   startKey = SKDB.RowKey::create(
     SKDB.RowValues::create(Array[primaryKey], 1),
@@ -241,7 +241,7 @@ fun lwwEdits(
     };
     if (rowKey.row.getValue(0) != primaryKey) break void;
 
-    for ((tick, source, _) in dir.getDataIterWithoutTombs(context, key)) {
+    for ((tick, source, _) in dir.getDataIterWithoutTombs(mcontext, key)) {
       if (
         tick.value < snapshot ||
         source.path() == writer ||
@@ -352,12 +352,19 @@ fun applyDiffStrategy(
     entries = mutable Vector[];
 
     for (row in rows) {
+      saved = SKStore.newObstack();
+      acc = mutable Vector[];
       key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
-      for ((tick, source, _) in dir.getDataIterWithoutTombs(newRoot, key)) {
+      for ((tick, source, _) in dir.unsafeGetDataIterWithoutTombs(key)) {
         if (tick.value < snapshot.default(0) || source.path() == writer) {
-          entries.push((key, (source.path(), writer, Array<SKStore.File>[])));
+          acc.push((key, (source.path(), writer, Array<SKStore.File>[])));
         }
-      }
+      };
+      rowEntries = SKStore.destroyObstackWithValue(
+        saved,
+        List[acc.collect(Array)],
+      ).getHead();
+      entries.extend(rowEntries);
     };
 
     if (!entries.isEmpty()) {
@@ -394,9 +401,11 @@ fun applyDiffStrategy(
       tick.value < snapshot.default(0) || source.path() == writer;
 
     for (row in rows) {
+      saved = SKStore.newObstack();
+      acc = mutable Vector[];
       key: SKStore.Key = SKDB.RowKey(row, table.kinds);
       keyRepeat = row.repeat;
-      for ((tick, source, files) in dir.getDataIterWithoutTombs(newRoot, key)) {
+      for ((tick, source, files) in dir.unsafeGetDataIterWithoutTombs(key)) {
         if (!isEligibleForTomb(tick, source)) {
           continue
         };
@@ -406,15 +415,21 @@ fun applyDiffStrategy(
         };
 
         if (keyRepeat - srcRepeat < 0) {
-          entries.push((key, (source.path(), writer, Array<SKStore.File>[])));
+          acc.push((key, (source.path(), writer, Array<SKStore.File>[])));
         } else {
           !keyRepeat = keyRepeat - srcRepeat;
         }
       };
 
       if (keyRepeat != 0) {
-        entries.push((key, (writer, writer, Array[row.setRepeat(keyRepeat)])));
-      }
+        acc.push((key, (writer, writer, Array[row.setRepeat(keyRepeat)])));
+      };
+
+      rowEntries = SKStore.destroyObstackWithValue(
+        saved,
+        List[acc.collect(Array)],
+      ).getHead();
+      entries.extend(rowEntries);
     };
 
     if (!entries.isEmpty()) {
@@ -450,13 +465,21 @@ fun applyDiffStrategy(
     entries = mutable Vector[];
 
     for (row in rows) {
+      saved = SKStore.newObstack();
+      acc = mutable Vector[];
+
       if (row.repeat < 1) {
         key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
-        for ((tick, source, _) in dir.getDataIterWithoutTombs(newRoot, key)) {
+        for ((tick, source, _) in dir.unsafeGetDataIterWithoutTombs(key)) {
           if (tick.value < snapshot.default(0) || source.path() == writer) {
-            entries.push((key, (source.path(), writer, Array<SKStore.File>[])));
+            acc.push((key, (source.path(), writer, Array<SKStore.File>[])));
           }
         };
+        rowEntries = SKStore.destroyObstackWithValue(
+          saved,
+          List[acc.collect(Array)],
+        ).getHead();
+        entries.extend(rowEntries);
         continue;
       };
 
@@ -469,8 +492,14 @@ fun applyDiffStrategy(
         dir,
         row,
       )) {
-        entries.push(change);
-      }
+        acc.push(change);
+      };
+
+      rowEntries = SKStore.destroyObstackWithValue(
+        saved,
+        List[acc.collect(Array)],
+      ).getHead();
+      entries.extend(rowEntries);
     };
 
     !dir = dir.writeArraySourceManyReturnDir(newRoot, entries.iterator());
@@ -490,6 +519,9 @@ fun applyDiffStrategy(
     entries = mutable Vector[];
 
     for (row in rows) {
+      saved = SKStore.newObstack();
+      acc = mutable Vector[];
+
       if (row.repeat < 1) {
         continue;
       };
@@ -503,9 +535,16 @@ fun applyDiffStrategy(
         dir,
         row,
       )) {
-        entries.push(change);
-      }
+        acc.push(change);
+      };
+
+      rowEntries = SKStore.destroyObstackWithValue(
+        saved,
+        List[acc.collect(Array)],
+      ).getHead();
+      entries.extend(rowEntries);
     };
+
     !dir = dir.writeArraySourceManyReturnDir(newRoot, entries.iterator());
 
     !dir = dir.reset(
@@ -620,10 +659,7 @@ fun parseTableChange(
     repeat,
   );
 
-  SKStore.destroyObstackWithValue(
-    saved,
-    List[ret]
-  ).getHead()
+  SKStore.destroyObstackWithValue(saved, List[ret]).getHead()
 }
 
 mutable class TableDiff(

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -726,7 +726,7 @@ fun nack(writer: mutable Debug.BufferedWriter, diff: readonly TableDiff): void {
 
 fun replayDiff(
   context: mutable SKStore.Context,
-  getLine: () -> String,
+  getLine: () -> ?String,
   user: ?String,
   identity: Int,
 ): SKStore.ContextOp {
@@ -742,7 +742,10 @@ fun replayDiff(
   state: ?(mutable DiffParsingState) = None();
   try {
     loop {
-      line = getLine();
+      line = getLine() match {
+        | Some(l) -> l
+        | None() -> break SKStore.CStop(None())
+      };
       !state = state match {
       | None() if (!line.startsWith("^")) -> None()
 

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -370,16 +370,32 @@ fun applyDiffStrategy(
     if (!entries.isEmpty()) {
       !dir = dir.writeArraySourceManyReturnDir(newRoot, entries.iterator());
     };
-    !dir = dir.writeArraySourceManyReturnDir(
-      newRoot,
-      rows
-        .iterator()
-        .filter(row -> row.repeat != 0)
-        .map(row -> {
-          (k, v) = (SKDB.RowKey(row, table.kinds), Array[row]);
-          ((k : SKStore.Key), (writer, writer, (v : Array<SKStore.File>)))
-        }),
-    );
+
+    // TODO: if this works well, combine with the obstack created above and just have one loop.
+    // TODO: rinse and repeat for the other strategies
+    for (row in rows) {
+      if (row.repeat < 1) {
+        continue;
+      };
+
+      (ctx, !dir) = {
+        saved = SKStore.newObstack();
+        tmpContext = newRoot.mclone();
+        newDir = dir.writeEntry(
+          tmpContext,
+          writer,
+          writer,
+          SKDB.RowKey(row, table.kinds),
+          Array[row],
+        );
+        SKStore.destroyObstackWithValue(
+          saved,
+          List[(tmpContext, newDir)],
+        ).getHead();
+      };
+
+      newRoot.replaceFromSaved(ctx);
+    };
 
     newRoot.setDir(dir.dirName, dir);
     checkpointAndAck(newRoot, delta);

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -611,11 +611,11 @@ fun parseCheckpoint(line: String): Int {
 }
 
 fun parseTableChange(
-  context: mutable SKStore.Context,
+  context: SKStore.Context,
   table: SKDB.DirDescr,
   line: String,
 ): Array<SKDB.RowValues> {
-  SKStore.withRegion(context, (_, context) ~> {
+  SKStore.withRegionValue(() ~> {
     if (line.startsWith("^") || line.startsWith(":") || line.startsWith("\t")) {
       invariant_violation("Not a table change")
     };
@@ -657,7 +657,7 @@ fun parseTableChange(
     // empty params since no placeholders in skdb diff write-csv
     params: Map<String, P.Value> = Map[];
     SKDB.computeInsert(
-      context,
+      context.mclone(),
       params,
       false,
       0,
@@ -737,6 +737,7 @@ fun replayDiff(
   | _ -> void
   };
 
+  immContext = context.clone();
   userFileOpt = user.map(x -> SKDB.UserFile::create(context, x));
   state: ?(mutable DiffParsingState) = None();
   try {
@@ -825,7 +826,7 @@ fun replayDiff(
 
       | current @ Some(DiffParsingState(_, currentDiff)) ->
         currentDiff.lines.push(line); // capture the raw input for if we end up rejecting the txn
-        newRows = parseTableChange(context, currentDiff.table, line);
+        newRows = parseTableChange(immContext, currentDiff.table, line);
         currentDiff.rows.extend(newRows);
         current
       };

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -615,60 +615,58 @@ fun parseTableChange(
   table: SKDB.DirDescr,
   line: String,
 ): Array<SKDB.RowValues> {
-  saved = SKStore.newObstack();
-
-  if (line.startsWith("^") || line.startsWith(":") || line.startsWith("\t")) {
-    invariant_violation("Not a table change")
-  };
-
-  chars: mutable Vector<Char> = mutable Vector[];
-  iter = line.getIter();
-  repeat = loop {
-    c = iter.next() match {
-    | None() ->
-      print_error("Error: unexpected end of line");
-      skipExit(23)
-    | Some(x) -> x
+  SKStore.withRegion(context, (_, context) ~> {
+    if (line.startsWith("^") || line.startsWith(":") || line.startsWith("\t")) {
+      invariant_violation("Not a table change")
     };
-    if (c == '\t') {
-      break String::fromChars(chars.toArray()).toInt()
-    };
-    if (c < '0' || c > '9') {
-      print_error("Error: expected an integer");
-      skipExit(23)
-    };
-    chars.push(c);
-  };
 
-  // parse out the remainder of the line - the csv values
-  str = line.sub(iter, line.length() - chars.size() - 1);
-  values = mutable Vector[];
-  strIter = str.getIter();
-  next = () -> {
-    val = strIter.next();
-    val match {
-    | None() -> '\n'
-    | Some(x) -> x
-    }
-  };
-  for (value in lex(next)) {
-    values.push(value);
-  };
-  cvalues = values.map(parseCSVValue);
-  // empty params since no placeholders in skdb diff write-csv
-  params: Map<String, P.Value> = Map[];
-  ret = SKDB.computeInsert(
-    context,
-    params,
-    false,
-    0,
-    None(),
-    Array[cvalues.toArray()],
-    table,
-    repeat,
-  );
+    chars: mutable Vector<Char> = mutable Vector[];
+    iter = line.getIter();
+    repeat = loop {
+      c = iter.next() match {
+      | None() ->
+        print_error("Error: unexpected end of line");
+        skipExit(23)
+      | Some(x) -> x
+      };
+      if (c == '\t') {
+        break String::fromChars(chars.toArray()).toInt()
+      };
+      if (c < '0' || c > '9') {
+        print_error("Error: expected an integer");
+        skipExit(23)
+      };
+      chars.push(c);
+    };
 
-  SKStore.destroyObstackWithValue(saved, List[ret]).getHead()
+    // parse out the remainder of the line - the csv values
+    str = line.sub(iter, line.length() - chars.size() - 1);
+    values = mutable Vector[];
+    strIter = str.getIter();
+    next = () -> {
+      val = strIter.next();
+      val match {
+      | None() -> '\n'
+      | Some(x) -> x
+      }
+    };
+    for (value in lex(next)) {
+      values.push(value);
+    };
+    cvalues = values.map(parseCSVValue);
+    // empty params since no placeholders in skdb diff write-csv
+    params: Map<String, P.Value> = Map[];
+    SKDB.computeInsert(
+      context,
+      params,
+      false,
+      0,
+      None(),
+      Array[cvalues.toArray()],
+      table,
+      repeat,
+    );
+  })
 }
 
 mutable class TableDiff(

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -400,46 +400,56 @@ fun applyDiffStrategy(
     };
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
-    entries = mutable Vector[];
 
     // we may only affect rows that have been seen
     isEligibleForTomb = (tick, source) ~>
       tick.value < snapshot.default(0) || source.path() == writer;
 
     for (row in rows) {
-      saved = SKStore.newObstack();
-      acc = mutable Vector[];
-      key: SKStore.Key = SKDB.RowKey(row, table.kinds);
-      keyRepeat = row.repeat;
-      for ((tick, source, files) in dir.unsafeGetDataIterWithoutTombs(key)) {
-        if (!isEligibleForTomb(tick, source)) {
-          continue
+      (ctx, !dir) = {
+        saved = SKStore.newObstack();
+        newDir = dir;
+        tmpContext = newRoot.mclone();
+        key: SKStore.Key = SKDB.RowKey(row, table.kinds);
+        keyRepeat = row.repeat;
+        for ((tick, source, files) in dir.unsafeGetDataIterWithoutTombs(key)) {
+          if (!isEligibleForTomb(tick, source)) {
+            continue
+          };
+          srcRepeat = 0;
+          for (file in files) {
+            !srcRepeat = srcRepeat + SKDB.RowValues::type(file).repeat
+          };
+
+          if (keyRepeat - srcRepeat < 0) {
+            !newDir = newDir.writeEntry(
+              tmpContext,
+              source.path(),
+              writer,
+              key,
+              Array[],
+            );
+          } else {
+            !keyRepeat = keyRepeat - srcRepeat;
+          }
         };
-        srcRepeat = 0;
-        for (file in files) {
-          !srcRepeat = srcRepeat + SKDB.RowValues::type(file).repeat
+
+        if (keyRepeat != 0) {
+          !newDir = newDir.writeEntry(
+            tmpContext,
+            writer,
+            writer,
+            key,
+            Array[row.setRepeat(keyRepeat)],
+          );
         };
 
-        if (keyRepeat - srcRepeat < 0) {
-          acc.push((key, (source.path(), writer, Array<SKStore.File>[])));
-        } else {
-          !keyRepeat = keyRepeat - srcRepeat;
-        }
+        SKStore.destroyObstackWithValue(
+          saved,
+          List[(tmpContext, newDir)],
+        ).getHead();
       };
-
-      if (keyRepeat != 0) {
-        acc.push((key, (writer, writer, Array[row.setRepeat(keyRepeat)])));
-      };
-
-      rowEntries = SKStore.destroyObstackWithValue(
-        saved,
-        List[acc.collect(Array)],
-      ).getHead();
-      entries.extend(rowEntries);
-    };
-
-    if (!entries.isEmpty()) {
-      !dir = dir.writeArraySourceManyReturnDir(newRoot, entries.iterator());
+      newRoot.replaceFromSaved(ctx);
     };
 
     !dir = dir.reset(
@@ -468,47 +478,56 @@ fun applyDiffStrategy(
     };
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
-    entries = mutable Vector[];
 
     for (row in rows) {
-      saved = SKStore.newObstack();
-      acc = mutable Vector[];
+      (ctx, !dir) = {
+        saved = SKStore.newObstack();
+        newDir = dir;
+        tmpContext = newRoot.mclone();
 
-      if (row.repeat < 1) {
-        key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
-        for ((tick, source, _) in dir.unsafeGetDataIterWithoutTombs(key)) {
-          if (tick.value < snapshot.default(0) || source.path() == writer) {
-            acc.push((key, (source.path(), writer, Array<SKStore.File>[])));
-          }
+        if (row.repeat < 1) {
+          key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
+          for ((tick, source, _) in dir.unsafeGetDataIterWithoutTombs(key)) {
+            if (tick.value < snapshot.default(0) || source.path() == writer) {
+              !newDir = newDir.writeEntry(
+                tmpContext,
+                source.path(),
+                writer,
+                key,
+                Array[],
+              );
+            }
+          };
+        } else {
+          for (edit in lwwEdits(
+            table,
+            snapshot.default(0),
+            writer,
+            primaryIdx,
+            tmpContext,
+            newDir,
+            row,
+          )) {
+            (editKey, (editSrc, editWriter, editFiles)) = edit;
+            !newDir = newDir.writeEntry(
+              tmpContext,
+              editSrc,
+              editWriter,
+              editKey,
+              editFiles,
+            );
+          };
         };
-        rowEntries = SKStore.destroyObstackWithValue(
+
+        SKStore.destroyObstackWithValue(
           saved,
-          List[acc.collect(Array)],
+          List[(tmpContext, newDir)],
         ).getHead();
-        entries.extend(rowEntries);
-        continue;
       };
 
-      for (change in lwwEdits(
-        table,
-        snapshot.default(0),
-        writer,
-        primaryIdx,
-        newRoot,
-        dir,
-        row,
-      )) {
-        acc.push(change);
-      };
-
-      rowEntries = SKStore.destroyObstackWithValue(
-        saved,
-        List[acc.collect(Array)],
-      ).getHead();
-      entries.extend(rowEntries);
+      newRoot.replaceFromSaved(ctx);
     };
 
-    !dir = dir.writeArraySourceManyReturnDir(newRoot, entries.iterator());
     newRoot.setDir(dir.dirName, dir);
     checkpointAndAck(newRoot, delta);
     newRoot.update()
@@ -522,36 +541,42 @@ fun applyDiffStrategy(
     };
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
-    entries = mutable Vector[];
 
     for (row in rows) {
-      saved = SKStore.newObstack();
-      acc = mutable Vector[];
+      (ctx, !dir) = {
+        saved = SKStore.newObstack();
+        newDir = dir;
+        tmpContext = newRoot.mclone();
 
-      if (row.repeat < 1) {
-        continue;
+        if (row.repeat > 0) {
+          for (edit in lwwEdits(
+            table,
+            snapshot.default(0),
+            writer,
+            primaryIdx,
+            tmpContext,
+            newDir,
+            row,
+          )) {
+            (editKey, (editSrc, editWriter, editFiles)) = edit;
+            !newDir = newDir.writeEntry(
+              tmpContext,
+              editSrc,
+              editWriter,
+              editKey,
+              editFiles,
+            );
+          };
+        };
+
+        SKStore.destroyObstackWithValue(
+          saved,
+          List[(tmpContext, newDir)],
+        ).getHead();
       };
 
-      for (change in lwwEdits(
-        table,
-        snapshot.default(0),
-        writer,
-        primaryIdx,
-        newRoot,
-        dir,
-        row,
-      )) {
-        acc.push(change);
-      };
-
-      rowEntries = SKStore.destroyObstackWithValue(
-        saved,
-        List[acc.collect(Array)],
-      ).getHead();
-      entries.extend(rowEntries);
+      newRoot.replaceFromSaved(ctx);
     };
-
-    !dir = dir.writeArraySourceManyReturnDir(newRoot, entries.iterator());
 
     !dir = dir.reset(
       newRoot,

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -743,11 +743,12 @@ fun replayDiff(
   try {
     loop {
       line = getLine() match {
-        | Some(l) -> l
-        | None() -> break SKStore.CStop(None())
+      | Some(l) -> l
+      | None() -> break SKStore.CStop(None())
       };
       !state = state match {
-      | None() if (!line.startsWith("^")) -> None()
+      | None() if (String.getByte(line, 0) != 94) -> // !startsWith("^")
+        None()
 
       | None() ->
         (table, snapshot) = parseHeader(context, line);
@@ -760,7 +761,7 @@ fun replayDiff(
 
       | Some(
         DiffParsingState(tableDiffs, currentDiff),
-      ) if (line.startsWith("^")) ->
+      ) if (String.getByte(line, 0) == 94) -> // startsWith("^")
         (table, snapshot) = parseHeader(context, line);
         tableDiffs.push(currentDiff);
         Some(
@@ -772,7 +773,7 @@ fun replayDiff(
 
       | Some(
         DiffParsingState(tableDiffs, currentDiff),
-      ) if (line.startsWith(":")) ->
+      ) if (String.getByte(line, 0) == 58) -> // startsWith(":")
         currentDiff.lines.push(line);
         tableDiffs.push(currentDiff);
         checkpoint = parseCheckpoint(line);

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -349,45 +349,35 @@ fun applyDiffStrategy(
     };
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
-    entries = mutable Vector[];
 
     for (row in rows) {
-      saved = SKStore.newObstack();
-      acc = mutable Vector[];
-      key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
-      for ((tick, source, _) in dir.unsafeGetDataIterWithoutTombs(key)) {
-        if (tick.value < snapshot.default(0) || source.path() == writer) {
-          acc.push((key, (source.path(), writer, Array<SKStore.File>[])));
-        }
-      };
-      rowEntries = SKStore.destroyObstackWithValue(
-        saved,
-        List[acc.collect(Array)],
-      ).getHead();
-      entries.extend(rowEntries);
-    };
-
-    if (!entries.isEmpty()) {
-      !dir = dir.writeArraySourceManyReturnDir(newRoot, entries.iterator());
-    };
-
-    // TODO: if this works well, combine with the obstack created above and just have one loop.
-    // TODO: rinse and repeat for the other strategies
-    for (row in rows) {
-      if (row.repeat < 1) {
-        continue;
-      };
-
       (ctx, !dir) = {
         saved = SKStore.newObstack();
+        newDir = dir;
         tmpContext = newRoot.mclone();
-        newDir = dir.writeEntry(
-          tmpContext,
-          writer,
-          writer,
-          SKDB.RowKey(row, table.kinds),
-          Array[row],
-        );
+        key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
+        for ((tick, source, _) in dir.unsafeGetDataIterWithoutTombs(key)) {
+          if (tick.value < snapshot.default(0) || source.path() == writer) {
+            !newDir = newDir.writeEntry(
+              tmpContext,
+              source.path(),
+              writer,
+              key,
+              Array<SKStore.File>[],
+            );
+          }
+        };
+
+        if (row.repeat > 0) {
+          !newDir = newDir.writeEntry(
+            tmpContext,
+            writer,
+            writer,
+            SKDB.RowKey(row, table.kinds),
+            Array[row],
+          );
+        };
+
         SKStore.destroyObstackWithValue(
           saved,
           List[(tmpContext, newDir)],

--- a/sql/test_replication_primary_key.sh
+++ b/sql/test_replication_primary_key.sh
@@ -1101,7 +1101,7 @@ test_user_privacy_control() {
 
     $SKDB_BIN --data $LOCAL2_DB <<< "INSERT INTO test_with_pk VALUES (44, 'baz', 'new_group');"
 
-    $SKDB_BIN --data $LOCAL2_DB diff --format=csv --since 23 $(cat $SESSION2) | $SKDB_BIN write-csv --data $SERVER_DB --source 3333 --user test_user2 > $WRITE_OUTPUT
+    $SKDB_BIN --data $LOCAL2_DB diff --format=csv --since 31 $(cat $SESSION2) | $SKDB_BIN write-csv --data $SERVER_DB --source 3333 --user test_user2 > $WRITE_OUTPUT
     replicate_to_local test_with_pk test_user
 
     $SKDB_BIN --data $SERVER_DB <<< 'select * from test_with_pk;' > "$server_output"

--- a/sql/test_replication_resets.sh
+++ b/sql/test_replication_resets.sh
@@ -110,16 +110,16 @@ EOF
     # just sanity check that U98 can see erase but not keep
     assert_line_count "$SERVER_TAIL" 'erase' 1
     assert_line_count "$SERVER_TAIL" 'keep' 0
-    # and that the server is at 39 and we sent up at 10
+    # and that the server is at 42 and we sent up at 10
     assert_line_count "$SERVER_TAIL" 'test_with_access 10' 1
-    assert_line_count "$SERVER_TAIL" ':39' 1
+    assert_line_count "$SERVER_TAIL" ':42' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value and the erase
     # from U99. but not the keep, because it can't see this
     # row.
     $SKDB_BIN write-csv --data $SERVER_DB --source 1234 --user U98 > /dev/null << EOF
-^test_with_access 39
+^test_with_access 42
 1	1,"baz","G1"
 1	2,"quux","G1"
 		
@@ -155,13 +155,13 @@ EOF
 
     # if we did replicate now we would get the new row
     assert_line_count "$SERVER_TAIL" 'new' 1
-    # sanity check the tick value - it's important for later - we're at 38 they're at 10
+    # sanity check the tick value - it's important for later - we're at 39 they're at 10
     assert_line_count "$SERVER_TAIL" 'test 10' 1
-    assert_line_count "$SERVER_TAIL" ':38' 1
+    assert_line_count "$SERVER_TAIL" ':39' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value but not the new,
-    # because it hasn't seen this row yet: 35 < 38.
+    # because it hasn't seen this row yet: 35 < 39.
     $SKDB_BIN write-csv --data $SERVER_DB --source 1234 --user U98 > /dev/null << EOF
 ^test 35
 1	1,"baz","read-write"
@@ -465,16 +465,16 @@ EOF
     # just sanity check that U98 can see erase but not keep
     assert_line_count "$SERVER_TAIL" 'erase' 1
     assert_line_count "$SERVER_TAIL" 'keep' 0
-    # and that the server is at 39 and we sent up at 10
+    # and that the server is at 42 and we sent up at 10
     assert_line_count "$SERVER_TAIL" 'test_with_pk_with_access 10' 1
-    assert_line_count "$SERVER_TAIL" ':39' 1
+    assert_line_count "$SERVER_TAIL" ':42' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value and the erase
     # from U99. but not the keep, because it can't see this
     # row.
     $SKDB_BIN write-csv --data $SERVER_DB --source 1234 --user U98 > /dev/null << EOF
-^test_with_pk_with_access 39
+^test_with_pk_with_access 42
 1	1,"baz","G1"
 1	2,"quux","G1"
 		
@@ -509,13 +509,13 @@ EOF
 
     # if we did replicate now we would get the new row
     assert_line_count "$SERVER_TAIL" 'new' 1
-    # sanity check the tick value - it's important for later - we're at 38 they're at 10
+    # sanity check the tick value - it's important for later - we're at 39 they're at 10
     assert_line_count "$SERVER_TAIL" 'test_with_pk 10' 1
-    assert_line_count "$SERVER_TAIL" ':38' 1
+    assert_line_count "$SERVER_TAIL" ':39' 1
 
     # now the source under test sends up a reset for whatever reason -
     # maybe reconnect. it wipes out its own foo value but not the new,
-    # because it hasn't seen this row yet: 35 < 38.
+    # because it hasn't seen this row yet: 35 < 39.
     $SKDB_BIN write-csv --data $SERVER_DB --source 1234 --user U98 > /dev/null << EOF
 ^test_with_pk 35
 1	1,"baz","read-write"

--- a/sql/ts/tests/node.play.ts
+++ b/sql/ts/tests/node.play.ts
@@ -1,4 +1,4 @@
-import { test, type Page } from "@playwright/test";
+import { test, type Page, expect } from "@playwright/test";
 import { tests } from "./tests";
 import { createSkdb } from "skdb";
 
@@ -12,3 +12,30 @@ function run(t, asWorker: boolean) {
 
 tests(false).forEach((t) => run(t, false));
 tests(true).forEach((t) => run(t, true));
+
+// this is to detect memory regression in wasm, it's not a behaviour
+// test. running only in node as I saw timeout flakiness with firefox.
+run({
+  name: "Write-csv memory regression test",
+  fun: async (skdb: SKDB) => {
+    await skdb.exec(
+      "CREATE TABLE no_pk_inserts (id INTEGER, client INTEGER, value INTEGER, skdb_access STRING NOT NULL);",
+      {},
+    );
+
+    const N = 675000; // we should be able to process this many rows without running out of address space
+
+    const rows = ["^no_pk_inserts"];
+    for (let i = 0; i < N; i++) {
+      rows.push(`1\t${i},1,${i},read-write`);
+    }
+    rows.push(":10");
+
+    skdb.skdbSync.runLocal(["write-csv"], rows.join("\n") + '\n');
+
+    return await skdb.exec("select count(*) as n from no_pk_inserts");
+  },
+  check: (res) => {
+    expect(res).toEqual([{n: 675000}]);
+  },
+}, false);


### PR DESCRIPTION
I wrote a test script that inserts 50k rows at once. RSS used is 587Mb
under node. After these changes it is 285Mb. 51% reduction in peak
memory.

More importantly I tried running larger inputs, e.g. 200k rows and it
survives and processes this. Previously it would crash where it runs
out of address space.

In summary: by managing the GC carefully in the row iterations we
ensure the processing overhead is O(1). We still build all the rows
though.

This also extends the soak running time from 18hrs to 21. We're now
hitting the db size limit which after 21hrs is > 1gb. Will work on
making us more memory efficient here next.