### PR TITLE
[skip] Require `module end;` statement at end of file.

### DIFF
--- a/cli/src/cli.sk
+++ b/cli/src/cli.sk
@@ -194,3 +194,5 @@ class Command(
     res
   }
 }
+
+module end;

--- a/cli/src/parser.sk
+++ b/cli/src/parser.sk
@@ -331,3 +331,5 @@ private fun parse(
     error => error,
   }
 }
+
+module end;

--- a/cli/src/usage.sk
+++ b/cli/src/usage.sk
@@ -129,3 +129,5 @@ fun usage(
     },
   ].filterNone().join("\n\n")
 }
+
+module end;

--- a/cli/tests/tests.sk
+++ b/cli/tests/tests.sk
@@ -315,3 +315,5 @@ fun intArgsFromEnv(): void {
   T.expectEq(args.getInt("bar"), 456);
   T.expectEq(args.getInt("baz"), 42);
 }
+
+module end;

--- a/compiler/src/AsmOutput.sk
+++ b/compiler/src/AsmOutput.sk
@@ -4165,3 +4165,5 @@ fun cppIsImported(funInfo: FunInfoCommon, pos: Pos): Bool {
   annotationsContainParam(funInfo.annotations, "@cpp_runtime", pos).isSome() ||
     annotationsContainParam(funInfo.annotations, "@cpp_extern", pos).isSome()
 }
+
+module end;

--- a/compiler/src/Emitter.sk
+++ b/compiler/src/Emitter.sk
@@ -94,3 +94,5 @@ mutable class .Emitter{} extends Rewrite {
     invariant_violation("This should not be called for Emitter.")
   }
 }
+
+module end;

--- a/compiler/src/Layout.sk
+++ b/compiler/src/Layout.sk
@@ -464,3 +464,5 @@ private fun layoutCppExportClass(
       LayoutSlot(field.name, offset, scalarType)
     });
 }
+
+module end;

--- a/compiler/src/NameMangler.sk
+++ b/compiler/src/NameMangler.sk
@@ -278,3 +278,5 @@ fun toString(t: ?TypeBase): String {
   | None() -> "<None>"
   }
 }
+
+module end;

--- a/compiler/src/OuterIstToIR.sk
+++ b/compiler/src/OuterIstToIR.sk
@@ -5426,3 +5426,5 @@ fun createIR(
 
   env
 }
+
+module end;

--- a/compiler/src/ParseTree.sk
+++ b/compiler/src/ParseTree.sk
@@ -569,3 +569,5 @@ mutable class ReplaceTokenCodeMod{
     }
   }
 }
+
+module end;

--- a/compiler/src/PrettyIR.sk
+++ b/compiler/src/PrettyIR.sk
@@ -2274,3 +2274,5 @@ fun debugWriteFunction(
 
   print_error(sstr.toString());
 }
+
+module end;

--- a/compiler/src/Rewrite.sk
+++ b/compiler/src/Rewrite.sk
@@ -1565,3 +1565,5 @@ mutable base class .Rewrite{
     f
   }
 }
+
+module end;

--- a/compiler/src/SkipParseTree.sk
+++ b/compiler/src/SkipParseTree.sk
@@ -4948,3 +4948,5 @@ class YieldExpressionTree{
     );
   }
 }
+
+module end;

--- a/compiler/src/SkipParser.sk
+++ b/compiler/src/SkipParser.sk
@@ -244,9 +244,8 @@ mutable class SkipParser{
   }
 
   // module-end:
-  //    module  end  ;
-  //    end-of-file
-  mutable fun parseModuleEndOpt(): ParseTree {
+  //    module  end
+  mutable fun parseModuleEnd(): ParseTree {
     this.peek() match {
     | TokenKind.MODULE() ->
       start = this.mark();
@@ -271,12 +270,7 @@ mutable class SkipParser{
           "Module declarations may not be nested.",
         );
       }
-    | TokenKind.END_OF_FILE() -> this.createEmptyTreeBefore()
-    | _ ->
-      this.errorResult(
-        errorModuleEndExpected,
-        "Expected 'module end;' or end of file",
-      )
+    | _ -> this.errorResult(errorModuleEndExpected, "Expected 'module end;'")
     }
   }
 
@@ -302,12 +296,12 @@ mutable class SkipParser{
         errorModuleWithCurly,
         "Unexpected '{'. Modules are declared with 'module " +
           name.token.value +
-          ";' and are optionally terminated with 'module end;'",
+          ";' and are terminated with 'module end;'",
       );
     } else {
       semiColon = this.eatTree(TokenKind.SEMI_COLON());
       declarations = this.parseModuleMemberList();
-      end = this.parseModuleEndOpt();
+      end = this.parseModuleEnd();
       ParseTree.ModuleTree{
         range => this.createRange(start),
         moduleKeyword,

--- a/compiler/src/TextOutputStream.sk
+++ b/compiler/src/TextOutputStream.sk
@@ -468,3 +468,5 @@ mutable class BufferedTextOutputStream{
     }
   }
 }
+
+module end;

--- a/compiler/src/Token.sk
+++ b/compiler/src/Token.sk
@@ -29,3 +29,5 @@ class Token{
     "(" + this.kind + "," + this.value + ", " + this.range + ")"
   }
 }
+
+module end;

--- a/compiler/src/UMap.sk
+++ b/compiler/src/UMap.sk
@@ -303,3 +303,5 @@ class .UMap<+V>(
     this.inner.eqBy(other.inner, eq)
   }
 }
+
+module end;

--- a/compiler/src/alloc.sk
+++ b/compiler/src/alloc.sk
@@ -185,3 +185,5 @@ mutable class .Alloc{
     }
   }
 }
+
+module end;

--- a/compiler/src/const.sk
+++ b/compiler/src/const.sk
@@ -525,3 +525,5 @@ fun lowerAllConsts(env: GlobalEnv, config: Config.Config): GlobalEnv {
     initializeAllConstsID => initAllFun.id,
   }
 }
