### PR TITLE
Add compiler build stage that uses the host compiler

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -74,6 +74,26 @@ stage3/bin/skc stage3/bin/skfmt stage3/bin/skargo: stage2
 	(cd ../skargo && PATH=../compiler/stage2/bin:$(PATH) skargo build -r --target-dir ../compiler/stage3/bin)
 # 	TODO: Ensure stage2 == stage3.
 
+stageA/bin/skc:
+	mkdir -p stageA/bin
+	cp $(shell command -v skc) stageA/bin/skc
+
+stageA/bin/skargo:
+	mkdir -p stageA/bin
+	cp $(shell command -v skargo) stageA/bin/skargo
+
+stageA/bin/skfmt:
+	mkdir -p stageA/bin
+	cp $(shell command -v skfmt) stageA/bin/skfmt
+
+stageB/bin/skc stageB/bin/skfmt stageB/bin/skargo: stageA
+	PATH=stageA/bin/:$(PATH) skargo build -r --target-dir stageB/bin
+	(cd ../skargo && PATH=../compiler/stageA/bin:$(PATH) skargo build -r --target-dir ../compiler/stageB/bin)
+
+stageC/bin/skc stageC/bin/skfmt stageC/bin/skargo: stageB
+	PATH=stageB/bin/:$(PATH) skargo build -r --target-dir stageC/bin
+	(cd ../skargo && PATH=../compiler/stageB/bin:$(PATH) skargo build -r --target-dir ../compiler/stageC/bin)
+
 .PHONY: install
 install: stage$(STAGE)
 	install -d $(libdir)


### PR DESCRIPTION
The current bootstrap procedure does not keep the compiler and runtime system in sync. The stage0 build compiles the current runtime sources together with the checked-in compiler bitcode, and then the stage1 build compiles the current compiler and runtime sources. This means that the current runtime sources have to work for both the bootstrap and current compiler sources. This makes it difficult to make changes that require modifications in both the compiler and runtime.

This PR adds an alternate build process that starts with the host skc, which is already linked with its contemporary runtime system, instead of the bootstrap bitcode. In particular, stageA builds the current runtime sources, and copies the host skc. Then stageB compiles the current compiler sources using the stageA compiler and links them with the current runtime compiled during stageA. Then stageC compiles the current compiler sources using the stageB executable. It seems necessary to copy the host compiler so that it can be in the same directory as the new runtime system library, as that is where skargo looks for it. Note that due to the way builds are time-stamped in magic.c, builds are guaranteed to be non-reproducible and no fixed-point will ever be reached.