### PR TITLE
Revert "Fixed the way we stored MInfo (#71)"

### DIFF
--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -202,14 +202,12 @@ base class MInfo {
   children =
   | MInfoEmpty()
   | MInfoSingle(Key)
-  | MInfoMultiple(Array<Key>)
   | MInfoFull(Array<Key>, Array<DirName>, Array<Path>)
 
   fun getKeys(): Array<Key> {
     this match {
     | MInfoEmpty() -> Array[]
     | MInfoSingle(x) -> Array[x]
-    | MInfoMultiple(keys) -> keys
     | MInfoFull(keys, _, _) -> keys
     }
   }
@@ -218,7 +216,6 @@ base class MInfo {
     this match {
     | MInfoEmpty() -> Array[]
     | MInfoSingle(_) -> Array[]
-    | MInfoMultiple(_) -> Array[]
     | MInfoFull(_, dirs, _) -> dirs
     }
   }
@@ -226,7 +223,6 @@ base class MInfo {
     this match {
     | MInfoEmpty() -> Array[]
     | MInfoSingle(_) -> Array[]
-    | MInfoMultiple(_) -> Array[]
     | MInfoFull(_, _, reads) -> reads
     }
   }
@@ -236,11 +232,10 @@ base class MInfo {
     newDirs: Array<DirName>,
     reads: Array<Path>,
   ): MInfo {
-    if (newDirs.isEmpty() && reads.isEmpty()) {
-      if (keys.isEmpty()) return MInfoEmpty();
-      if (keys.size() == 1) return MInfoSingle(keys[0]);
-      return MInfoMultiple(keys);
+    if (keys.isEmpty() && newDirs.isEmpty() && reads.isEmpty()) {
+      return MInfoEmpty()
     };
+    if (keys.size() == 1) return MInfoSingle(keys[0]);
     MInfoFull(keys, newDirs, reads)
   }
 
@@ -260,9 +255,6 @@ base class MInfo {
     | MInfoSingle(key) ->
       if (newDirs.isEmpty()) return this;
       MInfoFull(Array[key], newDirs, Array[])
-    | MInfoMultiple(keys) ->
-      if (newDirs.isEmpty()) return this;
-      MInfoFull(keys, newDirs, Array[])
     | MInfoFull(keys, _, reads) -> static::create(keys, newDirs, reads)
     }
   }


### PR DESCRIPTION
Revert in order to fix the broken build - many of the wasm tests fail
with this commit. It looks like CI didn't run the skdb or wasm tests
in #71, just skfs, so no one saw it. I haven't looked in to why this
causes such issues, just wanted to unbreak the build for now.

PR #72 fails wasm tests until I rebase on this revert, both locally
and in CI, so I'm fairly confident that the problem is here.