### PR TITLE
Change our js/ts/npm build config to get types working in downstream projects

### DIFF
--- a/prelude/ts/src/package.json
+++ b/prelude/ts/src/package.json
@@ -4,5 +4,6 @@
   },
   "dependencies": {
     "ws": "^8.12.0"
-  }
+  },
+  "type": "module"
 }

--- a/prelude/ts/src/sk_browser.ts
+++ b/prelude/ts/src/sk_browser.ts
@@ -1,5 +1,5 @@
-import { float, int, Environment, Wrk, Shared } from "#std/sk_types";
-import { MemFS, MemSys } from "#std/sk_mem_utils";
+import type { float, int, Environment, Wrk, Shared } from "./sk_types.js";
+import { MemFS, MemSys } from "./sk_mem_utils.js";
 
 class WrkImpl implements Wrk {
   worker: Worker;

--- a/prelude/ts/src/sk_mem_utils.ts
+++ b/prelude/ts/src/sk_mem_utils.ts
@@ -1,4 +1,5 @@
-import { int, FileSystem, Options, System } from "#std/sk_types";
+import type { int, FileSystem, System } from "./sk_types.js";
+import { Options } from "./sk_types.js";
 
 class File {
   contents: string;

--- a/prelude/ts/src/sk_node.ts
+++ b/prelude/ts/src/sk_node.ts
@@ -1,5 +1,5 @@
-import { float, int, Environment, Wrk, Shared } from "#std/sk_types";
-import { MemFS, MemSys } from "#std/sk_mem_utils";
+import type { float, int, Environment, Wrk, Shared } from "./sk_types.js";
+import { MemFS, MemSys } from "./sk_mem_utils.js";
 
 import * as fs from "fs";
 import * as util from "util";

--- a/prelude/ts/src/sk_posix.ts
+++ b/prelude/ts/src/sk_posix.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   int,
   ptr,
   Environment,
@@ -6,8 +6,8 @@ import {
   ToWasmManager,
   Utils,
   FileSystem,
-  Options,
-} from "#std/sk_types";
+} from "./sk_types.js";
+import { Options } from "./sk_types.js";
 
 interface ToWasm {
   SKIP_check_if_file_exists: (skPath: ptr) => boolean;

--- a/prelude/ts/src/sk_runtime.ts
+++ b/prelude/ts/src/sk_runtime.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   int,
   float,
   ptr,
@@ -6,9 +6,8 @@ import {
   Utils,
   ToWasmManager,
   Environment,
-  Stream,
-  Options,
-} from "#std/sk_types";
+} from "./sk_types.js";
+import { Stream } from "./sk_types.js";
 
 interface Env extends Environment {
   window: () => Window | null;

--- a/prelude/ts/src/sk_worker.ts
+++ b/prelude/ts/src/sk_worker.ts
@@ -1,4 +1,4 @@
-import { int, Wrk } from "#std/sk_types";
+import type { int, Wrk } from "./sk_types.js";
 
 interface Payload {}
 

--- a/skdate/ts/src/sk_date.ts
+++ b/skdate/ts/src/sk_date.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   int,
   ptr,
   Environment,
@@ -7,7 +7,7 @@ import {
   Utils,
   FileSystem,
   Options,
-} from "#std/sk_types";
+} from "#std/sk_types.js";
 
 interface ToWasm {
   SKIP_localetimezone: (year: int, month: int, day: int) => int;

--- a/sknpm/src/main.sk
+++ b/sknpm/src/main.sk
@@ -698,7 +698,7 @@ fun manage(
   if (bc.env.verbose) {
     print_string(">> Copy types declaration files.");
   };
-  declFiles.each(f -> copyToDir(f, distDir, ".mjs"));
+  declFiles.each(f -> copyToDir(f, distDir));
   srcDir = Path.join(npmDir, "src");
   checkDir(srcDir);
   if (bc.env.verbose) {
@@ -708,7 +708,7 @@ fun manage(
     tsDir,
     f -> f.endsWith(".ts"),
     _f -> false,
-  ).each(f -> copyToDir(f, srcDir, ""));
+  ).each(f -> copyToDir(f, srcDir));
   if (bc.env.verbose) {
     print_string(">> Manage license and package files.");
   };
@@ -825,11 +825,15 @@ fun tsc(tsDir: String, link: ?(String, String), verbose: Bool): void {
   Skargo.run(Array["tsc", "--project", tsconfig], verbose);
 }
 
-fun copyToDir(tsFile: String, dir: String, ext: String = ".ts"): void {
+fun copyToDir(tsFile: String, dir: String): void {
   contents = FileSystem.readTextFile(tsFile);
   target = Path.join(dir, Path.basename(tsFile));
   lines = contents.split("\n").map(line -> {
-    if (line.startsWith("import ") || line.startsWith("export {")) {
+    if (
+      line.startsWith("import ") ||
+      line.startsWith("export {") ||
+      line.startsWith("export type {")
+    ) {
       elements = line.split(" from ");
       if (elements.size() == 2) {
         imported = elements[1].split("\"");
@@ -837,13 +841,7 @@ fun copyToDir(tsFile: String, dir: String, ext: String = ".ts"): void {
           elems = imported[1].split("/");
           size = elems.size();
           if (size > 1 && elems[0].startsWith("#")) {
-            !elems = elems.mapWithIndex((idx, v) ->
-              if (idx == 0) "." else if (idx == size - 1) {
-                `${v}${ext}`
-              } else {
-                v
-              }
-            );
+            !elems = elems.mapWithIndex((idx, v) -> if (idx == 0) "." else v);
             !line = `${elements[0]} from "${elems.join("/")}"`
           }
         }

--- a/sknpm/src/main.sk
+++ b/sknpm/src/main.sk
@@ -616,6 +616,7 @@ fun manage(
       "dependencies" => JSON.Object(
         pckDependencies.map((_, v) -> JSON.String(v)),
       ),
+      "type" => JSON.String("module"),
     ],
   );
 
@@ -789,12 +790,12 @@ fun tsConfig(deps: Vector<String>): String {
           "baseUrl" => JSON.String("."),
           "paths" => JSON.Object(unsafe_chill_trust_me(paths)),
           "strictNullChecks" => JSON.Bool(true),
-          "module" => JSON.String("ESNext"),
+          "module" => JSON.String("node16"),
           "sourceMap" => JSON.Bool(true),
           "declaration" => JSON.Bool(true),
           "declarationMap" => JSON.Bool(true),
           "incremental" => JSON.Bool(true),
-          "moduleResolution" => JSON.String("Node"),
+          "verbatimModuleSyntax" => JSON.Bool(true),
         ],
       ),
     ],

--- a/sknpm/src/main.sk
+++ b/sknpm/src/main.sk
@@ -908,6 +908,7 @@ fun copyAndConvertImport(
     optCategory: ?String = None();
     lines = contents.split("\n").map(line -> {
       if (line.startsWith("import ") || line.startsWith("export {")) {
+        !line = line.replace(".js", ".mjs");
         elements = line.split(" from ");
         if (elements.size() == 2) {
           imported = elements[1].split("\"");
@@ -916,11 +917,7 @@ fun copyAndConvertImport(
             size = elems.size();
             if (size > 1 && elems[0].startsWith("#")) {
               !elems = elems.mapWithIndex((idx, v) ->
-                if (idx == 0) "." else if (idx == size - 1) {
-                  `${v}.mjs`
-                } else {
-                  v
-                }
+                if (idx == 0) "." else v
               );
               !line = `${elements[0]} from "${elems.join("/")}"`
             }

--- a/sql/ts/src/package.json
+++ b/sql/ts/src/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
     "@types/node": "^20.10.7"
-  }
+  },
+  "type": "module"
 }

--- a/sql/ts/src/skdb-cli.ts
+++ b/sql/ts/src/skdb-cli.ts
@@ -4,7 +4,7 @@ import { parseArgs } from "util";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { createSkdb } from "#skdb/skdb";
+import { createSkdb } from "./skdb.js";
 import { webcrypto } from "crypto";
 import * as readline from "readline/promises";
 import * as process from "process";

--- a/sql/ts/src/skdb.ts
+++ b/sql/ts/src/skdb.ts
@@ -1,10 +1,10 @@
-import { run, loadEnv, isNode } from "#std/sk_types";
-import { SKDB, SKDBSync, SKDBShared } from "#skdb/skdb_types";
-import { SKDBWorker } from "#skdb/skdb_wdatabase";
-export { SKDB, RemoteSKDB } from "#skdb/skdb_types";
-export { SKDBTable as SKDBTable } from "#skdb/skdb_util";
-export { Creds, MuxedSocket } from "#skdb/skdb_orchestration";
-export { Environment } from "#std/sk_types";
+import { run, loadEnv, isNode } from "#std/sk_types.js";
+import type { SKDB, SKDBSync, SKDBShared } from "./skdb_types.js";
+import { SKDBWorker } from "./skdb_wdatabase.js";
+export { SKDBTable as SKDBTable } from "./skdb_util.js";
+export type { SKDB, RemoteSKDB } from "./skdb_types.js";
+export type { Creds, MuxedSocket } from "./skdb_orchestration.js";
+export type { Environment } from "#std/sk_types.js";
 
 var wasm64 = "skdb";
 // sknpm searches for the modules line verbatim

--- a/sql/ts/src/skdb_database.ts
+++ b/sql/ts/src/skdb_database.ts
@@ -1,5 +1,5 @@
-import { Environment, FileSystem } from "#std/sk_types";
-import {
+import type { Environment, FileSystem } from "#std/sk_types.js";
+import type {
   SKDBMechanism,
   SKDB,
   RemoteSKDB,
@@ -7,10 +7,10 @@ import {
   Params,
   SKDBSync,
   MirrorDefn,
-} from "#skdb/skdb_types";
-import { SKDBTable } from "#skdb/skdb_util";
-import { SKDBGroupImpl } from "#skdb/skdb_group";
-import { connect } from "#skdb/skdb_orchestration";
+} from "./skdb_types.js";
+import { SKDBTable } from "./skdb_util.js";
+import { SKDBGroupImpl } from "./skdb_group.js";
+import { connect } from "./skdb_orchestration.js";
 
 class SKDBMechanismImpl implements SKDBMechanism {
   writeCsv: (payload: string, source: string) => void;

--- a/sql/ts/src/skdb_group.ts
+++ b/sql/ts/src/skdb_group.ts
@@ -1,4 +1,4 @@
-import { SKDB, SKDBGroup } from "#skdb/skdb_types";
+import type { SKDB, SKDBGroup } from "./skdb_types.js";
 
 export class SKDBGroupImpl implements SKDBGroup {
   skdb: SKDB;

--- a/sql/ts/src/skdb_nodeworker.ts
+++ b/sql/ts/src/skdb_nodeworker.ts
@@ -1,4 +1,4 @@
-import { onDbWorkerMessage } from "#skdb/skdb_wmessage";
+import { onDbWorkerMessage } from "./skdb_wmessage.js";
 import { parentPort } from "worker_threads";
 
 var post = (message: any) => {

--- a/sql/ts/src/skdb_orchestration.ts
+++ b/sql/ts/src/skdb_orchestration.ts
@@ -1,11 +1,11 @@
-import { Environment } from "#std/sk_types";
-import {
+import type { Environment } from "#std/sk_types.js";
+import type {
   SKDBMechanism,
   RemoteSKDB,
   Params,
   MirrorDefn,
-} from "#skdb/skdb_types";
-import { SKDBTable } from "#skdb/skdb_util";
+} from "./skdb_types.js";
+import { SKDBTable } from "./skdb_util.js";
 
 const npmVersion = "";
 

--- a/sql/ts/src/skdb_skdb.ts
+++ b/sql/ts/src/skdb_skdb.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   int,
   ptr,
   Environment,
@@ -6,19 +6,18 @@ import {
   ToWasmManager,
   Utils,
   Shared,
-} from "#std/sk_types";
-import {
+} from "#std/sk_types.js";
+import type {
   PagedMemory,
   Page,
   Storage,
-  SKDB,
   SKDBHandle,
   Params,
   SKDBSync,
-} from "#skdb/skdb_types";
-import { ExternalFuns, SKDBTable } from "#skdb/skdb_util";
-import { IDBStorage } from "#skdb/skdb_storage";
-import { SKDBImpl, SKDBSyncImpl } from "#skdb/skdb_database";
+} from "./skdb_types.js";
+import { ExternalFuns, SKDBTable } from "./skdb_util.js";
+import { IDBStorage } from "./skdb_storage.js";
+import { SKDBImpl, SKDBSyncImpl } from "./skdb_database.js";
 
 interface Exported {
   sk_pop_dirty_page: () => number;

--- a/sql/ts/src/skdb_storage.ts
+++ b/sql/ts/src/skdb_storage.ts
@@ -1,4 +1,4 @@
-import { Storage, PagedMemory } from "#skdb/skdb_types";
+import type { Storage, PagedMemory } from "./skdb_types.js";
 
 function makeSKDBStore(
   dbName: string,

--- a/sql/ts/src/skdb_types.ts
+++ b/sql/ts/src/skdb_types.ts
@@ -1,5 +1,5 @@
-import { Shared } from "#std/sk_types";
-import { SKDBTable } from "#skdb/skdb_util";
+import type { Shared } from "#std/sk_types.js";
+import { SKDBTable } from "./skdb_util.js";
 
 export interface SKDBHandle {
   runner: (fn: () => string) => SKDBTable;

--- a/sql/ts/src/skdb_wdatabase.ts
+++ b/sql/ts/src/skdb_wdatabase.ts
@@ -1,14 +1,14 @@
-import { Wrk } from "#std/sk_types";
-import { PromiseWorker, Function, Caller } from "#std/sk_worker";
-import {
+import type { Wrk } from "#std/sk_types.js";
+import { PromiseWorker, Function, Caller } from "#std/sk_worker.js";
+import type {
   SKDB,
   ProtoResponseCreds,
   Params,
   RemoteSKDB,
   MirrorDefn,
-} from "#skdb/skdb_types";
-import { SKDBTable } from "#skdb/skdb_util";
-import { SKDBGroupImpl } from "#skdb/skdb_group";
+} from "./skdb_types.js";
+import { SKDBTable } from "./skdb_util.js";
+import { SKDBGroupImpl } from "./skdb_group.js";
 
 class WrappedRemote implements RemoteSKDB {
   private worker: PromiseWorker;

--- a/sql/ts/src/skdb_wmessage.ts
+++ b/sql/ts/src/skdb_wmessage.ts
@@ -1,5 +1,7 @@
-import { Creator, onWorkerMessage } from "#std/sk_worker";
-import { createSkdb, SKDB } from "#skdb/skdb";
+import { onWorkerMessage } from "#std/sk_worker.js";
+import type { Creator } from "#std/sk_worker.js";
+import type { SKDB } from "./skdb.js";
+import { createSkdb } from "./skdb.js";
 
 class DbCreator implements Creator<SKDB> {
   getName() {

--- a/sql/ts/src/skdb_worker.ts
+++ b/sql/ts/src/skdb_worker.ts
@@ -1,4 +1,4 @@
-import { onDbWorkerMessage } from "#skdb/skdb_wmessage";
+import { onDbWorkerMessage } from "./skdb_wmessage.js";
 
 var post = (message: any) => {
   postMessage(message);

--- a/sql/ts/src/tsconfig.json
+++ b/sql/ts/src/tsconfig.json
@@ -8,7 +8,12 @@
       "#skdb/*": ["./*"]
     },
     "strictNullChecks": true,
-    "module": "ESNext",
+    "module": "node16",
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true,
     "moduleResolution": "Node",
     "incremental": true,
     "noEmit": true

--- a/sql/ts/src/tsconfig.json
+++ b/sql/ts/src/tsconfig.json
@@ -4,8 +4,7 @@
     "outDir": "../dist/src",
     "baseUrl": ".",
     "paths": {
-      "#std/*": ["../../../prelude/ts/src/*"],
-      "#skdb/*": ["./*"]
+      "#std/*": ["../../../prelude/ts/src/*"]
     },
     "strictNullChecks": true,
     "module": "node16",


### PR DESCRIPTION
This was a journey. And I've had some journeys with JS. I hope it's
over. But I'm definitely playing with fire here.

The goal: when you use skdb as a dependency in a downstream project,
you don't get any typing info other than for the one exported function
defined in skdb.ts. I wanted to fix this.

I tried a lot of things, but eventually found compiler and npm config
that works and is recommended by the typescript documentation.

https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html#im-writing-a-library

I had to make a lot of adjustments to how we define imports/exports to
make typescript happy under this new config. Which then broke what
sknpm produces, so I fixed that.

Something to note -- which sknpm was already taking care of, so I left
well alone -- is that using paths in libraries is bad and we should
make sure they never leak out in to the deliverable. They are not
re-written by the compiler and require all downstream libraries to
define them. Complete insanity.

https://stackoverflow.com/a/52501384
https://github.com/Microsoft/TypeScript/issues/15479

I'm somewhat confident this works and is correct, but it's JS and
there are many many permutations of env, so who knows?

- The tests all pass
- My node service that I'm working on gets type info, compiles, and runs
- I checked out the todo app as a vite example and this appears to load up, run, and work