+
+module end;

--- a/compiler/src/control.sk
+++ b/compiler/src/control.sk
@@ -830,3 +830,5 @@ mutable class .Control{
     }
   }
 }
+
+module end;

--- a/compiler/src/coroutine.sk
+++ b/compiler/src/coroutine.sk
@@ -797,3 +797,5 @@ private mutable class .LowerCoroutine{
     emitter.finish("Create coroutine rampup", false)
   }
 }
+
+module end;

--- a/compiler/src/deadcode.sk
+++ b/compiler/src/deadcode.sk
@@ -273,3 +273,5 @@ private fun alwaysLive(instr: Stmt): Bool {
     false
   }
 }
+
+module end;

--- a/compiler/src/dominator.sk
+++ b/compiler/src/dominator.sk
@@ -110,3 +110,5 @@ fun computeDominatorChildren(
     }
   )
 }
+
+module end;

--- a/compiler/src/escape.sk
+++ b/compiler/src/escape.sk
@@ -131,3 +131,5 @@ fun computeWhetherPointersCanEscape(env: GlobalEnv): GlobalEnv {
     }),
   }
 }
+
+module end;

--- a/compiler/src/gc.sk
+++ b/compiler/src/gc.sk
@@ -686,3 +686,5 @@ fun .funAllocAmount(
     Some(AllocNothing())
   }
 }
+
+module end;

--- a/compiler/src/inline.sk
+++ b/compiler/src/inline.sk
@@ -788,3 +788,5 @@ fun computeInlineComplexity(f: Function, env: GlobalEnv): Int {
     }
   }
 }
+
+module end;

--- a/compiler/src/intrinsics.sk
+++ b/compiler/src/intrinsics.sk
@@ -398,3 +398,5 @@ mutable class .IntrinsicsInliner{
     this.jumpIfInvoke(call)
   }
 }
+
+module end;

--- a/compiler/src/ipa.sk
+++ b/compiler/src/ipa.sk
@@ -281,3 +281,5 @@ fun instrCanThrow(
     false
   }
 }
+
+module end;

--- a/compiler/src/lower.sk
+++ b/compiler/src/lower.sk
@@ -1289,3 +1289,5 @@ fun lowerFunctions(env: GlobalEnv, config: Config.Config): GlobalEnv {
 
   env with {sfuns => newFuns.chill(), vtables => Some(vtableInfo)}
 }
+
+module end;

--- a/compiler/src/optinfo.sk
+++ b/compiler/src/optinfo.sk
@@ -509,3 +509,5 @@ fun computePredecessors(
     }
   })
 }
+
+module end;

--- a/compiler/src/peephole.sk
+++ b/compiler/src/peephole.sk
@@ -1935,3 +1935,5 @@ private fun peepholeWith(peep: With, _s: mutable Peephole): Instr {
   }
     */
 }
+
+module end;

--- a/compiler/src/regpromote.sk
+++ b/compiler/src/regpromote.sk
@@ -453,3 +453,5 @@ mutable class .RegisterPromote{
     }
   }
 }
+
+module end;

--- a/compiler/src/safepoint.sk
+++ b/compiler/src/safepoint.sk
@@ -359,3 +359,5 @@ mutable base class .Safepoint<SafepointBlock: mutable SafepointBlockBase>{
     for (b in blocks) this.optimizeBlock(b)
   }
 }
+
+module end;

--- a/compiler/src/skfmt.sk
+++ b/compiler/src/skfmt.sk
@@ -59,3 +59,5 @@ untracked fun main(): void {
     }
   }
 }
+
+module end;

--- a/compiler/src/skipAstPp.sk
+++ b/compiler/src/skipAstPp.sk
@@ -1148,3 +1148,5 @@ fun literal_to_string(x: SkipAst.LiteralValue): String {
   | SkipAst.StringLiteral(s) -> "\"" + Token.escapeStringLiteralValue(s) + "\""
   }
 }
+
+module end;

--- a/compiler/src/skipEmitLLVM.sk
+++ b/compiler/src/skipEmitLLVM.sk
@@ -283,3 +283,5 @@ mutable class Emitter{
     }
   }
 }
+
+module end;

--- a/compiler/src/skipExhaustivePatterns.sk
+++ b/compiler/src/skipExhaustivePatterns.sk
@@ -2358,3 +2358,5 @@ fun check_exhaustive_match_as(
   | exn -> throw exn
   }
 }
+
+module end;

--- a/compiler/src/skipLowerMatches.sk
+++ b/compiler/src/skipLowerMatches.sk
@@ -1097,3 +1097,5 @@ mutable class MatchCompiler(
     (true, O.TryCatch(t.pos, t.stmt, exn_binding, catch_match))
   }
 }
+
+module end;

--- a/compiler/src/skipLowerOuterIst.sk
+++ b/compiler/src/skipLowerOuterIst.sk
@@ -113,3 +113,5 @@ fun method_def(
   pipe = loweringPipeline(context, new_id, program);
   pipe.method_def(method_def).i1
 }
+
+module end;

--- a/compiler/src/skipMain.sk
+++ b/compiler/src/skipMain.sk
@@ -35,3 +35,5 @@ fun type_program(
   SkipNaming.populateFuns(context, defsDir);
   SkipTyping.program(context, defsDir)
 }
+
+module end;

--- a/compiler/src/skipMakeOuterIst.sk
+++ b/compiler/src/skipMakeOuterIst.sk
@@ -1535,7 +1535,6 @@ fun type_identifier(x: TAst.Type_identifier): O.TypeIdentifier {
     O.TidStatic(O.className(ns.i0), O.localName(ns.i1), O.localName(n))
   }
 }
-
 /*****************************************************************************/
 /* Typed Ast compilation phases. */
 /*****************************************************************************/
@@ -1588,3 +1587,6 @@ fun compileTypedAstConst_def(
   cst
 }
 */
+
+
+module end;

