### PR TITLE
Catch exceptions on sending data/close

### DIFF
--- a/sql/server/core/src/main/kotlin/core/Mux.kt
+++ b/sql/server/core/src/main/kotlin/core/Mux.kt
@@ -1035,11 +1035,19 @@ class MuxedSocket(
   }
 
   private fun sendClose(code: Int, reason: String) {
-    channel.sendClose(code, reason)
+    try {
+      channel.sendClose(code, reason)
+    } catch (ex: Exception) {
+      onSocketError(0u, "IO failure while sending close")
+    }
   }
 
   private fun sendData(data: ByteBuffer) {
-    channel.sendData(data)
+    try {
+      channel.sendData(data)
+    } catch (ex: Exception) {
+      onSocketError(0u, "IO failure while sending data")
+    }
   }
 
   private fun scheduleSessionTimeout() {


### PR DESCRIPTION
On IO error we pessimistically assume that we're in a bad state and
fail the socket. This is the only practical option to ensure invariants.

We must catch here otherwise the exception bubbles up leaving the
socket in a bad state but the application doesn't get notified. This
was the root cause of running out of connections when we should not.

Why do we get IO exceptions? Because undertow is badly designed. If
the client exits quickly it closes the TCP socket before we've had a
chance to gracefully close the muxed socket, websocket, etc. This
_should_ be fine, it's half-closed and so we should be allowed to send
our closing messages even though the client is not reading them. But
undertow throws exceptions in this state even though there's nothing
exceptional about this.