### PR TITLE
Remove dead support for disabling GC

### DIFF
--- a/compiler/runtime/obstack.c
+++ b/compiler/runtime/obstack.c
@@ -249,18 +249,7 @@ void* SKIP_destroy_Obstack_with_value(sk_saved_obstack_t* saved, void* toCopy) {
   return result;
 }
 
-static int sk_gc_enabled = 1;
-
-void SKIP_disable_GC() {
-  sk_gc_enabled = 0;
-}
-
-void SKIP_enable_GC() {
-  sk_gc_enabled = 1;
-}
-
 uint32_t SKIP_should_GC(sk_saved_obstack_t* saved) {
-  if (!sk_gc_enabled) return 0;
   size_t nbr_page = 0;
   size_t size = 0;
   void* cursor = page;


### PR DESCRIPTION
The sk_gc_enabled flag is dead as it is never changed.