### PR TITLE
Add a get_gc_type function to the runtime

### DIFF
--- a/compiler/runtime/copy.c
+++ b/compiler/runtime/copy.c
@@ -22,7 +22,7 @@ static char* shallow_copy(char* obj, size_t memsize, size_t leftsize,
 }
 
 static char* SKIP_copy_class(sk_stack_t* st, char* obj, char* large_page) {
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t memsize = ty->m_userByteSize;
   size_t leftsize = ty->m_uninternedMetadataByteSize;
@@ -56,7 +56,7 @@ static char* SKIP_copy_class(sk_stack_t* st, char* obj, char* large_page) {
 }
 
 static char* SKIP_copy_array(sk_stack_t* st, char* obj, char* large_page) {
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
   size_t memsize = ty->m_userByteSize * len;
@@ -104,7 +104,7 @@ static char* SKIP_copy_string(char* obj, char* large_page) {
 static char* SKIP_copy_obj(sk_stack_t* st, char* obj, char* large_page) {
   char* result;
 
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   switch (ty->m_kind) {
     case 0:

--- a/compiler/runtime/free.c
+++ b/compiler/runtime/free.c
@@ -33,7 +33,7 @@ void free_intern(char* obj, size_t memsize, size_t leftsize) {
 }
 
 void sk_free_class(sk_stack_t* st, char* obj) {
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t memsize = ty->m_userByteSize;
   size_t leftsize = ty->m_uninternedMetadataByteSize;
@@ -83,7 +83,7 @@ void sk_free_class(sk_stack_t* st, char* obj) {
 }
 
 void sk_free_array(sk_stack_t* st, char* obj) {
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
   size_t memsize = ty->m_userByteSize * len;
@@ -131,7 +131,7 @@ void sk_free_obj(sk_stack_t* st, char* obj) {
     return;
   }
 
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   switch (ty->m_kind) {
     case 0:

--- a/compiler/runtime/hash.c
+++ b/compiler/runtime/hash.c
@@ -138,7 +138,7 @@ SkipInt SKIP_hash_combine(SkipInt crc1, SkipInt crc2) {
 /*****************************************************************************/
 
 static uint64_t sk_hash_class(sk_stack_t* st, char* obj) {
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t memsize = ty->m_userByteSize;
   size_t leftsize = ty->m_uninternedMetadataByteSize;
@@ -174,7 +174,7 @@ static uint64_t sk_hash_class(sk_stack_t* st, char* obj) {
 
 static uint64_t sk_hash_array(sk_stack_t* st, char* obj) {
   uint64_t crc = CRC_INIT;
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
   size_t memsize = ty->m_userByteSize * len;
@@ -232,7 +232,7 @@ static uint64_t sk_hash_obj(sk_stack_t* st, char* obj) {
     return sk_hash_string(obj);
   }
 
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
   uint64_t crc;
 
   switch (ty->m_kind) {

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -79,7 +79,7 @@ void sk_incr_ref_count(void* obj) {
     count -= 3;
 #endif
   } else {
-    SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+    SKIP_gc_type_t* ty = get_gc_type(obj);
 
     switch (ty->m_kind) {
       case 0:
@@ -105,7 +105,7 @@ static uintptr_t* sk_get_ref_count_addr(void* obj) {
     count -= 3;
 #endif
   } else {
-    SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+    SKIP_gc_type_t* ty = get_gc_type(obj);
 
     switch (ty->m_kind) {
       case 0:
@@ -136,7 +136,7 @@ uintptr_t sk_get_ref_count(void* obj) {
 }
 
 static char* SKIP_intern_class(sk_stack_t* st, char* obj) {
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t memsize = ty->m_userByteSize;
   size_t leftsize = ty->m_uninternedMetadataByteSize;
@@ -171,7 +171,7 @@ static char* SKIP_intern_class(sk_stack_t* st, char* obj) {
 }
 
 static char* SKIP_intern_array(sk_stack_t* st, char* obj) {
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
   size_t memsize = ty->m_userByteSize * len;
@@ -223,7 +223,7 @@ uint32_t SKIP_is_string(char* obj) {
 static char* SKIP_intern_obj(sk_stack_t* st, char* obj) {
   char* result;
 
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   switch (ty->m_kind) {
     case 0:

--- a/compiler/runtime/native_eq.c
+++ b/compiler/runtime/native_eq.c
@@ -29,8 +29,8 @@
 SkipInt SKIP_native_eq_class(sk_stack_t* st, char* obj1, char* obj2) {
   if (obj1 == obj2) return 0;
 
-  SKIP_gc_type_t* ty1 = *(*(((SKIP_gc_type_t***)obj1) - 1) + 1);
-  SKIP_gc_type_t* ty2 = *(*(((SKIP_gc_type_t***)obj2) - 1) + 1);
+  SKIP_gc_type_t* ty1 = get_gc_type(obj1);
+  SKIP_gc_type_t* ty2 = get_gc_type(obj2);
 
   if (ty1 != ty2) {
     return 1;
@@ -69,8 +69,8 @@ SkipInt SKIP_native_eq_class(sk_stack_t* st, char* obj1, char* obj2) {
 }
 
 SkipInt SKIP_native_eq_array(sk_stack_t* st, char* obj1, char* obj2) {
-  SKIP_gc_type_t* ty1 = *(*(((SKIP_gc_type_t***)obj1) - 1) + 1);
-  SKIP_gc_type_t* ty2 = *(*(((SKIP_gc_type_t***)obj2) - 1) + 1);
+  SKIP_gc_type_t* ty1 = get_gc_type(obj1);
+  SKIP_gc_type_t* ty2 = get_gc_type(obj2);
 
   if (ty1 != ty2) {
     return 1;
@@ -144,8 +144,8 @@ SkipInt SKIP_native_eq_helper(sk_stack_t* st, char* obj1, char* obj2) {
     return 1;
   }
 
-  SKIP_gc_type_t* ty1 = *(*(((SKIP_gc_type_t***)obj1) - 1) + 1);
-  SKIP_gc_type_t* ty2 = *(*(((SKIP_gc_type_t***)obj2) - 1) + 1);
+  SKIP_gc_type_t* ty1 = get_gc_type(obj1);
+  SKIP_gc_type_t* ty2 = get_gc_type(obj2);
 
   if (ty1 != ty2) {
     return 1;

--- a/compiler/runtime/obstack.c
+++ b/compiler/runtime/obstack.c
@@ -146,7 +146,7 @@ void* SKIP_Obstack_calloc(size_t size) {
 }
 
 char* SKIP_Obstack_shallowClone(size_t _size, char* obj) {
-  SKIP_gc_type_t* ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t memsize = ty->m_userByteSize;
   size_t leftsize = ty->m_uninternedMetadataByteSize;

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -703,7 +703,7 @@ void SKIP_memory_init(int argc, char** argv) {
 #endif  // __APPLE__
 
   char* obj = sk_get_external_pointer();
-  epointer_ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  epointer_ty = get_gc_type(obj);
 }
 
 /*****************************************************************************/

--- a/compiler/runtime/runtime.c
+++ b/compiler/runtime/runtime.c
@@ -5,6 +5,20 @@
 #endif
 
 /*****************************************************************************/
+/* Operations on the runtime representation of skip values. */
+/*****************************************************************************/
+
+SKIP_gc_type_t* get_gc_type(char* skip_object) {
+  // a vtable pointer immediately precedes a pointer to each skip object
+  SKIP_gc_type_t*** vtable = ((SKIP_gc_type_t***)skip_object) - 1;
+  // the gc_type of each object is stored in slot 1 of the vtable,
+  // see createVTableBuilders in vtable.sk
+  SKIP_gc_type_t** slot1 = *(vtable) + 1;
+  return *slot1;
+}
+
+
+/*****************************************************************************/
 /* Saving/restoring context to thread locals.
  *
  * These primitives are very dangerous to use unless you really know what you

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -155,6 +155,7 @@ sk_value3_t sk_stack3_pop(sk_stack3_t* st);
 /* The type information exposed by the Skip compiler for each object. */
 /*****************************************************************************/
 
+// vtable entries created by createGCType in vtable.sk
 typedef struct {
   uint8_t m_refsHintMask;
   uint8_t m_kind;
@@ -170,6 +171,8 @@ typedef struct {
   void (*m_onStateChange)(void*, long);
   size_t m_refMask[0];
 } SKIP_gc_type_t;
+
+SKIP_gc_type_t* get_gc_type(char* skip_object);
 
 /*****************************************************************************/
 /* SKIP String representation. */

--- a/compiler/runtime/runtime32_specific.c
+++ b/compiler/runtime/runtime32_specific.c
@@ -37,7 +37,7 @@ void SKIP_skfs_init(uint32_t size) {
   end_of_static = (char*)bump_pointer;
   sk_ftable = sk_ftable_holder;
   char* obj = sk_get_external_pointer();
-  epointer_ty = *(*(((SKIP_gc_type_t***)obj) - 1) + 1);
+  epointer_ty = get_gc_type(obj);
 }
 
 void SKIP_destroy_Obstack(void*);


### PR DESCRIPTION
This function encodes the knowledge of the runtime representation of
values used to obtain a skip object's vtable and then the gc_type from
slot 1.