### PR TITLE
Make db creation idempotent

### DIFF
--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -299,7 +299,7 @@ class Skdb(val name: String, private val dbPath: String) {
 
   fun createDb(encryptedRootPrivateKey: String): Skdb {
     if (File(dbPath).exists()) {
-      throw RevealableException(2003u, "Database already exists")
+      return openSkdb(name)!!
     }
     val initScript = Files.readString(Path.of(ENV.skdbInitPath), Charsets.UTF_8)
     blockingRun(ProcessBuilder(ENV.skdbPath, "--init", dbPath))


### PR DESCRIPTION
This makes partial failure and retries much easier. It also gives us a
mechanism of fetching the root credentials for a database if we need
them. Something that couldn't be done remotely before.

The dev server is not impacted, it only creates a db after checking
that it needs to. It creates databases just in time and doesn't
support explicit creation.