### PR TITLE
Change compiler CI job to build stageB instead of stage1

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -22,8 +22,8 @@ jobs:
           no_output_timeout: 30m
           command: |
             mkdir -p ~/test-results
-            cd compiler && make STAGE=1
-            PATH=./stage1/bin:$PATH skargo test --junitxml ~/test-results/skc.xml
+            cd compiler && make STAGE=B
+            PATH=./stageB/bin:$PATH skargo test --junitxml ~/test-results/skc.xml
       - store_test_results:
           path: ~/test-results/skc.xml
 


### PR DESCRIPTION
This enables checking PRs that change both the compiler and runtime at
once, see https://github.com/SkipLabs/skdb/pull/65.