### PR TITLE
[sqlparser] Allow keywords as identifiers in various places.

### DIFF
--- a/sqlparser/src/Create.sk
+++ b/sqlparser/src/Create.sk
@@ -33,7 +33,7 @@ extension class Parser {
     ifNotExists = this.parseIfNotExists();
 
     // TODO: Schema-qualified name.
-    name = Name::create(this.expect_identifier());
+    name = Name::create(this.expect_identifier(true));
 
     if (this.parse_token(TLParen())) {
       this.errorNotImplemented()
@@ -52,11 +52,11 @@ extension class Parser {
     ifNotExists = this.parseIfNotExists();
 
     // TODO: Schema-qualified name.
-    name = Name::create(this.expect_identifier());
+    name = Name::create(this.expect_identifier(true));
 
     this.expect_keyword(TOn());
 
-    on = Name::create(this.expect_identifier());
+    on = Name::create(this.expect_identifier(true));
 
     columns = this.parseIndexedColumns();
 
@@ -88,7 +88,7 @@ extension class Parser {
     expr = this.parseExpr();
 
     collate = if (this.parse_keyword(TCollate())) {
-      Some(Name::create(this.expect_identifier()))
+      Some(Name::create(this.expect_identifier(true)))
     } else {
       None()
     };
@@ -110,7 +110,7 @@ extension class Parser {
     ifNotExists = this.parseIfNotExists();
 
     // TODO: Schema-qualified name.
-    name = Name::create(this.expect_identifier());
+    name = Name::create(this.expect_identifier(true));
 
     if (this.parse_keyword(TAs())) {
       this.errorNotImplemented()
@@ -262,7 +262,7 @@ extension class Parser {
 
   mutable fun parseColumnConstraintNamedConstraint(): ColumnConstraint {
     this.tokens.advance();
-    constraintName = Some(Name::create(this.expect_identifier()));
+    constraintName = Some(Name::create(this.expect_identifier(true)));
     // TODO: This currently allows `CONSTRAINT foo CONSTRAINT bar ...`.
     this.parseColumnConstraint().fromSome() with {constraintName}
   }

--- a/sqlparser/src/Delete.sk
+++ b/sqlparser/src/Delete.sk
@@ -6,9 +6,9 @@ extension class Parser {
     this.expect_keyword(TFrom());
 
     // TODO: Schema-qualified name.
-    from = Name::create(this.expect_identifier());
+    from = Name::create(this.expect_identifier(true));
     alias = if (this.parse_keyword(TAs())) {
-      Some(Name::create(this.expect_identifier()))
+      Some(Name::create(this.expect_identifier(true)))
     } else {
       None()
     };

--- a/sqlparser/src/Drop.sk
+++ b/sqlparser/src/Drop.sk
@@ -25,7 +25,7 @@ extension class Parser {
     };
 
     // TODO: Schema-qualified name.
-    name = Name::create(this.expect_identifier());
+    name = Name::create(this.expect_identifier(true));
 
     kind match {
     | TIndex() -> DropIndex{name, ifExists}

--- a/sqlparser/src/Insert.sk
+++ b/sqlparser/src/Insert.sk
@@ -17,9 +17,9 @@ extension class Parser {
     this.expect_keyword(TInto());
 
     // TODO: Schema-qualified name.
-    into = Name::create(this.expect_identifier());
+    into = Name::create(this.expect_identifier(true));
     alias = if (this.parse_keyword(TAs())) {
-      Some(Name::create(this.expect_identifier()))
+      Some(Name::create(this.expect_identifier(true)))
     } else {
       None()
     };

--- a/sqlparser/src/Pragma.sk
+++ b/sqlparser/src/Pragma.sk
@@ -5,7 +5,7 @@ extension class Parser {
     this.expect_keyword(TPragma());
 
     // TODO: Schema-qualified name.
-    name = Name::create(this.expect_identifier());
+    name = Name::create(this.expect_identifier(true));
 
     value = if (this.parse_token(TEq())) {
       Some(this.parsePragmaValue())

--- a/sqlparser/src/Select.sk
+++ b/sqlparser/src/Select.sk
@@ -135,7 +135,7 @@ extension class Parser {
       | TValues() ->
         select = this.parseSelect();
         asName = if (this.parse_keyword(TAs())) {
-          Some(Name::create(this.expect_identifier()))
+          Some(Name::create(this.expect_identifier(true)))
         } else {
           None()
         };
@@ -149,15 +149,14 @@ extension class Parser {
     };
 
     // TODO: Schema-qualified name.
-    name = Name::create(this.expect_identifier());
+    name = Name::create(this.expect_identifier(true));
     if (this.peek_token() == TLParen()) {
       // table-function
       this.errorNotImplemented()
     } else {
-      asName = if (
-        this.parse_keyword(TAs()) ||
-        this.peek_token() is TWord(_, _, None _)
-      ) {
+      asName = if (this.parse_keyword(TAs())) {
+        Some(Name::create(this.expect_identifier(true)))
+      } else if (this.peek_token() is TWord(_, _, None _)) {
         Some(Name::create(this.expect_identifier()))
       } else {
         None()
@@ -165,7 +164,7 @@ extension class Parser {
 
       indexed = if (this.parse_keyword(TIndexed())) {
         this.expect_keyword(TBy());
-        Some(Name::create(this.expect_identifier()))
+        Some(Name::create(this.expect_identifier(true)))
       } else {
         if (this.parse_keyword(TNot())) {
           this.expect_keyword(TIndexed())
@@ -285,7 +284,7 @@ extension class Parser {
       Some(Name::create(id))
     | _ ->
       if (this.parse_keyword(TAs())) {
-        Some(Name::create(this.expect_identifier()))
+        Some(Name::create(this.expect_identifier(true)))
       } else {
         None()
       }

--- a/sqlparser/src/Update.sk
+++ b/sqlparser/src/Update.sk
@@ -11,17 +11,17 @@ extension class Parser {
     };
 
     // TODO: Schema-qualified name.
-    tableName = Name::create(this.expect_identifier());
+    tableName = Name::create(this.expect_identifier(true));
 
     alias = if (this.parse_keyword(TAs())) {
-      Some(Name::create(this.expect_identifier()))
+      Some(Name::create(this.expect_identifier(true)))
     } else {
       None()
     };
 
     indexed = if (this.parse_keyword(TIndexed())) {
       this.expect_keyword(TBy());
-      Some(Name::create(this.expect_identifier()))
+      Some(Name::create(this.expect_identifier(true)))
     } else {
       if (this.parse_keyword(TNot())) {
         this.expect_keyword(TIndexed())
@@ -59,7 +59,7 @@ extension class Parser {
         res = mutable Vector[];
         loop {
           pos = this.current_pos();
-          res.push((pos, Name::create(this.expect_identifier())));
+          res.push((pos, Name::create(this.expect_identifier(true))));
           if (!this.parse_token(TComma())) {
             break void
           }
@@ -68,7 +68,7 @@ extension class Parser {
         res.toArray()
       } else {
         pos = this.current_pos();
-        Array[(pos, Name::create(this.expect_identifier()))]
+        Array[(pos, Name::create(this.expect_identifier(true)))]
       };
 
       this.expect_token(TEq());


### PR DESCRIPTION
Fixes #29.