### PR TITLE
Flag in the console any rejected changes

### DIFF
--- a/prelude/ts/src/sk_browser.ts
+++ b/prelude/ts/src/sk_browser.ts
@@ -19,6 +19,7 @@ class WrkImpl implements Wrk {
 
 class Env implements Environment {
   shared: Map<string, Shared>;
+  disableWarnings: boolean = false;
   fileSystem: MemFS;
   system: MemSys;
   timestamp: () => float;

--- a/prelude/ts/src/sk_node.ts
+++ b/prelude/ts/src/sk_node.ts
@@ -30,6 +30,7 @@ var encoder = new util.TextEncoder();
 class Env implements Environment {
   shared: Map<string, Shared>;
   fileSystem: MemFS;
+  disableWarnings: boolean = false;
   system: MemSys;
   timestamp: () => float;
   window: () => Window;

--- a/prelude/ts/src/sk_runtime.ts
+++ b/prelude/ts/src/sk_runtime.ts
@@ -124,7 +124,7 @@ class LinksImpl implements Links {
       this.lineBuffer = utils.readStdInToEnd();
       return this.lineBuffer.length;
     };
-    this.SKIP_read_line_get = (i: int) =>  {
+    this.SKIP_read_line_get = (i: int) => {
       return this.lineBuffer[i];
     };
     this.SKIP_getchar = utils.getStdInChar;

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -543,7 +543,7 @@ export class Utils {
       this.current_stdin++;
     }
     return lineBuffer;
-  }
+  };
 
   getStdInChar = () => {
     if (this.current_stdin >= this.stdin.length) {

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -148,6 +148,7 @@ export interface Wrk {
 export interface Environment {
   shared: Map<string, Shared>;
   name: () => string;
+  disableWarnings: boolean;
   environment: Array<string>;
   createSocket: (uir: string) => WebSocket;
   createWorker: (filename: string | URL, options?: WorkerOptions) => Wrk;

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -107,15 +107,15 @@ class FixedDir<T: frozen> private {
     sorted = loop {
       !i = i + 1;
       if (i >= sz) break true;
-      keyComparison = data[i-1].key.compare(data[i].key);
+      keyComparison = data[i - 1].key.compare(data[i].key);
       keyComparison match {
-        | LT() -> continue;
-        | GT() -> break false;
-        | EQ() -> data[i-1].value.i0.compare(data[i].value.i0)
+      | LT() -> continue
+      | GT() -> break false
+      | EQ() -> data[i - 1].value.i0.compare(data[i].value.i0)
       } match {
-        | LT() -> continue;
-        | EQ() -> continue;
-        | GT() -> break false;
+      | LT() -> continue
+      | EQ() -> continue
+      | GT() -> break false
       };
     };
     if (!sorted) {

--- a/sql/ts/src/skdb_orchestration.ts
+++ b/sql/ts/src/skdb_orchestration.ts
@@ -1610,8 +1610,16 @@ class SKDBServer implements RemoteSKDB {
               if (line.startsWith("^") || line.startsWith(":")) {
                 if (count > 0) {
                   console.warn(
-                    "[skdb] %d row updates were rejected by the server. Query table %s to examine the rejected rows.",
+                    "[skdb] %d row updates were rejected by the server. " +
+                      "Query table %s to examine the rejected rows.",
                     count,
+                    currentTable,
+                  );
+                  console.info(
+                    "[skdb] Rejected updates are caused by writes that violate " +
+                      "access rules. These rules are checked locally at write time so " +
+                      "must have changed concurrently. You can watchChanges on %s " +
+                      "if you wish to handle this with application logic.",
                     currentTable,
                   );
                 }

--- a/sql/ts/src/skdb_orchestration.ts
+++ b/sql/ts/src/skdb_orchestration.ts
@@ -1590,11 +1590,11 @@ class SKDBServer implements RemoteSKDB {
           const warningsEnabled = true;
 
           if (!warningsEnabled) {
-            return
+            return;
           }
 
           let count = 0;
-          let currentTable: string|undefined = undefined;
+          let currentTable: string | undefined = undefined;
 
           for (const line of payload.split("\n")) {
             if (line.trim() === "") {
@@ -1609,10 +1609,16 @@ class SKDBServer implements RemoteSKDB {
             } else {
               if (line.startsWith("^") || line.startsWith(":")) {
                 if (count > 0) {
-                  console.warn("[skdb] %d row updates were rejected by the server. Query table %s to examine the rejected rows.", count, currentTable);
+                  console.warn(
+                    "[skdb] %d row updates were rejected by the server. Query table %s to examine the rejected rows.",
+                    count,
+                    currentTable,
+                  );
                 }
                 count = 0;
-                currentTable = line.startsWith("^") ? line.split(" ")[0].substring(1) : undefined;
+                currentTable = line.startsWith("^")
+                  ? line.split(" ")[0].substring(1)
+                  : undefined;
               } else {
                 count++;
               }

--- a/sql/ts/src/skdb_orchestration.ts
+++ b/sql/ts/src/skdb_orchestration.ts
@@ -1586,10 +1586,7 @@ class SKDBServer implements RemoteSKDB {
           // the server responds with acks and any rejections
           client.writeCsv(payload, this.replicationUid);
 
-          // TODO:
-          const warningsEnabled = true;
-
-          if (!warningsEnabled) {
+          if (this.env.disableWarnings) {
             return;
           }
 
@@ -1621,6 +1618,10 @@ class SKDBServer implements RemoteSKDB {
                       "must have changed concurrently. You can watchChanges on %s " +
                       "if you wish to handle this with application logic.",
                     currentTable,
+                  );
+                  console.info(
+                    "[skdb] To silence skdb warnings you can pass " +
+                      "`{ disableWarnings: true }` to createSkdb.",
                   );
                 }
                 count = 0;

--- a/sql/ts/tests/node.play.ts
+++ b/sql/ts/tests/node.play.ts
@@ -15,27 +15,30 @@ tests(true).forEach((t) => run(t, true));
 
 // this is to detect memory regression in wasm, it's not a behaviour
 // test. running only in node as I saw timeout flakiness with firefox.
-run({
-  name: "Write-csv memory regression test",
-  fun: async (skdb: SKDB) => {
-    await skdb.exec(
-      "CREATE TABLE no_pk_inserts (id INTEGER, client INTEGER, value INTEGER, skdb_access TEXT NOT NULL);",
-      {},
-    );
+run(
+  {
+    name: "Write-csv memory regression test",
+    fun: async (skdb: SKDB) => {
+      await skdb.exec(
+        "CREATE TABLE no_pk_inserts (id INTEGER, client INTEGER, value INTEGER, skdb_access TEXT NOT NULL);",
+        {},
+      );
 
-    const N = 675000; // we should be able to process this many rows without running out of address space
+      const N = 675000; // we should be able to process this many rows without running out of address space
 
-    const rows = ["^no_pk_inserts"];
-    for (let i = 0; i < N; i++) {
-      rows.push(`1\t${i},1,${i},read-write`);
-    }
-    rows.push(":10");
+      const rows = ["^no_pk_inserts"];
+      for (let i = 0; i < N; i++) {
+        rows.push(`1\t${i},1,${i},read-write`);
+      }
+      rows.push(":10");
 
-    skdb.skdbSync.runLocal(["write-csv"], rows.join("\n") + '\n');
+      skdb.skdbSync.runLocal(["write-csv"], rows.join("\n") + "\n");
 
-    return await skdb.exec("select count(*) as n from no_pk_inserts");
+      return await skdb.exec("select count(*) as n from no_pk_inserts");
+    },
+    check: (res) => {
+      expect(res).toEqual([{ n: 675000 }]);
+    },
   },
-  check: (res) => {
-    expect(res).toEqual([{n: 675000}]);
-  },
-}, false);
+  false,
+);


### PR DESCRIPTION
With local privacy checking, rejected changes should be very rare now.
I don't think it makes sense to - at this time anyway - build anything
particularly sophisticated. But I wanted to raise the visibility of
the __skdb_mirror_feedback tables. I think this is a nice compromise.