### PR TITLE
[skc] Exit on internal errors

### DIFF
--- a/compiler/src/main.sk
+++ b/compiler/src/main.sk
@@ -69,7 +69,13 @@ fun main(): void {
     _context ~> {
       SKStore.CStop(
         Some((context, _, _) ~> {
-          _result = compile(config, context, config.unknown);
+          try {
+            compile(config, context, config.unknown)
+          } catch {
+          | exn ->
+            print_error(exn.getMessage());
+            skipExit(2)
+          }
         }),
       )
     },


### PR DESCRIPTION
If exceptions escape out of functions run by `runWithGc`, they are
just printed and ignored. In the case of skc, this results in skargo
not noticing when compilation fails.