--- a/compiler/src/skipNamedAst.sk
+++ b/compiler/src/skipNamedAst.sk
@@ -1478,3 +1478,5 @@ fun is_pure<Ta>(p: (.Array<Purity_modifier>, Ta)): Bool {
     }
   })
 }
+
+module end;

--- a/compiler/src/skipNamedAstPp.sk
+++ b/compiler/src/skipNamedAstPp.sk
@@ -959,3 +959,5 @@ fun field(o: mutable BufferedPrinter.Out, p: (String, N.Expr)): void {
     expr(o, e)
   }
 }
+
+module end;

--- a/compiler/src/skipNaming.sk
+++ b/compiler/src/skipNaming.sk
@@ -4506,3 +4506,5 @@ fun binop_(x: A.Binop_): N.Binop_ {
   | A.Percent() -> N.Percent()
   }
 }
+
+module end;

--- a/compiler/src/skipOuterIstPp.sk
+++ b/compiler/src/skipOuterIstPp.sk
@@ -876,3 +876,5 @@ fun literal(o: mutable BufferedPrinter.Out, l: O.Literal): void {
     },
   )
 }
+
+module end;

--- a/compiler/src/skipOuterIstUtils.sk
+++ b/compiler/src/skipOuterIstUtils.sk
@@ -2457,3 +2457,5 @@ private fun is_leaf_class(
 ): Bool {
   !is_base_class(base_to_derived_classes, class_name)
 }
+
+module end;

--- a/compiler/src/skipSerGenPp.sk
+++ b/compiler/src/skipSerGenPp.sk
@@ -566,3 +566,5 @@ fun type_alias_def(
   emit_decode_type_alias(o, tyd.name.i1, tyd.body);
   o.newline()
 }
+
+module end;

--- a/compiler/src/skipToken.sk
+++ b/compiler/src/skipToken.sk
@@ -186,3 +186,5 @@ fun stringValue(value: String): String {
 
   String::fromChars(chars.toArray())
 }
+
+module end;

--- a/compiler/src/skipTypedAst.sk
+++ b/compiler/src/skipTypedAst.sk
@@ -293,3 +293,5 @@ base class Type_identifier {
   | Tid_object(Name)
   | Tid_static((Name, Name), Name)
 }
+
+module end;

--- a/compiler/src/skipTypedAstExpand.sk
+++ b/compiler/src/skipTypedAstExpand.sk
@@ -736,3 +736,5 @@ fun binding(
   (ty, n, byref) = binding;
   (type(context, env, subst, ty), n, byref)
 }
+
+module end;

--- a/compiler/src/skipTypedAstPp.sk
+++ b/compiler/src/skipTypedAstPp.sk
@@ -769,3 +769,5 @@ fun field(o: mutable BufferedPrinter.Out, f: (String, T.Expr)): void {
     expr(o, e)
   }
 }
+
+module end;

--- a/compiler/src/skipTypedAstUtils.sk
+++ b/compiler/src/skipTypedAstUtils.sk
@@ -480,3 +480,5 @@ mutable class Visitor<State>{
     */
   }
 }
+
+module end;

--- a/compiler/src/skipTypes.sk
+++ b/compiler/src/skipTypes.sk
@@ -3354,3 +3354,5 @@ fun hasUnresolvedConditions(
     has_unresolved(subst, wc.i0) || wc.i1.any(t -> has_unresolved(subst, t))
   )
 }
+
+module end;

--- a/compiler/src/skipTyping.sk
+++ b/compiler/src/skipTyping.sk
@@ -6356,3 +6356,5 @@ fun constructor_invalid_argument_message(
     cname +
     "'"
 }
+
+module end;

--- a/compiler/src/skipTypingUtils.sk
+++ b/compiler/src/skipTypingUtils.sk
@@ -4146,3 +4146,5 @@ const literal_class_names: SSet = ({
     ),
   )
 });
+
+module end;

--- a/compiler/src/specialize.sk
+++ b/compiler/src/specialize.sk
@@ -3796,3 +3796,5 @@ mutable class FunSpecializer{
     this.finish()
   }
 }
+
+module end;

--- a/compiler/src/verify.sk
+++ b/compiler/src/verify.sk
@@ -760,3 +760,5 @@ fun verifyFunction(
     v.verify()
   }
 }
+
+module end;

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -1138,3 +1138,5 @@ fun populateVTables(
 
   vti
 }
+
+module end;

