### PR TITLE
Move definition of SKIP_String_eq from preamble to runtime

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -22,7 +22,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             mkdir -p ~/test-results
-            cd compiler && make STAGE=B
+            make -C compiler clean stageB
             PATH=./stageB/bin:$PATH skargo test --junitxml ~/test-results/skc.xml
       - store_test_results:
           path: ~/test-results/skc.xml

--- a/compiler/preamble/preamble32.ll
+++ b/compiler/preamble/preamble32.ll
@@ -26,6 +26,7 @@ declare ptr @SKIP_Obstack_shallowClone(i32, ptr)
 declare i64 @SKIP_String_StringIterator__rawCurrent(ptr)
 declare void @SKIP_String_StringIterator__rawDrop(ptr, i64)
 declare i64 @SKIP_String_cmp(ptr, ptr)
+declare i8 @SKIP_String_eq(ptr, ptr)
 declare {i64, i64} @SKIP_String_toIntOptionHelper(ptr)
 declare ptr @SKIP_intern(ptr)
 declare void @SKIP_exit(i64)
@@ -101,19 +102,5 @@ define void @SKIP_Obstack_store(ptr %obj, ptr %val) {
 define void @SKIP_debug_break() {
   ret void
 }
-
-; Function Attrs: noinline nounwind optnone
-define i1 @SKIP_String_eq(ptr %0, ptr %1) #0 {
-  %3 = alloca ptr, align 4
-  %4 = alloca ptr, align 4
-  store ptr %0, ptr %3, align 4
-  store ptr %1, ptr %4, align 4
-  %5 = load ptr, ptr %3, align 4
-  %6 = load ptr, ptr %4, align 4
-  %7 = call i64 @SKIP_String_cmp(ptr %5, ptr %6)
-  %8 = icmp eq i64 %7, 0
-  ret i1 %8
-}
-
 
 %struct._FunctionSignature = type { ptr, ptr, i8, i8, ptr }

--- a/compiler/preamble/preamble64.ll
+++ b/compiler/preamble/preamble64.ll
@@ -25,6 +25,7 @@ declare ptr @SKIP_Obstack_shallowClone(i64, ptr)
 declare i64 @SKIP_String_StringIterator__rawCurrent(ptr)
 declare void @SKIP_String_StringIterator__rawDrop(ptr, i64)
 declare i64 @SKIP_String_cmp(ptr, ptr)
+declare i8 @SKIP_String_eq(ptr, ptr)
 declare {i64, i64} @SKIP_String_toIntOptionHelper(ptr)
 declare ptr @SKIP_intern(ptr)
 declare void @SKIP_exit(i64)
@@ -127,20 +128,6 @@ define void @SKIP_debug_break() {
   tail call void @llvm.debugtrap()
   ret void
 }
-
-; Function Attrs: noinline nounwind optnone
-define i1 @SKIP_String_eq(ptr %0, ptr %1) #0 {
-  %3 = alloca ptr, align 4
-  %4 = alloca ptr, align 4
-  store ptr %0, ptr %3, align 4
-  store ptr %1, ptr %4, align 4
-  %5 = load ptr, ptr %3, align 4
-  %6 = load ptr, ptr %4, align 4
-  %7 = call i64 @SKIP_String_cmp(ptr %5, ptr %6)
-  %8 = icmp eq i64 %7, 0
-  ret i1 %8
-}
-
 
 %struct._FunctionSignature = type { ptr, ptr, i8, i8, ptr }
 

--- a/compiler/runtime/string.c
+++ b/compiler/runtime/string.c
@@ -189,6 +189,10 @@ SkipInt SKIP_String_cmp(unsigned char* str1, unsigned char* str2) {
   }
 }
 
+uint8_t SKIP_String_eq(unsigned char* str1, unsigned char* str2) {
+  return SKIP_String_cmp(str1, str2) == 0;
+}
+
 /*****************************************************************************/
 /* Unsafe char access */
 /*****************************************************************************/

--- a/compiler/src/AsmOutput.sk
+++ b/compiler/src/AsmOutput.sk
@@ -3594,7 +3594,7 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
 
           cmpVar = asm.llvmIdentifier("%longstringcase_eq");
           asm.print(
-            "  %s = call i1 @SKIP_String_eq(%N, %N), %D\n" %
+            "  %s = call i8 @SKIP_String_eq(%N, %N), %D\n" %
               cmpVar %
               valueInstr %
               v.cases[c] %

--- a/compiler/src/Rewrite.sk
+++ b/compiler/src/Rewrite.sk
@@ -1166,7 +1166,7 @@ mutable base class .RewriteBase{
     id: InstrID = this.iid(),
     prettyName: String = "",
   }: StringCmpEq {
-    this.emitStmt(StringCmpEq{id, pos, typ => tBool, prettyName, lhs, rhs})
+    this.emitStmt(StringCmpEq{id, pos, typ => tInt8, prettyName, lhs, rhs})
   }
 
   mutable fun emitStringConcat{

--- a/compiler/src/peephole.sk
+++ b/compiler/src/peephole.sk
@@ -1231,8 +1231,7 @@ private fun peepholeBinOpSame(peep: BinOp, s: mutable Peephole): Instr {
   | BoolCmpLe _
   | IntCmpEq _
   | IntCmpLe _
-  | IntCmpUle _
-  | StringCmpEq _ ->
+  | IntCmpUle _ ->
     s.constantBool(true)
   | FloatCmpLt _
   | BoolCmpNe _
@@ -1245,7 +1244,8 @@ private fun peepholeBinOpSame(peep: BinOp, s: mutable Peephole): Instr {
   | IntRem _
   | IntSub _
   | IntXor _
-  | StringCmp _ ->
+  | StringCmp _
+  | StringCmpEq _ ->
     s.constantInt(0)
   | IntAnd _
   | IntOr _ ->
@@ -1725,7 +1725,7 @@ private fun peepholeStringBinOp(peep: StringBinOp, s: mutable Peephole): Instr {
           | GT() -> 1
           },
         )
-      | StringCmpEq _ -> s.constantBool(lhsValue == rhsValue)
+      | StringCmpEq _ -> s.constantInt(if (lhsValue == rhsValue) 0 else 1)
       }
     | _ -> peep
     }


### PR DESCRIPTION
It seems that SKIP_String_eq is defined in the preamble only to be
able to have an i1 return type instead of i8. This is an optimization
that LLVM should be able to do itself, so this PR simplifies the code
by moving the definition from LLVM assembly in the prelude to C in the
runtime.