### PR TITLE
Share more data on INSERT

### DIFF
--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -986,7 +986,7 @@ class Evaluator{options: Options, user: ?UserFile} {
   ): void {
     dir = getDir(table);
     newDir = context.unsafeGetEagerDir(dir.dirName);
-    kinds = table.schema.mapWithIndex((idx, x) -> (idx, P.IASC(), x.ty));
+    kinds = table.kinds;
     for (row in rows) {
       key = RowKey(row, kinds);
       source = SKStore.Path(dir.dirName, SKStore.IID(SKStore.genSym(0)));


### PR DESCRIPTION
Up until now, we were recomputing the order of the rows for every single row in a table. It is correct, but it was incredibly wasteful. The order is always going to be the same for every single entry of the table, we should make them all share the same pointer instead of recomputing it every time.

This is a 20% win in memory for a table 100000 integer entries.