--- a/compiler/tests/expand/expand_const.sk
+++ b/compiler/tests/expand/expand_const.sk
@@ -5,3 +5,5 @@ fun main(): void {
 module Test;
 
 const x: Int = 42;
+
+module end;

--- a/compiler/tests/expand/expand_const2.sk
+++ b/compiler/tests/expand/expand_const2.sk
@@ -7,3 +7,5 @@ fun main(): void {
 module Test;
 
 const x: Int = 42;
+
+module end;

--- a/compiler/tests/expand/expand_self.sk
+++ b/compiler/tests/expand/expand_self.sk
@@ -11,3 +11,5 @@ fun test(): void {
 fun bar(): void {
   void
 }
+
+module end;

--- a/compiler/tests/expand/expand_self2.sk
+++ b/compiler/tests/expand/expand_self2.sk
@@ -11,3 +11,5 @@ fun test(): void {
 fun bar(): void {
   void
 }
+
+module end;

--- a/compiler/tests/expand/global_access_private.sk
+++ b/compiler/tests/expand/global_access_private.sk
@@ -27,3 +27,5 @@ class .Cglobal() extends Bpriv {
     Cpriv()
   }
 }
+
+module end;

--- a/compiler/tests/expand/global_identifiers.sk
+++ b/compiler/tests/expand/global_identifiers.sk
@@ -19,3 +19,5 @@ base class Bar {
 fun .pass(): String {
   "Pass\n"
 }
+
+module end;

--- a/compiler/tests/expand/invalid/expand_unbound_class.sk
+++ b/compiler/tests/expand/invalid/expand_unbound_class.sk
@@ -11,3 +11,5 @@ fun test(): void {
 fun bar(): void {
   void
 }
+
+module end;

--- a/compiler/tests/expand/module_multiple_classes.sk
+++ b/compiler/tests/expand/module_multiple_classes.sk
@@ -9,3 +9,5 @@ base class Nat {
   | Zero()
   | Succ(Nat)
 }
+
+module end;

--- a/compiler/tests/expand/multiple_modules.sk
+++ b/compiler/tests/expand/multiple_modules.sk
@@ -14,3 +14,5 @@ module B;
 fun test2(): void {
   void
 }
+
+module end;

--- a/compiler/tests/expand/uppercase_const_1.sk
+++ b/compiler/tests/expand/uppercase_const_1.sk
@@ -19,3 +19,5 @@ fun doIt(): String {
   _ = Color;
   "" + blue + BLACK + M.GRAY + GRAY + gray()
 }
+
+module end;

--- a/compiler/tests/expand/uppercase_const_2.sk
+++ b/compiler/tests/expand/uppercase_const_2.sk
@@ -11,3 +11,5 @@ const STR: String = "Pass";
 fun doIt(): String {
   STR
 }
+
+module end;

--- a/compiler/tests/runtime/module_consttype.sk
+++ b/compiler/tests/runtime/module_consttype.sk
@@ -15,3 +15,5 @@ class Baz() extends Bar {
     "Pass\n"
   }
 }
+
+module end;

--- a/compiler/tests/syntax/factory.sk
+++ b/compiler/tests/syntax/factory.sk
@@ -16,3 +16,5 @@ class Factory() {
     Foo{attr => attr}
   }
 }
+
+module end;

--- a/compiler/tests/syntax/global_type.sk
+++ b/compiler/tests/syntax/global_type.sk
@@ -16,3 +16,5 @@ type MyOtherInt = Int;
 fun foo(): MyOtherInt {
   0
 }
+
+module end;

--- a/compiler/tests/syntax/invalid/module_curly.exp_err
+++ b/compiler/tests/syntax/invalid/module_curly.exp_err
@@ -1,5 +1,5 @@
 File "tests/syntax/invalid/module_curly.sk", line 1, characters 19-19:
-Unexpected '{'. Modules are declared with 'module ModuleName;' and are optionally terminated with 'module end;'
+Unexpected '{'. Modules are declared with 'module ModuleName;' and are terminated with 'module end;'
 1 | module ModuleName {
   |                   ^
 2 |

--- a/compiler/tests/syntax/invalid/public_module_member.exp_err
+++ b/compiler/tests/syntax/invalid/public_module_member.exp_err
@@ -1,5 +1,5 @@
 File "tests/syntax/invalid/public_module_member.sk", line 5, characters 1-6:
-Expected 'module end;' or end of file
+Expected 'module end;'
 3 |
 4 | fun f1(): void { void }
 5 | public

--- a/compiler/tests/syntax/module.sk
+++ b/compiler/tests/syntax/module.sk
@@ -20,3 +20,5 @@ class Y() {
 fun get(): Int {
   0
 }
+
+module end;

--- a/compiler/tests/syntax/pattern_match_shadow.sk
+++ b/compiler/tests/syntax/pattern_match_shadow.sk
@@ -13,3 +13,5 @@ fun z(): String {
   | Test.MixedString(y) -> y
   }
 }
+
+module end;

--- a/compiler/tests/tests.sk
+++ b/compiler/tests/tests.sk
@@ -99,3 +99,5 @@ fun main(): void {
 
   SKTest.test_harness(tests)
 }
+
+module end;

--- a/compiler/tests/typechecking/invalid/unbound_module.sk
+++ b/compiler/tests/typechecking/invalid/unbound_module.sk
@@ -3,3 +3,5 @@ module A;
 fun main(): void {
   print_raw(M.a)
 }
+
+module end;

--- a/compiler/tests/typechecking/invalid/unbound_module_name.sk
+++ b/compiler/tests/typechecking/invalid/unbound_module_name.sk
@@ -2,3 +2,4 @@ module M;
 fun f(): void {
   M.x()
 }
+module end;

--- a/compiler/tests/typechecking/private_constructor.sk
+++ b/compiler/tests/typechecking/private_constructor.sk
@@ -6,3 +6,5 @@ fun main(): void {
 module Foo;
 
 private class .Foo{attr: Int}
+
+module end;

--- a/compiler/tests/typechecking/unknown_pattern6.sk
+++ b/compiler/tests/typechecking/unknown_pattern6.sk
@@ -16,3 +16,5 @@ fun test(x: List_<_>): Int {
   | Cell _ -> 0
   }
 }
+
+module end;

--- a/compiler/tests/visibility/invalid/module_protected_class.exp_err
+++ b/compiler/tests/visibility/invalid/module_protected_class.exp_err
@@ -1,6 +1,7 @@
 File "tests/visibility/invalid/module_protected_class.sk", line 3, characters 1-9:
-Expected 'module end;' or end of file
+Expected 'module end;'
 1 | module M;
 2 |
 3 | protected class Foo
   | ^^^^^^^^^
+4 |

--- a/compiler/tests/visibility/invalid/module_protected_class.sk
+++ b/compiler/tests/visibility/invalid/module_protected_class.sk
@@ -1,3 +1,5 @@
 module M;
 
 protected class Foo
+
+module end;

--- a/compiler/tests/visibility/invalid/module_protected_const.exp_err
+++ b/compiler/tests/visibility/invalid/module_protected_const.exp_err
@@ -1,5 +1,5 @@
 File "tests/visibility/invalid/module_protected_const.sk", line 3, characters 1-9:
-Expected 'module end;' or end of file
+Expected 'module end;'
 1 | module Foo;
 2 |
 3 | protected const bar : Int = 112;

--- a/compiler/tests/visibility/invalid/module_protected_fun.exp_err
+++ b/compiler/tests/visibility/invalid/module_protected_fun.exp_err
@@ -1,5 +1,5 @@
 File "tests/visibility/invalid/module_protected_fun.sk", line 3, characters 1-9:
-Expected 'module end;' or end of file
+Expected 'module end;'
 1 | module Foo;
 2 |
 3 | protected fun bar() : Int { 112 }

--- a/prelude/build.sk
+++ b/prelude/build.sk
@@ -91,3 +91,5 @@ fun main(): void {
     )
   }
 }
+
+module end;

--- a/prelude/src/core/Parallel.sk
+++ b/prelude/src/core/Parallel.sk
@@ -91,3 +91,5 @@ fun tabulate<T>(count: Int, f: Int ~> T): mutable Array<T> {
     }
   }
 }
