### PR TITLE
Wire up query params with mirroring

### DIFF
--- a/sql/server/core/build.gradle.kts
+++ b/sql/server/core/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
   implementation("io.undertow:undertow-core:2.3.2.Final") // http/ws
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
   implementation("org.java-websocket:Java-WebSocket:1.5.3")
+
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1") // json
+
   implementation("com.squareup.moshi:moshi:1.14.0") // json
   implementation("com.squareup.moshi:moshi-kotlin:1.14.0") // json
 }

--- a/sql/server/core/build.gradle.kts
+++ b/sql/server/core/build.gradle.kts
@@ -23,9 +23,6 @@ dependencies {
   implementation("org.java-websocket:Java-WebSocket:1.5.3")
 
   implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1") // json
-
-  implementation("com.squareup.moshi:moshi:1.14.0") // json
-  implementation("com.squareup.moshi:moshi-kotlin:1.14.0") // json
 }
 
 // Apply a specific Java toolchain to ease working on different environments.

--- a/sql/server/core/src/main/kotlin/core/Orchestration.kt
+++ b/sql/server/core/src/main/kotlin/core/Orchestration.kt
@@ -1,5 +1,7 @@
 package io.skiplabs.skdb
 
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets
@@ -8,6 +10,7 @@ import java.nio.charset.StandardCharsets
 
 // 10MiB ought to be enough for anybody
 val MAX_QUERY_LENGTH = 10 * 1024 * 1024
+val jsonMapper = ObjectMapper()
 
 sealed class ProtoMessage()
 
@@ -64,8 +67,11 @@ fun decodeParams(data: ByteBuffer): Map<String, Any?> {
   val paramsLength = data.getShort()
   val paramsBytes = ByteArray(paramsLength.toInt())
   data.get(paramsBytes)
-  // TODO: decode json in to map
-  return HashMap<String, Any>()
+
+  val typeRef = object : TypeReference<HashMap<String, Any>>() {}
+  val ret: Map<String, Any?> = jsonMapper.readValue(paramsBytes, typeRef)
+
+  return ret
 }
 
 fun decodeProtoMsg(data: ByteBuffer): ProtoMessage {

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -198,7 +198,7 @@ class Skdb(val name: String, private val dbPath: String) {
 
     val moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
     val jsonAdapter: JsonAdapter<Map<String, TailSpec>> = moshi.adapter<Map<String, TailSpec>>()
-    val serialisedSpec = jsonAdapter.toJson(spec)
+    val serialisedSpec = jsonAdapter.serializeNulls().toJson(spec)
 
     // TODO: for hacky debug
     tailPb.redirectError(ProcessBuilder.Redirect.INHERIT)

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -187,16 +187,13 @@ class Skdb(val name: String, private val dbPath: String) {
             user,
             "--read-spec")
 
-    val serialisedSpec = jsonMapper.writeValueAsString(spec)
 
     // TODO: for hacky debug
     tailPb.redirectError(ProcessBuilder.Redirect.INHERIT)
     val proc = tailPb.start()
 
-    val stdin = proc.outputStream
-    val writer = stdin.bufferedWriter()
-    writer.write(serialisedSpec)
-    writer.flush()
+    val stdin = proc.outputStream.buffered()
+    jsonMapper.writeValue(stdin, spec)
     stdin.close()
 
     // TODO: working with text currently to detect checkpoint flush

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -158,7 +158,6 @@ class Skdb(val name: String, private val dbPath: String) {
     return proc
   }
 
-  @OptIn(kotlin.ExperimentalStdlibApi::class)
   fun tail(
       user: String,
       replicationId: String,

--- a/sql/ts/src/skdb_orchestration.ts
+++ b/sql/ts/src/skdb_orchestration.ts
@@ -1532,7 +1532,7 @@ class SKDBServer implements RemoteSKDB {
           expectedColumns: def.expectedColumns,
           since: this.client.watermark(this.replicationUid, def.table),
           filterExpr: def.filterExpr ?? "",
-          params: new Map(),
+          params: def.filterParams ?? new Map(),
         };
       });
       return encodeProtoMsg({

--- a/sql/ts/src/skdb_types.ts
+++ b/sql/ts/src/skdb_types.ts
@@ -21,6 +21,7 @@ export type MirrorDefn = {
   table: string;
   expectedColumns: string;
   filterExpr?: string;
+  filterParams?: Params;
 };
 
 export interface SKDBSync {

--- a/sql/ts/tests/apitests.ts
+++ b/sql/ts/tests/apitests.ts
@@ -1,5 +1,5 @@
 import { expect } from "@playwright/test";
-import { createSkdb, SKDB } from "skdb";
+import { createSkdb, SKDB, Params } from "skdb";
 
 type dbs = {
   root: SKDB;
@@ -244,7 +244,7 @@ function waitSynch(
   skdb: SKDB,
   query: string,
   check: (v: any) => boolean,
-  query_params: Map<string, any> = new Map(),
+  query_params: Params = new Map(),
   server: boolean = false,
   max: number = 6,
 ) {

--- a/sql/ts/tests/apitests.ts
+++ b/sql/ts/tests/apitests.ts
@@ -366,7 +366,7 @@ async function testLargeMirror(root: SKDB, user: SKDB) {
   };
   const large_copy = {
     table: "large_copy",
-    expectedColumns: "(t INTEGER, skdb_access TEXT)",
+    expectedColumns: "*", // just to test the *, would be better to be explicit
   };
 
   await user.mirror(test_pk, view_pk, large);

--- a/sql/ts/tests/apitests.ts
+++ b/sql/ts/tests/apitests.ts
@@ -213,7 +213,8 @@ async function testMirroring(skdb: SKDB) {
   const test_pk = {
     table: "test_pk",
     expectedColumns: "(x INTEGER PRIMARY KEY, y INTEGER, skdb_access TEXT)",
-    filterExpr: "x < 43",
+    filterExpr: "x < @thresh",
+    filterParams: { thresh: 43 },
   };
   const view_pk = {
     table: "view_pk",


### PR DESCRIPTION
I already did most of the work to support this, it just wasn't hooked
up. Finally circling back round.

While here I ran in to all sorts of grief parsing json in java. Every
library wants to handle the most sophisticated cases but can't handle
a simple case of deserialising a value of unknown shape so that it can
be spliced in to another json object and then re-serialised. Ended up
migrating off of moshi and on to good ol' trusty jackson, which just
works. Oh and can work directly with bytes rather than going through
strings. Oh and it doesn't need experimental kotlin features. Win.