### PR TITLE
Add script to release amd64/arm64 skiplabs/skdb docker images

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -6,8 +6,9 @@ and NPM artifacts.
 
 ## Release Docker images
 
-In order to update `skiplabs/skdb-base` or `skiplabs/skdb-dev-server` to the
-current state of your git clone, you can run `release_docker_skdb_base.sh` or
+In order to update `skiplabs/skdb-base`, `skiplabs/skdb`, or
+`skiplabs/skdb-dev-server` to the current state of your git clone, you can run
+`release_docker_skdb_base.sh`, `release_docker_skdb.sh`, or
 `release_docker_skdb_dev_server.sh` respectively. For the `dev-server`, you can
 choose to release either or both of the `latest` and `quickstart` tags.
 

--- a/bin/release_docker_skdb.sh
+++ b/bin/release_docker_skdb.sh
@@ -11,37 +11,19 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 cd "$SCRIPT_DIR/../" || exit 1
 
-read -r -p "Release 'latest' version? [y/N] " latest
-if [[ "$latest" =~ ^([yY]|[yY][eE][sS])$ ]]; then
-    push_latest="-t skiplabs/skdb-dev-server:latest"
-fi
-
-read -r -p "Release 'quickstart' version? [y/N] " quickstart
-if [[ "$quickstart" =~ ^([yY]|[yY][eE][sS])$ ]]; then
-    push_quickstart="-t skiplabs/skdb-dev-server:quickstart"
-fi
-
-if [[ -z "$push_latest" && -z "$push_quickstart" ]]; then
-    echo Nothing to do, exiting.
-    exit 0
-fi
-
 git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
 echo ".git" >> .dockerignore
 
-builder=$(docker buildx create --platform linux/amd64,linux/arm64 --use)
+builder=$(docker buildx create --use)
 
 docker buildx build \
        --no-cache \
        --progress=plain \
        --platform linux/amd64,linux/arm64 \
-       $push_latest \
-       $push_quickstart \
-       -f sql/server/dev/Dockerfile \
+       -t skiplabs/skdb:latest \
+       -f sql/Dockerfile \
        --push \
        .
-
-# TODO: keep versions and alias latest
 
 docker buildx stop "$builder"
 docker buildx rm "$builder"

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skdb-dev",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "main": "./dist/skdb-dev.js",
   "module": "./dist/skdb-dev.js",
@@ -9,7 +9,7 @@
     "build": "tsc -p src/tsconfig.json"
   },
   "dependencies": {
-    "skdb": "^0.0.54"
+    "skdb": "^0.0.57"
   },
   "devDependencies": {
     "typescript": "^5.0.2"

--- a/packages/dev/yarn.lock
+++ b/packages/dev/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-skdb@^0.0.54:
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/skdb/-/skdb-0.0.54.tgz#07e26b5c5140efdf6eba96c715fccbf77ad3c1a3"
-  integrity sha512-u2RwQyXysl8pmXHA2DdQNJ0fTCjqZ+qwDa0vIkk82iSrDQgNKWL96mz84HJ8pD8RE40V63Qk4P7hrzxLlQc+vg==
+skdb@^0.0.57:
+  version "0.0.57"
+  resolved "https://registry.yarnpkg.com/skdb/-/skdb-0.0.57.tgz#9f81da42e75605940e7ce1683b4470b8c878ace1"
+  integrity sha512-lIUhAK7zX5tfDpKcKV4mp2+fQNPbfEyOprhEV+7Q0ZQeT2+iYCVClkHoRVk5V15rIpdEhGoYhZHU5wVmoGeHVg==
   dependencies:
     ws "^8.12.0"
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skdb-react",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "main": "./dist/main.js",
   "module": "./dist/main.js",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "skdb": "^0.0.55"
+    "skdb": "^0.0.57"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/packages/react/yarn.lock
+++ b/packages/react/yarn.lock
@@ -45,10 +45,10 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
-skdb@^0.0.54:
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/skdb/-/skdb-0.0.54.tgz#07e26b5c5140efdf6eba96c715fccbf77ad3c1a3"
-  integrity sha512-u2RwQyXysl8pmXHA2DdQNJ0fTCjqZ+qwDa0vIkk82iSrDQgNKWL96mz84HJ8pD8RE40V63Qk4P7hrzxLlQc+vg==
+skdb@^0.0.57:
+  version "0.0.57"
+  resolved "https://registry.yarnpkg.com/skdb/-/skdb-0.0.57.tgz#9f81da42e75605940e7ce1683b4470b8c878ace1"
+  integrity sha512-lIUhAK7zX5tfDpKcKV4mp2+fQNPbfEyOprhEV+7Q0ZQeT2+iYCVClkHoRVk5V15rIpdEhGoYhZHU5wVmoGeHVg==
   dependencies:
     ws "^8.12.0"
 

--- a/sql/npm.json
+++ b/sql/npm.json
@@ -1,6 +1,6 @@
 {
   "name": "skdb",
   "author": "SkipLabs",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "binary": "skdb-cli"
 }


### PR DESCRIPTION
I also set up and pushed to https://hub.docker.com/repository/docker/skiplabs/skdb, which is needed for multi-platform dev server builds now that the `sql/Dockerfile` docker image has been factored out for the cloud repo.