### PR TITLE
Fix: query params were not serialising null in the server

### DIFF
--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -87,7 +87,7 @@ class Skdb(val name: String, private val dbPath: String) {
     val adapter: JsonAdapter<Map<String, Any?>> =
         moshi.adapter(
             Types.newParameterizedType(Map::class.java, String::class.java, Object::class.java))
-    buf.append(adapter.toJson(params))
+    buf.append(adapter.serializeNulls().toJson(params))
     buf.append("\n")
     buf.append(stmts)
     return blockingRun(


### PR DESCRIPTION
This meant that logging inserts were failing. I think it also affected
config lookups.