### PR TITLE
Define SKDB_PORT before using it

### DIFF
--- a/sql/server/core/src/main/kotlin/core/StaticConfig.kt
+++ b/sql/server/core/src/main/kotlin/core/StaticConfig.kt
@@ -7,8 +7,8 @@ import java.util.Optional
 import java.util.Properties
 
 val USER_CONFIG_FILE = ".skdb.conf"
-var ENV = UserConfig.create()
 val SKDB_PORT = 3586
+var ENV = UserConfig.create()
 
 class UserConfig(
     val port: Int,


### PR DESCRIPTION
It gets used by the default arg of UserConfig.create but this is
called statically in the module before the port is defined. This isn't
an error but uses zero. Which undertow happily interprets as bind to
any port you like.