### PR TITLE
Add test-skfs target, unbreak tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,11 @@ fmt:
 
 .PHONY: test
 test:
-	$(MAKE) --keep-going SKARGO_PROFILE=dev SKDB_WASM=sql/target/wasm32/dev/skdb.wasm SKDB_BIN=sql/target/host/dev/skdb test-native test-wasm
+	$(MAKE) --keep-going SKARGO_PROFILE=dev SKDB_WASM=sql/target/wasm32/dev/skdb.wasm SKDB_BIN=sql/target/host/dev/skdb test-skfs test-native test-wasm
+
+.PHONY: test-skfs
+test-skfs:
+	cd skfs && SKARGO_PROFILE=$(SKARGO_PROFILE) skargo test
 
 .PHONY: test-native
 test-native: build/skdb

--- a/skfs/tests/StressTest.sk
+++ b/skfs/tests/StressTest.sk
@@ -675,3 +675,5 @@ fun testStress(): void {
     }
   })
 }
+
+module end;

--- a/skfs/tests/TestChangesAfter.sk
+++ b/skfs/tests/TestChangesAfter.sk
@@ -82,3 +82,5 @@ fun testChangesAfter(): void {
     );
   }
 }
+
+module end;

--- a/skfs/tests/TestCreateDir.sk
+++ b/skfs/tests/TestCreateDir.sk
@@ -33,3 +33,5 @@ fun testCreateDir(): void {
     SKStore.CStop(None())
   })
 }
+
+module end;

--- a/skfs/tests/TestExternalPointer.sk
+++ b/skfs/tests/TestExternalPointer.sk
@@ -38,3 +38,5 @@ fun testExternalPointer(): void {
     };
   })
 }
+
+module end;

--- a/skfs/tests/TestFilter.sk
+++ b/skfs/tests/TestFilter.sk
@@ -349,3 +349,5 @@ fun testFilter(): void {
     }
   })
 }
+
+module end;

--- a/skfs/tests/TestFixedDirTime.sk
+++ b/skfs/tests/TestFixedDirTime.sk
@@ -45,3 +45,5 @@ fun testFixedDirTime(): void {
     }
   };
 }
+
+module end;

--- a/skfs/tests/TestKsuid.sk
+++ b/skfs/tests/TestKsuid.sk
@@ -94,3 +94,5 @@ fun testKsuid(): void {
   T.expectEq(root___id0, root___id1);
   T.expectEq(root___str0, root___str1);
 }
+
+module end;

--- a/skfs/tests/TestLazy.sk
+++ b/skfs/tests/TestLazy.sk
@@ -133,3 +133,5 @@ fun testLazy(): void {
     "Eeager after update",
   )
 }
+
+module end;

--- a/skfs/tests/TestMap.sk
+++ b/skfs/tests/TestMap.sk
@@ -280,3 +280,5 @@ fun testMultiMapSameParent(): void {
     Array["02", "12"],
   );
 }
+
+module end;

--- a/skfs/tests/TestPre.sk
+++ b/skfs/tests/TestPre.sk
@@ -103,3 +103,5 @@ fun testPre(): void {
     "Test pre 3",
   )
 }
+
+module end;

--- a/skfs/tests/TestRuntime.sk
+++ b/skfs/tests/TestRuntime.sk
@@ -150,3 +150,5 @@ fun testRuntime(): void {
     "Native Eq 14",
   );
 }
+
+module end;

--- a/skfs/tests/TestShared.sk
+++ b/skfs/tests/TestShared.sk
@@ -60,3 +60,5 @@ fun testShared(): void {
   //  y = 223;
   //  debug(foo(x ~> x + y)(24))
 }
+
+module end;

--- a/skfs/tests/TestSize.sk
+++ b/skfs/tests/TestSize.sk
@@ -65,3 +65,5 @@ fun testSize(): void {
     "Test size after file removal",
   )
 }
+
+module end;

--- a/skfs/tests/TestString.sk
+++ b/skfs/tests/TestString.sk
@@ -29,3 +29,5 @@ fun testString(): void {
     "Utf8 from/to chars",
   )
 }
+
+module end;

--- a/skfs/tests/TestSubDir.sk
+++ b/skfs/tests/TestSubDir.sk
@@ -184,3 +184,5 @@ fun testSubSubDirUnit(): void {
   dir2.writeArray(context, SKStore.IID(0), Array[SKStore.IntFile(1)]);
   context.update()
 }
+
+module end;

--- a/skfs/tests/TestWikipedia.sk
+++ b/skfs/tests/TestWikipedia.sk
@@ -88,3 +88,5 @@ fun testWikipedia(path: String): mutable SKStore.Context {
     );
   })
 }
+
+module end;

--- a/skfs/tests/TestWithRegion.sk
+++ b/skfs/tests/TestWithRegion.sk
@@ -19,3 +19,5 @@ fun testWithRegion(): void {
   };
   T.expectEq(acc, 9, "Test withRegion")
 }
+
+module end;

--- a/skfs/tests/test.sk
+++ b/skfs/tests/test.sk
@@ -681,3 +681,5 @@ fun testSearch(): void {
     );
   })
 }
+
+module end;

--- a/sknpm/tests/version.sk
+++ b/sknpm/tests/version.sk
@@ -50,3 +50,5 @@ fun order(): void {
   got = versions.sorted();
   T.expectEq(got, expected)
 }
+
+module end;


### PR DESCRIPTION
The skfs tests, which includes the tests for the stdlib, are not run
by any of the existing test targets, and seem to be only rarely
triggered in the CI. As a result they have been broken for a while.

This PR adds a `test-skfs` target, makes `test` depend on it, and
unbreaks the tests.