### PR TITLE
Change of the representation of indexes keys

### DIFF
--- a/sql/src/SqlIndex.sk
+++ b/sql/src/SqlIndex.sk
@@ -6,18 +6,37 @@ module alias P = SQLParser;
 
 module SKDB;
 
-class IndexProjKey(values: Array<(Int, ?CValue)>) extends SKStore.Key
-
-fun makeIndexProjKey(
-  v: RowValues,
+class IndexProjKey private (
+  row: RowValues,
   kinds: Array<(Int, P.IKind, P.Type)>,
-  size: Int,
-): IndexProjKey {
-  indexedValues = mutable Vector[];
-  for (i in Range(0, size)) {
-    indexedValues.push((kinds[i].i0, v.values[kinds[i].i0]));
-  };
-  IndexProjKey(indexedValues.toArray());
+) extends SKStore.Key {
+  static fun create(values: Array<(Int, P.Type, ?CValue)>): this {
+    row = RowValues::create(values.map(x -> x.i2));
+    kinds = values.map(x -> (x.i0, P.IASC(), x.i1));
+    static(row, kinds)
+  }
+
+  static fun createFromRowValues(
+    row: RowValues,
+    kinds: Array<(Int, P.IKind, P.Type)>,
+  ): IndexProjKey {
+    static(row, kinds)
+  }
+
+  fun toArray(): Array<(Int, ?CValue)> {
+    indexedValues = mutable Vector[];
+    for (i in Range(0, this.kinds.size())) {
+      indexedValues.push((this.kinds[i].i0, this.row.values[this.kinds[i].i0]));
+    };
+    indexedValues.toArray()
+  }
+
+  fun compare(other: SKStore.Key): Order {
+    other match {
+    | IndexProjKey(row2, _) -> compareRows(this.kinds, this.row, row2)
+    | _ -> this.getClassName().compare(other.getClassName())
+    }
+  }
 }
 
 fun createIndexName(
@@ -69,6 +88,7 @@ fun createIndex(
     )
   };
   if (unique) {
+    subKinds = kinds.slice(0, size);
     _ = index
       .map(
         x ~> x,
@@ -79,9 +99,14 @@ fun createIndex(
           result = SortedMap<IndexProjKey, mutable Vector<RowValues>>[];
           valuesArr = values.collect(Array);
           for (v in valuesArr) {
-            k = makeIndexProjKey(v, kinds, size);
+            k = IndexProjKey::createFromRowValues(v, subKinds);
             if (v.repeat != 1) {
-              throw Conflict(0, "UNIQUE constraint failed", k.values, valuesArr)
+              throw Conflict(
+                0,
+                "UNIQUE constraint failed",
+                k.toArray(),
+                valuesArr,
+              )
             };
             if (!result.containsKey(k)) {
               !result[k] = mutable Vector[];
@@ -109,7 +134,7 @@ fun createIndex(
               0,
               "UNIQUE constraint failed",
               key match {
-              | IndexProjKey(arr) -> arr
+              | projKey @ IndexProjKey _ -> projKey.toArray()
               | _ -> invariant_violation("Unexpected key type")
               },
               valuesArr,

--- a/sql/src/SqlPrivacy.sk
+++ b/sql/src/SqlPrivacy.sk
@@ -264,7 +264,9 @@ class SKDBUsersByName extends PredefinedTable {
   const indexedFields: Array<P.Name> = Array[P.Name::create("userID")];
 
   fun makeKey(userID: String): IndexProjKey {
-    IndexProjKey(Array[(this.getColNbr(userIDColName), Some(CString(userID)))])
+    IndexProjKey::create(
+      Array[(this.getColNbr(userIDColName), P.TEXT(), Some(CString(userID)))],
+    )
   }
 }
 
@@ -289,8 +291,10 @@ class SKDBUserPermissions extends PredefinedTable {
   const indexedFields: Array<P.Name> = Array[P.Name::create("userID")];
 
   fun makeKey(userID: ?String): IndexProjKey {
-    IndexProjKey(
-      Array[(this.getColNbr(userIDColName), userID.map(x -> CString(x)))],
+    IndexProjKey::create(
+      Array[
+        (this.getColNbr(userIDColName), P.TEXT(), userID.map(x -> CString(x))),
+      ],
     )
   }
 }
@@ -313,8 +317,8 @@ class SKDBGroups extends PredefinedTable {
 
   const indexedFields: Array<P.Name> = Array[groupIDColName];
   fun makeKey(groupID: String): IndexProjKey {
-    IndexProjKey(
-      Array[(this.getColNbr(groupIDColName), Some(CString(groupID)))],
+    IndexProjKey::create(
+      Array[(this.getColNbr(groupIDColName), P.TEXT(), Some(CString(groupID)))],
     )
   }
 }
@@ -340,10 +344,10 @@ class SKDBGroupPermissions extends PredefinedTable {
   ];
 
   fun makeKey(groupID: String, userID: ?String): IndexProjKey {
-    IndexProjKey(
+    IndexProjKey::create(
       Array[
-        (this.getColNbr(groupIDColName), Some(CString(groupID))),
-        (this.getColNbr(userIDColName), userID.map(x -> CString(x))),
+        (this.getColNbr(groupIDColName), P.TEXT(), Some(CString(groupID))),
+        (this.getColNbr(userIDColName), P.TEXT(), userID.map(x -> CString(x))),
       ],
     )
   }


### PR DESCRIPTION
We use to represent keys of an index in a very inefficient way: this was mostly due to accommodate "INSERT OR REPLACE". That construction requires meta-data to understand the nature of the conflict. In this diff, we only reconstruct that meta-data when necessary, saving a lot of space.

This is a 20% win in space for a table that defines an index.