### PR TITLE
Fail fast improvements

### DIFF
--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -23,14 +23,14 @@ data class ProcessOutput(val output: ByteArray, val exitCode: Int) {
   }
 
   fun logOnError(): ProcessOutput {
-    if (exitCode != 0) {
+    if (!exitSuccessfully()) {
       System.err.println(decode())
     }
     return this
   }
 
   fun getOrThrow(): ByteArray {
-    if (exitCode != 0) {
+    if (!exitSuccessfully()) {
       logOnError()
       throw RuntimeException("Process exited unsuccessfully: ${exitCode}")
     }

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -22,9 +22,16 @@ data class ProcessOutput(val output: ByteArray, val exitCode: Int) {
     return exitCode == 0
   }
 
-  fun getOrThrow(): ByteArray {
+  fun logOnError(): ProcessOutput {
     if (exitCode != 0) {
       System.err.println(decode())
+    }
+    return this
+  }
+
+  fun getOrThrow(): ByteArray {
+    if (exitCode != 0) {
+      logOnError()
       throw RuntimeException("Process exited unsuccessfully: ${exitCode}")
     }
     return output
@@ -280,7 +287,7 @@ class Skdb(val name: String, private val dbPath: String) {
                 "SELECT privateKey FROM skdb_users WHERE userID = @user;",
                 mapOf("user" to user),
                 OutputFormat.RAW)
-            .decode()
+            .decodeOrThrow()
             .trim()
 
     if (key.isEmpty()) {
@@ -310,14 +317,15 @@ class Skdb(val name: String, private val dbPath: String) {
                 "BEGIN TRANSACTION; INSERT INTO skdb_users VALUES (id('userID'), @privateKey); SELECT id('userID'); COMMIT;",
                 mapOf("privateKey" to encryptedPrivateKey),
                 OutputFormat.RAW)
-            .decode()
+            .decodeOrThrow()
             .trim()
     return accessKey
   }
 
   fun canMirror(table: String, schema: String): Boolean {
     val result = blockingRun(ProcessBuilder(ENV.skdbPath, "can-mirror", table, schema))
-    return result.decode() == ""
+    result.logOnError()
+    return result.exitSuccessfully() && result.decode() == ""
   }
 }
 

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -24,6 +24,7 @@ data class ProcessOutput(val output: ByteArray, val exitCode: Int) {
 
   fun getOrThrow(): ByteArray {
     if (exitCode != 0) {
+      System.err.println(decode())
       throw RuntimeException("Process exited unsuccessfully: ${exitCode}")
     }
     return output

--- a/sql/server/core/src/main/kotlin/core/StaticConfig.kt
+++ b/sql/server/core/src/main/kotlin/core/StaticConfig.kt
@@ -8,7 +8,6 @@ import java.util.Properties
 
 val USER_CONFIG_FILE = ".skdb.conf"
 var ENV = UserConfig.create()
-val SERVICE_MGMT_DB_NAME = "skdb_service_mgmt"
 val SKDB_PORT = 3586
 
 class UserConfig(

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -571,9 +571,24 @@ class Evaluator{options: Options, user: ?UserFile} {
       views = getViewsDir(context);
       viewsDir = context.unsafeGetEagerDir(views.dirName);
       key = SKStore.SID(viewName.lower);
-      if (viewsDir.getArrayRaw(key).size() != 0) {
-        if (ifNotExists) return None();
-        error(pos, "VIEW " + viewName + " already exists");
+      cselect1 = SKDB.Compiler::create(
+        false,
+        this.options with {virtual => true},
+        selectAst.pos,
+        params,
+      ).compileSelect(context, selectAst, viewName, true);
+      existingFiles = viewsDir.getArrayRaw(key);
+      if (existingFiles.size() > 0) {
+        existingFiles[0] match {
+        | _ if (!ifNotExists) ->
+          error(pos, "VIEW " + viewName + " already exists")
+        | SelectFile(_, _, _, _, _, cs) if (cselect1 != cs) ->
+          error(
+            pos,
+            "VIEW " + viewName + " already exists with a different query",
+          )
+        | _ -> return None()
+        }
       } else {
         tables = getTableDir(context);
         tablesDir = context.unsafeGetEagerDir(tables.dirName);
@@ -581,12 +596,6 @@ class Evaluator{options: Options, user: ?UserFile} {
           error(pos, "Table " + viewName + " exists");
         };
       };
-      cselect1 = SKDB.Compiler::create(
-        false,
-        this.options with {virtual => true},
-        selectAst.pos,
-        params,
-      ).compileSelect(context, selectAst, viewName, true);
       viewsDir.write(
         context,
         key,

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -1004,6 +1004,11 @@ class Evaluator{options: Options, user: ?UserFile} {
   ): void {
     dirName = dirDescr.dirName;
     if (context.unsafeMaybeGetEagerDir(dirName) is Some _ && ifNotExists) {
+      currentSchema = getTable(context, pos, name).schema;
+      newSchema = dirDescr.schema;
+      if (currentSchema != newSchema) {
+        error(pos, "table exists with a different schema")
+      };
       return void;
     };
 

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -743,12 +743,20 @@ class Evaluator{options: Options, user: ?UserFile} {
   fun makeIndex(context: mutable SKStore.Context, index: P.CreateIndex): void {
     input = getIndexInputDir(context);
     key = SKStore.SID::create(index.name.lower);
-    size = (context.unsafeGetEagerDir(input.dirName)).getArrayRaw(key).size();
-    if (size != 0) {
-      if (index.ifNotExists) {
-        return void;
-      };
-      error(index.pos, "INDEX " + index.name.origName + " already exists");
+    current = (context.unsafeGetEagerDir(input.dirName)).getArrayRaw(key);
+    if (current.size() > 0) {
+      current[0] match {
+      | _ if (!index.ifNotExists) ->
+        error(index.pos, "INDEX " + index.name.origName + " already exists")
+      | ci @ P.CreateIndex _ if (ci != index) ->
+        error(
+          index.pos,
+          "INDEX " +
+            index.name.origName +
+            " already exists with different schema",
+        )
+      | _ -> return void
+      }
     };
     this.write(context, input.dirName, key, index);
     _ = getIndexOutputDir(context);

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -748,13 +748,19 @@ class Evaluator{options: Options, user: ?UserFile} {
       current[0] match {
       | _ if (!index.ifNotExists) ->
         error(index.pos, "INDEX " + index.name.origName + " already exists")
-      | ci @ P.CreateIndex _ if (ci != index) ->
-        error(
-          index.pos,
-          "INDEX " +
-            index.name.origName +
-            " already exists with different schema",
-        )
+      | ci @ P.CreateIndex _ ->
+        old = ci with {ifNotExists => true, pos => 0};
+        new = index with {pos => 0};
+        if (old != new) {
+          error(
+            index.pos,
+            "INDEX " +
+              index.name.origName +
+              " already exists with different schema",
+          )
+        } else {
+          return void
+        }
       | _ -> return void
       }
     };


### PR DESCRIPTION
A couple of improvements to get things to fail faster rather than allowing you to continue with bad assumptions.

- We check table, view, and schema creation to make sure when idempotent you really are getting the expected result. This prevents you moving forward with a misaligned schema.

- Made sure that the dev server checks the result of process calls and does not drop valuable error info.