### PR TITLE
Fixed the way we stored MInfo

### DIFF
--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -202,12 +202,14 @@ base class MInfo {
   children =
   | MInfoEmpty()
   | MInfoSingle(Key)
+  | MInfoMultiple(Array<Key>)
   | MInfoFull(Array<Key>, Array<DirName>, Array<Path>)
 
   fun getKeys(): Array<Key> {
     this match {
     | MInfoEmpty() -> Array[]
     | MInfoSingle(x) -> Array[x]
+    | MInfoMultiple(keys) -> keys
     | MInfoFull(keys, _, _) -> keys
     }
   }
@@ -216,6 +218,7 @@ base class MInfo {
     this match {
     | MInfoEmpty() -> Array[]
     | MInfoSingle(_) -> Array[]
+    | MInfoMultiple(_) -> Array[]
     | MInfoFull(_, dirs, _) -> dirs
     }
   }
@@ -223,6 +226,7 @@ base class MInfo {
     this match {
     | MInfoEmpty() -> Array[]
     | MInfoSingle(_) -> Array[]
+    | MInfoMultiple(_) -> Array[]
     | MInfoFull(_, _, reads) -> reads
     }
   }
@@ -232,10 +236,11 @@ base class MInfo {
     newDirs: Array<DirName>,
     reads: Array<Path>,
   ): MInfo {
-    if (keys.isEmpty() && newDirs.isEmpty() && reads.isEmpty()) {
-      return MInfoEmpty()
+    if (newDirs.isEmpty() && reads.isEmpty()) {
+      if (keys.isEmpty()) return MInfoEmpty();
+      if (keys.size() == 1) return MInfoSingle(keys[0]);
+      return MInfoMultiple(keys);
     };
-    if (keys.size() == 1) return MInfoSingle(keys[0]);
     MInfoFull(keys, newDirs, reads)
   }
 
@@ -255,6 +260,9 @@ base class MInfo {
     | MInfoSingle(key) ->
       if (newDirs.isEmpty()) return this;
       MInfoFull(Array[key], newDirs, Array[])
+    | MInfoMultiple(keys) ->
+      if (newDirs.isEmpty()) return this;
+      MInfoFull(keys, newDirs, Array[])
     | MInfoFull(keys, _, reads) -> static::create(keys, newDirs, reads)
     }
   }


### PR DESCRIPTION
MInfo is a datastructure we use to store what was produced during a map by a particular key. It contains, the keys that were emitted, the directories that were created and the keys that were read.

So for example, let's consider the following map:

myDirectory.map(..., (context, writer, key, values) ~> {
  foo = myOtherDirectory.getArray(...) <---- This is a read
  bar = myOtherDirectory.map(...) <--- this is a directory creation
  writer.set(myKey, _) <--- this is a key being emitted
})

So the natural type for this datastructure should be:

class MInfo(
  keys: Array<Key>, newDirs: Array<...>, reads: Array<...>
)

However, it is very (very!) frequent, that a map does not read from other directories, or create a new directory. So the datastructure has been optimized for the cases were we are only emitting keys.

Unfortunately, the logic was wrong, but it was undetectable, it would omit the directories and reads if the number of keys was exactly equal to one. Which is obviously wrong. However, in practice, you would always have a read greater than one for any read or directory creation. That's why the bug has gone undetected so far. But it was clearly working for the wrong reasons.

This diff fixes that, and introduces a new type for the case were we have multiple keys. Both because it's more efficient in that case and because it made the code more natural.