+
+module end;

--- a/prelude/src/core/primitives/String.sk
+++ b/prelude/src/core/primitives/String.sk
@@ -552,3 +552,5 @@ base class Encoding {
   | Iso8859_1() -> "iso8859-1"
   | CustomEncoding(name) -> name
 }
+
+module end;

--- a/prelude/src/native/FastOption.sk
+++ b/prelude/src/native/FastOption.sk
@@ -372,3 +372,5 @@ private value class SentinelOption<+T, +Tag: OptionTag>() uses
     }
   }
 }
+
+module end;

--- a/prelude/src/native/String.sk
+++ b/prelude/src/native/String.sk
@@ -80,3 +80,5 @@ private mutable class ConvertBuffer{
     this.inputUsed == this.input.size()
   }
 }
+
+module end;

--- a/prelude/src/native/StringIterator.sk
+++ b/prelude/src/native/StringIterator.sk
@@ -191,3 +191,5 @@ mutable class StringIterator private (
     this.i == other.i
   }
 }
+
+module end;

--- a/prelude/src/stdlib/collections/mutable/Set.sk
+++ b/prelude/src/stdlib/collections/mutable/Set.sk
@@ -281,3 +281,5 @@ private value class EmptyValue() uses Equality, Hashable {
     true
   }
 }
+
+module end;

--- a/prelude/src/stdlib/collections/mutable/UnorderedSet.sk
+++ b/prelude/src/stdlib/collections/mutable/UnorderedSet.sk
@@ -282,3 +282,5 @@ private value class EmptyValue() uses Equality, Hashable {
     true
   }
 }
+
+module end;

--- a/prelude/src/stdlib/collections/persistent/SortedMap.sk
+++ b/prelude/src/stdlib/collections/persistent/SortedMap.sk
@@ -953,7 +953,6 @@ private class InBetween<Tk, +Tv>{
     }
   }
 }
-
 /*
 // states for iterative map()
 private base class MapNode<+K: Orderable, +V, V2> {
@@ -969,3 +968,6 @@ private class MapState<K: Orderable, V, V2>{
   top: MapNode<K, V, V2>
 }
 */
+
+
+module end;

--- a/prelude/src/stdlib/collections/persistent/SortedSet.sk
+++ b/prelude/src/stdlib/collections/persistent/SortedSet.sk
@@ -201,3 +201,5 @@ class .SortedSet<+T: Orderable>(
     cls::createFromIterator(this.iterator())
   }
 }
+
+module end;

--- a/prelude/src/stdlib/filesystem/Path.sk
+++ b/prelude/src/stdlib/filesystem/Path.sk
@@ -292,5 +292,7 @@ fun resolve(
     resolve2(resolve2(path1, path2), path3);
   };
 }
-
 // TOOD: Add relative(path1, path2)
+
+
+module end;

--- a/prelude/src/stdlib/logging/logger.sk
+++ b/prelude/src/stdlib/logging/logger.sk
@@ -99,3 +99,5 @@ base class LoggerBase(config: Config = Config{}) {
 }
 
 class .Logger() extends LoggerBase {}
+
+module end;

--- a/prelude/src/stdlib/other/ASIO.sk
+++ b/prelude/src/stdlib/other/ASIO.sk
@@ -49,3 +49,5 @@ async fun genFillBy<T: frozen>(size: Int, f: Int ~> ^T): ^Array<T> {
   v.reverse();
   unsafe_chill_trust_me(v)
 }
+
+module end;

--- a/prelude/src/stdlib/other/Environ.sk
+++ b/prelude/src/stdlib/other/Environ.sk
@@ -114,3 +114,5 @@ native fun set_var(name: String, value: String): void;
 @debug
 @cpp_extern("SKIP_unsetenv")
 native fun remove_var(name: String): void;
+
+module end;

--- a/prelude/src/stdlib/other/IO.sk
+++ b/prelude/src/stdlib/other/IO.sk
@@ -192,3 +192,5 @@ mutable class BufferedReader<T: mutable Readable>(
     res
   }
 }
+
+module end;

--- a/prelude/src/stdlib/other/Posix.sk
+++ b/prelude/src/stdlib/other/Posix.sk
@@ -384,3 +384,5 @@ fun spawnp(
   pid = internalSpawnp(argv, env, file_actions);
   mutable Process(pid)
 }
+
+module end;

--- a/prelude/src/stdlib/other/StringIterator.sk
+++ b/prelude/src/stdlib/other/StringIterator.sk
@@ -99,3 +99,5 @@ extension mutable class StringIterator {
     }
   }
 }
+
+module end;

--- a/prelude/src/stdlib/other/Time.sk
+++ b/prelude/src/stdlib/other/Time.sk
@@ -10,3 +10,5 @@ native fun time_ms(): Int;
 
 @cpp_extern("SKIP_strftime")
 native fun strftime(format: String, timestamp: Int): String;
+
+module end;

--- a/prelude/src/stdlib/other/termcolor.sk
+++ b/prelude/src/stdlib/other/termcolor.sk
@@ -76,3 +76,5 @@ fun colored(
 
   result
 }
+
+module end;

--- a/prelude/src/stdlib/testing/GTest.sk
+++ b/prelude/src/stdlib/testing/GTest.sk
@@ -52,3 +52,5 @@ class TestCase private {name: String, tests: UnorderedMap<String, () ~> void>} {
     void
   }
 }
