### PR TITLE
Minor runtime build simplifications

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -51,15 +51,15 @@ stage%/lib/skip_preamble32.ll: preamble/preamble32.ll
 
 stage0/bin/skargo: bootstrap/skargo_out64.ll stage0/lib/libskip_runtime64.a stage0/lib/libbacktrace.a
 	mkdir -p $(@D)
-	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g
+	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g3
 
 stage0/bin/skfmt: bootstrap/skfmt_out64.ll stage0/lib/libskip_runtime64.a stage0/lib/libbacktrace.a
 	mkdir -p $(@D)
-	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g
+	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g3
 
 stage0/bin/skc: bootstrap/skc_out64.ll stage0/lib/libskip_runtime64.a stage0/lib/libbacktrace.a
 	mkdir -p $(@D)
-	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g
+	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g3
 
 stage1/bin/skc stage1/bin/skfmt stage1/bin/skargo: stage0
 	PATH=stage0/bin/:$(PATH) skargo build -r --target-dir stage1/bin

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -23,8 +23,9 @@ CFILES=\
 	xoroshiro128plus.c
 
 NATIVE_FILES=\
-	palloc.c\
-	consts.c
+	consts.c \
+	palloc.c \
+	posix.c
 
 CFILES32=$(CFILES) runtime32_specific.c
 BCFILES32=magic.bc $(CFILES32:.c=.bc)
@@ -44,7 +45,7 @@ libskip_runtime32.bc: $(BCFILES32)
 %.bc: %.c
 	clang $(OLEVEL) $(CC32FLAGS) -o $@ -c $<
 
-libskip_runtime64.a: $(OFILES) posix.o runtime64_specific.o $(ONATIVE_FILES)
+libskip_runtime64.a: $(OFILES) runtime64_specific.o $(ONATIVE_FILES)
 	$(AR) rcs $@ $^
 
 .PHONY: libbacktrace

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -38,12 +38,6 @@ magic.c:
 	date | cksum | awk '{print "unsigned long version = " $$1 ";"}' > magic.c
 	echo "int SKIP_get_version() { return (int)version; }" >> magic.c
 
-magic.bc: magic.c
-	clang $(OLEVEL) $(CC32FLAGS) -o $@ -c $<
-
-magic.o: magic.c
-	clang $(CC64FLAGS) -o $@ -c $<
-
 libskip_runtime32.bc: $(BCFILES32)
 	llvm-link $(BCFILES32) -o $@
 

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -57,10 +57,10 @@ libbacktrace: .libs/libbacktrace.a
 	$(MAKE) -C libbacktrace
 
 runtime64_specific.o: runtime64_specific.cpp .libs/libbacktrace.a
-	clang++ -std=c++11 $(OLEVEL) -g -o $@ -c -Ilibbacktrace/ $<
+	clang++ -std=c++11 $(OLEVEL) -g3 -o $@ -c -Ilibbacktrace/ $<
 
 %.o: %.c
-	clang $(CC64FLAGS) -g -o $@ -c $<
+	clang $(CC64FLAGS) -g3 -o $@ -c $<
 
 .PHONY: clean
 clean:

--- a/prelude/build.mk
+++ b/prelude/build.mk
@@ -17,7 +17,7 @@ endif # ifeq ($(PRFDEF),DEBUG)
 endif # ifeq ($(PRFDEF),RELEASE)
 else
 DEFINITIONS=
-OLEVEL=-O2 -g
+OLEVEL=-O2 -g3
 endif # ifdef PROFILE
 
 LBT_EXISTS=$(shell [ -e $(LIB_DIR)/libbacktrace.a ] && echo 1 || echo 0 )
@@ -90,8 +90,8 @@ endif
 
 $(BUILD_DIR)runtime/runtime64_specific.o: $(COMP_DIR)/runtime/runtime64_specific.cpp
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@)
-	@clang++ $(OLEVEL) -g -o $@ -c -I$(COMP_DIR)/runtime/libbacktrace/ $<
+	@clang++ $(OLEVEL) -g3 -o $@ -c -I$(COMP_DIR)/runtime/libbacktrace/ $<
 
 $(BUILD_DIR)%.o: $(COMP_DIR)/%.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@)
-	@clang $(CC64FLAGS) -g -o $@ -c $<
+	@clang $(CC64FLAGS) -g3 -o $@ -c $<

--- a/prelude/build_wasm32.mk
+++ b/prelude/build_wasm32.mk
@@ -8,14 +8,14 @@ ifeq ($(PRFDEF),RELEASE)
 OLEVEL=-O3
 else
 ifeq ($(PRFDEF),DEBUG)
-OLEVEL=-O0 -g
+OLEVEL=-O0 -g3
 else
-OLEVEL=-O2 -g
+OLEVEL=-O2 -g3
 endif # ifeq ($(PRFDEF),DEBUG)
 endif # ifeq ($(PRFDEF),RELEASE)
 else
 DEFINITIONS=
-OLEVEL=-O2 -g
+OLEVEL=-O2 -g3
 endif # ifdef PROFILE
 
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc


### PR DESCRIPTION
- Handle posix.c the same as other native-only runtime source files

- Use generic build rules for magic.bc and magic.o

- Increase debug info to -g3