+
+module end;

--- a/skargo/src/build_context.sk
+++ b/skargo/src/build_context.sk
@@ -61,3 +61,5 @@ private fun getFiles(
   };
   files.collect(Array)
 }
+
+module end;

--- a/skargo/src/exceptions.sk
+++ b/skargo/src/exceptions.sk
@@ -8,3 +8,5 @@ base class SkargoError extends Exception {
   | SkargoManifestError(path, message) ->
     `Failed to parse manifest at \`${path}\`: ${message}.`
 }
+
+module end;

--- a/skargo/src/main.sk
+++ b/skargo/src/main.sk
@@ -467,3 +467,5 @@ fun execRun(args: Cli.ParseResults): void {
   };
   Posix.execvp(cmdArgs)
 }
+
+module end;

--- a/skargo/src/manifest.sk
+++ b/skargo/src/manifest.sk
@@ -168,3 +168,5 @@ class Manifest{
     }
   }
 }
+
+module end;

--- a/skargo/src/range_constraint.sk
+++ b/skargo/src/range_constraint.sk
@@ -261,3 +261,5 @@ mutable class VersionLexer private {position: mutable Lexer.LexingPosition} {
     )
   }
 }
+
+module end;

--- a/skargo/src/skargo.sk
+++ b/skargo/src/skargo.sk
@@ -221,6 +221,7 @@ const kProfile: String = "${
   }";
 const kTarget: String = "${kTarget}";
 const kWasm32: Bool = ${kWasm32};
+module end;
 `;
 
   FileSystem.writeTextFile(Path.join(bc.targetDir, kVersionFile), contents)
@@ -413,3 +414,5 @@ fun checkBuildFile(
   });
   links
 }
+
+module end;

--- a/skargo/src/solver.sk
+++ b/skargo/src/solver.sk
@@ -81,3 +81,5 @@ fun getDependencies(
     .map(e -> Failure(e))
     .default(Success(result.chill()));
 }
+
+module end;

--- a/skargo/tests/lexer.sk
+++ b/skargo/tests/lexer.sk
@@ -244,3 +244,5 @@ fun full2(): void {
   );
   T.expectEq(got, expected)
 }
+
+module end;

--- a/skbuild/src/checker.sk
+++ b/skbuild/src/checker.sk
@@ -33,3 +33,5 @@ fun max(ot1: ?Int, ot2: ?Int): ?Int {
   | (None(), optTime) -> optTime
   }
 }
+
+module end;

--- a/skfs/src/DeletedDir.sk
+++ b/skfs/src/DeletedDir.sk
@@ -75,3 +75,5 @@ class DeletedDir{time: Time, dirName: DirName} extends Dir {
     true
   }
 }
+
+module end;

--- a/skfs/src/Dir.sk
+++ b/skfs/src/Dir.sk
@@ -59,3 +59,5 @@ class CyclicData(key: String) extends Exception {
     `Cyclic dependencies detected on key ${this.key}`
   }
 }
+
+module end;

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -2184,3 +2184,5 @@ class EagerDir{
     false
   }
 }
+
+module end;

--- a/skfs/src/EagerFilter.sk
+++ b/skfs/src/EagerFilter.sk
@@ -262,3 +262,5 @@ class EagerFilter private {
     result.syncData(context, None(), filterRange);
   }
 }
+
+module end;

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -426,3 +426,5 @@ class FixedSingle<K: Orderable, +V: frozen>(data: Array<(K, V)> = Array[]) {
     Some(elt.i1);
   }
 }
+
+module end;

--- a/skfs/src/LazyDir.sk
+++ b/skfs/src/LazyDir.sk
@@ -219,3 +219,5 @@ class LazyDir{
     this.unsafeGetArray(context, key, true)
   }
 }
+
+module end;

--- a/skmd/src/Blocks.sk
+++ b/skmd/src/Blocks.sk
@@ -609,3 +609,5 @@ fun toEncoded(text: Sequence<Char>): String {
   );
   String::fromChars(tmp.toArray())
 }
+
+module end;

--- a/skmd/src/Html.sk
+++ b/skmd/src/Html.sk
@@ -436,3 +436,5 @@ fun toMenu(entities: Vector<Entity>, max: Int, depth: Int): Vector<HTMLEntity> {
   );
   items.chill();
 }
+
+module end;

--- a/skmd/src/Main.sk
+++ b/skmd/src/Main.sk
@@ -106,3 +106,5 @@ fun execHtml(args: Cli.ParseResults): void {
     }
   }
 }
+
+module end;

--- a/skmd/src/Parser.sk
+++ b/skmd/src/Parser.sk
@@ -518,3 +518,5 @@ mutable class ParseMulti(
 fun parse(str: String): mutable Iterator<Element> {
   parseMulti(parseElements(parseTextLines(str.getIter())));
 }
+
+module end;

--- a/skmd/src/Url.sk
+++ b/skmd/src/Url.sk
@@ -599,3 +599,5 @@ fun checkValidProtocol(protocol: Array<Char>, charset: Charset): Bool {
   };
   true;
 }
+
+module end;

--- a/skmd/tests/tests.sk
+++ b/skmd/tests/tests.sk
@@ -402,3 +402,5 @@ fun convertToHTMLTest(test: String, expect: String): void {
   print_error(got + "\n===============\n" + expect);
   T.expectEq(got, expect)
 }
+
+module end;

--- a/sknpm/build.sk
+++ b/sknpm/build.sk
@@ -19,3 +19,5 @@ fun resourceDirs(_env: Skbuild.Env): Array<String> {
 fun main(): void {
   _ = Skbuild.build();
 }
+
+module end;

--- a/sknpm/src/main.sk
+++ b/sknpm/src/main.sk
@@ -1406,3 +1406,5 @@ fun copy(src: String, dst: String, verbose: Bool = false): void {
   };
   _ = System.subprocess(cmd);
 }
+
+module end;

--- a/sktest/src/expectations.sk
+++ b/sktest/src/expectations.sk
@@ -59,3 +59,5 @@ fun expectThrow(f: () -> void, msg: String = "expected throw"): void {
     fail(msg)
   }
 }
+
+module end;

--- a/sktest/src/harness.sk
+++ b/sktest/src/harness.sk
@@ -277,3 +277,5 @@ fun main(): void {
     test_harness(tests)
   }
 }
+
+module end;

--- a/sktest/src/reporter.sk
+++ b/sktest/src/reporter.sk
@@ -200,3 +200,5 @@ mutable class JSONTestReporter{} extends TestReporter {
     this.writeLine(res.toJSON())
   }
 }
+
+module end;

--- a/sql/src/Cmd.sk
+++ b/sql/src/Cmd.sk
@@ -210,3 +210,5 @@ fun eval(env: mutable CmdEnv, cmd: String): void {
   | _ -> print_string("Unknown command")
   }
 }
+
+module end;

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -799,3 +799,5 @@ fun execToggleView(args: Cli.ParseResults, _options: SKDB.Options): void {
     SKStore.CStop(None())
   })
 }
+
+module end;

--- a/sql/src/Sql.sk
+++ b/sql/src/Sql.sk
@@ -59,3 +59,5 @@ value class Pos(value: Int) uses Equality
 fun errorNbr<T>(_nbr: Int, pos: Int, msg: String): T {
   throw (SqlError(pos, msg))
 }
+
+module end;

--- a/sql/src/SqlCAst.sk
+++ b/sql/src/SqlCAst.sk
@@ -291,3 +291,5 @@ class CStrftime(
 ) extends CExpr<String>
 
 class COn(P.JoinKind, CExpr<Int>) extends CExpr<Int>
+
+module end;

--- a/sql/src/SqlCompile.sk
+++ b/sql/src/SqlCompile.sk
@@ -2393,3 +2393,5 @@ fun selectOrRestIsAggrOrEmptyFrom(select: P.Select): Bool {
     selectIsEmptyFrom(select.core) ||
     select.rest.any(x -> selectIsAggr(x.i1) || selectIsEmptyFrom(x.i1))
 }
+
+module end;

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -882,3 +882,5 @@ fun replayStdin(): Map<String, (Int, Int)> {
     !lineNbr = lineNbr + 1;
   }
 }
+
+module end;

--- a/sql/src/SqlDate.sk
+++ b/sql/src/SqlDate.sk
@@ -615,3 +615,5 @@ fun strftime(
   _ = mktime(tz, tm);
   unixStrftime(format, tm);
 }
+
+module end;

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -2048,3 +2048,5 @@ fun printTable(
     bottomSeparator,
   )
 }
+
+module end;

--- a/sql/src/SqlExpr.sk
+++ b/sql/src/SqlExpr.sk
@@ -971,3 +971,5 @@ fun matching(text: String, pat: Pattern): Bool {
   };
   idx == subs.size()
 }
+
+module end;

--- a/sql/src/SqlIndex.sk
+++ b/sql/src/SqlIndex.sk
@@ -601,3 +601,5 @@ class LookUps private (array: SortedA<LookUp>) {
     }
   }
 }
+
+module end;

--- a/sql/src/SqlLexer.sk
+++ b/sql/src/SqlLexer.sk
@@ -258,3 +258,5 @@ class Lexer(idRoot: Int, content: Buffer) {
     }
   }
 }
+
+module end;

--- a/sql/src/SqlMigrate.sk
+++ b/sql/src/SqlMigrate.sk
@@ -169,3 +169,5 @@ fun dumpAdjustedInserts(
     },
   );
 }
+
+module end;

--- a/sql/src/SqlPrivacy.sk
+++ b/sql/src/SqlPrivacy.sk
@@ -729,3 +729,5 @@ fun userPrivacyChanged(
   skdbGroupPermissions.hasChangedForUser(context, user, tick) ||
     skdbUserPermissions.hasChangedForUser(context, user, tick)
 }
+
+module end;

--- a/sql/src/SqlSelect.sk
+++ b/sql/src/SqlSelect.sk
@@ -1575,3 +1575,5 @@ fun getStats(
   };
   None()
 }
+
+module end;

--- a/sql/src/SqlTables.sk
+++ b/sql/src/SqlTables.sk
@@ -890,3 +890,5 @@ class NamedIDs(
     this.map.maybeGet(var)
   }
 }
+
+module end;

--- a/sql/src/SqlTailer.sk
+++ b/sql/src/SqlTailer.sk
@@ -207,7 +207,9 @@ fun tailSub(
         // initialization, so that the client can start processing without waiting
         // for the full changeset.
         // this value is chosen based on some unscientific local testing
-        checkpointInterval = if (since.value == 0 && !isReset) 512 else Int::max;
+        checkpointInterval = if (since.value == 0 && !isReset) 512 else {
+          Int::max
+        };
 
         producedOutput = edir.writeDiff(
           context,
@@ -284,3 +286,5 @@ fun tailSub(
     }
   }
 }
+
+module end;

--- a/sql/src/SqlTokens.sk
+++ b/sql/src/SqlTokens.sk
@@ -284,3 +284,5 @@ base class TokenKind {
   | TKFloat()
   | TKWord()
 }
+
+module end;

--- a/sql/src/SqlValue.sk
+++ b/sql/src/SqlValue.sk
@@ -332,3 +332,5 @@ class RowKind(order: Int, kind: QueryKind, row: Row) extends Row {
     }
   }
 }
+
+module end;

--- a/sqlparser/src/Ast.sk
+++ b/sqlparser/src/Ast.sk
@@ -412,3 +412,5 @@ fun selectOrRestIsAggrOrEmptyFrom(select: Select): Bool {
     selectIsEmptyFrom(select.core) ||
     select.rest.any(x -> selectIsAggr(x.i1) || selectIsEmptyFrom(x.i1))
 }
+
+module end;

--- a/sqlparser/src/AstPp.sk
+++ b/sqlparser/src/AstPp.sk
@@ -494,3 +494,5 @@ extension base class TransactionKind {
   | TransactionImmediate() -> "IMMEDIATE"
   | TransactionExclusive() -> "EXCLUSIVE"
 }
+
+module end;

--- a/sqlparser/src/Create.sk
+++ b/sqlparser/src/Create.sk
@@ -387,3 +387,5 @@ extension class Parser {
     // }
   }
 }
+
+module end;

--- a/sqlparser/src/Delete.sk
+++ b/sqlparser/src/Delete.sk
@@ -28,3 +28,5 @@ extension class Parser {
     Delete{name => from, alias, where, indexed => None()}
   }
 }
+
+module end;

--- a/sqlparser/src/Drop.sk
+++ b/sqlparser/src/Drop.sk
@@ -36,3 +36,5 @@ extension class Parser {
     }
   }
 }
+
+module end;

--- a/sqlparser/src/Exceptions.sk
+++ b/sqlparser/src/Exceptions.sk
@@ -27,3 +27,5 @@ base class ParserError extends Error {
   | NotImplementedError _ -> "Construction not implemented"
   | UnexpectedExpressionError _ -> "Unexpected expression"
 }
+
+module end;

--- a/sqlparser/src/Expr.sk
+++ b/sqlparser/src/Expr.sk
@@ -405,3 +405,5 @@ extension class Parser {
     Between(lhs_expr, e1, e2, negated)
   }
 }
+
+module end;

--- a/sqlparser/src/Insert.sk
+++ b/sqlparser/src/Insert.sk
@@ -175,3 +175,5 @@ extension class Parser {
     }
   }
 }
+
+module end;

--- a/sqlparser/src/Keyword.sk
+++ b/sqlparser/src/Keyword.sk
@@ -451,3 +451,5 @@ base class Keyword uses Equality, Show, Hashable {
     "WITHOUT" => TWithout(),
   ];
 }
+
+module end;

--- a/sqlparser/src/LexingPosition.sk
+++ b/sqlparser/src/LexingPosition.sk
@@ -114,3 +114,5 @@ mutable class LexingPosition private {
     this.position;
   }
 }
+
+module end;

--- a/sqlparser/src/Parser.sk
+++ b/sqlparser/src/Parser.sk
@@ -296,3 +296,5 @@ mutable class Parser(tokens: mutable Tokenizer) {
     throw NotImplementedError(this.current_pos())
   }
 }
+
+module end;

--- a/sqlparser/src/Pragma.sk
+++ b/sqlparser/src/Pragma.sk
@@ -31,3 +31,5 @@ extension class Parser {
     }
   }
 }
+
+module end;

--- a/sqlparser/src/Select.sk
+++ b/sqlparser/src/Select.sk
@@ -318,3 +318,5 @@ extension class Parser {
     SelectCoreValues{values => values.toArray()}
   }
 }
+
+module end;

--- a/sqlparser/src/Token.sk
+++ b/sqlparser/src/Token.sk
@@ -312,3 +312,5 @@ base class Token uses Equality, Show, Hashable {
   // | AtQuestion()
   // | AtAt()
 }
+
+module end;

--- a/sqlparser/src/Tokenizer.sk
+++ b/sqlparser/src/Tokenizer.sk
@@ -365,3 +365,5 @@ private fun takeWhile(
     }
   }
 }
+
+module end;

--- a/sqlparser/src/Transaction.sk
+++ b/sqlparser/src/Transaction.sk
@@ -32,3 +32,5 @@ extension class Parser {
     EndTransaction{}
   }
 }
+
+module end;

--- a/sqlparser/src/Update.sk
+++ b/sqlparser/src/Update.sk
@@ -83,3 +83,5 @@ extension class Parser {
     sets.toArray()
   }
 }
+
+module end;

--- a/toml/src/datetime.sk
+++ b/toml/src/datetime.sk
@@ -200,3 +200,5 @@ private fun eatChar(iter: mutable String.StringIterator, c: Char): .Bool {
   | _ -> false
   }
 }
+
+module end;

--- a/toml/src/exceptions.sk
+++ b/toml/src/exceptions.sk
@@ -31,3 +31,5 @@ class KeyNotFoundError(key: .String) extends TOMLError {
     `KeyNotFoundError: ${this.getMessage()}`
   }
 }
+
+module end;

--- a/toml/src/float.sk
+++ b/toml/src/float.sk
@@ -80,3 +80,5 @@ private fun parseFloat(tok: .String): ?.Float {
 
   Some(sign * result)
 }
+
+module end;

--- a/toml/src/integer.sk
+++ b/toml/src/integer.sk
@@ -117,3 +117,5 @@ private fun eatInteger(iter: mutable String.StringIterator): ?(.Int, .Int) {
 
   Some((res, leadingZeros))
 }
+
+module end;

--- a/toml/src/lexer.sk
+++ b/toml/src/lexer.sk
@@ -573,3 +573,5 @@ private fun charToString(ch: Char): .String {
     };
   }
 }
+
+module end;

--- a/toml/src/parser.sk
+++ b/toml/src/parser.sk
@@ -350,3 +350,5 @@ private mutable base class Result {
     res
   }
 }
+
+module end;

--- a/toml/src/toml.sk
+++ b/toml/src/toml.sk
@@ -196,3 +196,5 @@ class DateTime(
       this.offset.default("")
   }
 }
+
+module end;

--- a/toml/tests/tests.sk
+++ b/toml/tests/tests.sk
@@ -133,3 +133,5 @@ fun main(): void {
 
   T.test_harness(tests)
 }
+
+module end;


### PR DESCRIPTION
Until this commit, the closing `module end;` statement could be
omitted at the end of a file.
The benefits were tenuous (and can be obtained using a linter with
autofix), and came at the cost of not being able to concatenate skip
files.