### PR TITLE
Optimize space

### DIFF
--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -528,10 +528,9 @@ class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Source>} {
     vec: mutable Vector<FixedRow<Array<File>>> = mutable Vector[],
     tombs: mutable Vector<FixedRow<Source>> = mutable Vector[],
   ): this {
-    data = if (FixedDirImpl::isCompressable(vec)) {
-      CompressedFixedDir::create(vec)
-    } else {
-      FixedDir::create(vec)
+    data = FixedDirImpl::isCompressable(vec) match {
+    | None() -> FixedDir::create(vec)
+    | state @ Some(_) -> CompressedFixedDir::create(state, vec)
     };
     static{data, tombs => FixedDir::create(tombs)}
   }

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -523,12 +523,17 @@ class DataMap{
   }
 }
 
-class FixedDataMap{data: FixedDir<Array<File>>, tombs: FixedDir<Source>} {
+class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Source>} {
   static fun create(
     vec: mutable Vector<FixedRow<Array<File>>> = mutable Vector[],
     tombs: mutable Vector<FixedRow<Source>> = mutable Vector[],
   ): this {
-    static{data => FixedDir::create(vec), tombs => FixedDir::create(tombs)}
+    data = if (FixedDirImpl::isCompressable(vec)) {
+      CompressedFixedDir::create(vec)
+    } else {
+      FixedDir::create(vec)
+    };
+    static{data, tombs => FixedDir::create(tombs)}
   }
 
   fun size(): Int {
@@ -552,7 +557,7 @@ class FixedDataMap{data: FixedDir<Array<File>>, tombs: FixedDir<Source>} {
   }
 
   fun getIterAll(): mutable Iterator<(Tick, Source, Source, Key, Array<File>)> {
-    iter1 = this.data.data.iterator();
+    iter1 = this.data.iterator();
     iter2 = this.tombs.data.iterator();
     left = iter1.next();
     right = iter2.next();

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -98,45 +98,7 @@ fun binSearch<T: Orderable>(get: Int ~> T, key: T, i: Int, j: Int): Int {
 }
 
 class FixedDir<T: frozen> extends FixedDirImpl<T, FixedRow<T>> {
-  static fun compress(x: FixedRow<T>): FixedRow<T> {
-    x
-  }
-  static fun decompress(x: FixedRow<T>): FixedRow<T> {
-    x
-  }
-}
-
-class CompressedFixedDir extends FixedDirImpl<Array<File>, FixedRow<File>> {
-  static fun compress(row: FixedRow<Array<File>>): FixedRow<File> {
-    size = row.value.i1.size();
-    invariant(size == 1);
-    FixedRow(row.key, (row.value.i0, row.value.i1[0]), row.tag);
-  }
-  static fun decompress(row: FixedRow<File>): FixedRow<Array<File>> {
-    FixedRow(row.key, (row.value.i0, Array[row.value.i1]), row.tag)
-  }
-}
-
-base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
-  data: Array<Compressed> = Array[],
-} extends FixedData<T> {
-  static fun compress(FixedRow<T>): Compressed;
-  static fun decompress(Compressed): FixedRow<T>;
-
-  fun iterator(): mutable Iterator<FixedRow<T>> {
-    for (elt in this.data.iterator()) {
-      yield static::decompress(elt)
-    }
-  }
-
-  static fun isCompressable(data: mutable Vector<FixedRow<Array<File>>>): Bool {
-    for (elt in data) {
-      if (elt.value.i1.size() != 1) return false;
-    };
-    true
-  }
-
-  static deferred fun create<C: FixedDirImpl<T, Compressed>>(
+  static fun create(
     data: mutable Vector<FixedRow<T>> = mutable Vector[],
   ): this {
     i = 0;
@@ -159,7 +121,205 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
       data.sortBy(row ~> (row.key, row.value.i0));
     };
     _ = static::computeTags(data, 0, data.size() - 1);
-    static{data => data.map(static::compress).toArray()}
+    static{
+      state => None(),
+      data => data.map(x -> static::compress(None(), x)).toArray(),
+    }
+  }
+
+  static fun compress(?CompressState, x: FixedRow<T>): FixedRow<T> {
+    x
+  }
+  static fun decompress(?CompressState, x: FixedRow<T>): FixedRow<T> {
+    x
+  }
+}
+/*****************************************************************************/
+/* SQL. */
+/*****************************************************************************/
+
+
+module end;
+module SQLParser;
+
+base class Type uses Orderable {
+  children =
+  | FLOAT()
+  | INTEGER()
+  | TEXT()
+}
+
+base class IKind uses Orderable {
+  children =
+  | INONE()
+  | IASC()
+  | IDESC()
+}
+
+module end;
+module SKDB;
+
+base class CValue uses Orderable {
+  children =
+  | CInt(value: Int)
+  | CFloat(value: Float)
+  | CString(value: String)
+}
+
+class RowKey(
+  row: RowValues,
+  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+) extends SKStore.Key
+
+class RowValues(
+  values: Array<?CValue>,
+  repeat: Int,
+) uses Orderable extends SKStore.File
+
+module end;
+module SKStore;
+
+/*****************************************************************************/
+value class CompressedRow(
+  sourceID: SKStore.Key,
+  values: Array<?SKDB.CValue>,
+  tag: TickRange,
+)
+
+class CompressState{
+  sourceDirs: SortedSet<DirName>,
+  keyIsSameAsValue: Bool,
+  isAlwaysSize1: Bool,
+  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+}
+
+class CompressedFixedDir extends FixedDirImpl<Array<File>, CompressedRow> {
+  static fun compress(
+    state: ?CompressState,
+    row: FixedRow<Array<File>>,
+  ): CompressedRow {
+    st = state match {
+    | None() -> invariant_violation("Expected a state")
+    | Some(x) -> x
+    };
+    invariant(st.sourceDirs.size() == 1);
+    invariant(row.value.i1.size() == 1);
+    // TODO check that source key == key
+    // TODO check that values in key == rowValues
+    // TODO check kinds are canonical
+    // TODO check repeat is 1
+    //    invariant(row.key.getRowValues() == row.value.i0.baseName);
+    result = CompressedRow(
+      row.value.i0.baseName,
+      row.value.i1[0] match {
+      | SKDB.RowValues(values, _kinds) -> values
+      | _ -> invariant_violation("Unexpected type")
+      },
+      row.tag,
+    );
+    //    debug(row);
+    //    debug(static::decompress(state, result));
+    invariant(inspect(static::decompress(state, result)) == inspect(row));
+    result
+  }
+  static fun decompress(
+    state: ?CompressState,
+    row: CompressedRow,
+  ): FixedRow<Array<File>> {
+    st = state match {
+    | None() -> invariant_violation("Expected a state")
+    | Some(x) -> x
+    };
+    rowValues = SKDB.RowValues(row.values, 1);
+    rowKey = SKDB.RowKey(rowValues, st.kinds);
+    FixedRow(
+      rowKey,
+      (
+        Source(st.sourceDirs.min().fromSome(), row.sourceID),
+        Array[(rowValues : File)],
+      ),
+      row.tag,
+    )
+  }
+
+  static fun create(
+    stateOption: ?CompressState,
+    data: mutable Vector<FixedRow<Array<File>>> = mutable Vector[],
+  ): this {
+    state = stateOption match {
+    | None() -> invariant_violation("Expected a state")
+    | Some(x) -> x
+    };
+    i = 0;
+    sz = data.size();
+    sorted = loop {
+      !i = i + 1;
+      if (i >= sz) break true;
+      keyComparison = data[i - 1].key.compare(data[i].key);
+      keyComparison match {
+      | LT() -> continue
+      | GT() -> break false
+      | EQ() -> data[i - 1].value.i0.compare(data[i].value.i0)
+      } match {
+      | LT() -> continue
+      | EQ() -> continue
+      | GT() -> break false
+      };
+    };
+    if (!sorted) {
+      data.sortBy(row ~> (row.key, row.value.i0));
+    };
+    _ = static::computeTags(data, 0, data.size() - 1);
+    invariant(state.keyIsSameAsValue);
+    static{
+      state => stateOption,
+      data => data.map(x -> static::compress(stateOption, x)).toArray(),
+    }
+  }
+}
+
+base class FixedDirImpl<T: frozen, Compressed: frozen> protected {
+  state: ?CompressState,
+  data: Array<Compressed> = Array[],
+} extends FixedData<T> {
+  static fun compress(?CompressState, FixedRow<T>): Compressed;
+  static fun decompress(?CompressState, Compressed): FixedRow<T>;
+
+  fun iterator(): mutable Iterator<FixedRow<T>> {
+    for (elt in this.data.iterator()) {
+      yield static::decompress(this.state, elt)
+    }
+  }
+
+  static fun isCompressable(
+    data: mutable Vector<FixedRow<Array<File>>>,
+  ): ?CompressState {
+    if (data.size() == 0) return None();
+    sourceDirs = SortedSet[];
+    kinds: ?Array<(Int, SQLParser.IKind, SQLParser.Type)> = None();
+
+    keyIsSameAsValue = true;
+    for (elt in data) {
+      if (elt.value.i1.size() != 1) return None();
+      (elt.key, elt.value.i1[0]) match {
+      | (SKDB.RowKey(row1, k), row2 @ SKDB.RowValues _) ->
+        kinds match {
+        | None() -> !kinds = Some(k)
+        | Some(k2) -> invariant(k == k2)
+        };
+        !sourceDirs = sourceDirs.set(elt.value.i0.dirName);
+        if (row1 != row2) return None()
+      | _ -> return None()
+      }
+    };
+    Some(
+      CompressState{
+        sourceDirs,
+        kinds => kinds.fromSome(),
+        keyIsSameAsValue,
+        isAlwaysSize1 => true,
+      },
+    )
   }
 
   fun size(): Int {
@@ -167,7 +327,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
   }
 
   fun get(idx: Int): FixedRow<T> {
-    static::decompress(this.data.unsafe_get(idx))
+    static::decompress(this.state, this.data.unsafe_get(idx))
   }
 
   fun getPos(key: Key): Int {
@@ -235,7 +395,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
       return void;
     };
     pivot = i + (j - i) / 2;
-    elt = static::decompress(this.data[pivot]);
+    elt = static::decompress(this.state, this.data[pivot]);
     tick = elt.tag;
     if (tick.max < after) return void;
     if (tick.current >= after) {
@@ -264,7 +424,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
   ): void {
     if (i <= j) {
       pivot = i + (j - i) / 2;
-      elt = static::decompress(this.data[pivot]);
+      elt = static::decompress(this.state, this.data[pivot]);
       tick = elt.tag;
       if (tick.max >= after) {
         if (key <= elt.key) {
@@ -293,7 +453,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
       None()
     } else {
       middle = (this.data.size() - 1) / 2;
-      tick = static::decompress(this.data[middle]).tag;
+      tick = static::decompress(this.state, this.data[middle]).tag;
       Some(tick.max)
     }
   }

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -48,6 +48,7 @@ base class FixedData<T> {
   fun getIterSourceKey(source: Source, key: Key): mutable Iterator<T>;
   fun getChangesAfter(tick: Tick): SortedSet<Key>;
   fun getTick(): ?Tick;
+  fun iterator(): mutable Iterator<FixedRow<T>>;
 }
 
 // Assuming delta is monotone, that is, i <= j implies delta(i) <= delta(j),
@@ -96,10 +97,46 @@ fun binSearch<T: Orderable>(get: Int ~> T, key: T, i: Int, j: Int): Int {
   findFirstBy(idx ~> key.compare(get(idx)), i, j)
 }
 
-class FixedDir<T: frozen> private {
-  data: Array<FixedRow<T>> = Array[],
+class FixedDir<T: frozen> extends FixedDirImpl<T, FixedRow<T>> {
+  static fun compress(x: FixedRow<T>): FixedRow<T> {
+    x
+  }
+  static fun decompress(x: FixedRow<T>): FixedRow<T> {
+    x
+  }
+}
+
+class CompressedFixedDir extends FixedDirImpl<Array<File>, FixedRow<File>> {
+  static fun compress(row: FixedRow<Array<File>>): FixedRow<File> {
+    size = row.value.i1.size();
+    invariant(size == 1);
+    FixedRow(row.key, (row.value.i0, row.value.i1[0]), row.tag);
+  }
+  static fun decompress(row: FixedRow<File>): FixedRow<Array<File>> {
+    FixedRow(row.key, (row.value.i0, Array[row.value.i1]), row.tag)
+  }
+}
+
+base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
+  data: Array<Compressed> = Array[],
 } extends FixedData<T> {
-  static fun create(
+  static fun compress(FixedRow<T>): Compressed;
+  static fun decompress(Compressed): FixedRow<T>;
+
+  fun iterator(): mutable Iterator<FixedRow<T>> {
+    for (elt in this.data.iterator()) {
+      yield static::decompress(elt)
+    }
+  }
+
+  static fun isCompressable(data: mutable Vector<FixedRow<Array<File>>>): Bool {
+    for (elt in data) {
+      if (elt.value.i1.size() != 1) return false;
+    };
+    true
+  }
+
+  static deferred fun create<C: FixedDirImpl<T, Compressed>>(
     data: mutable Vector<FixedRow<T>> = mutable Vector[],
   ): this {
     i = 0;
@@ -122,7 +159,7 @@ class FixedDir<T: frozen> private {
       data.sortBy(row ~> (row.key, row.value.i0));
     };
     _ = static::computeTags(data, 0, data.size() - 1);
-    FixedDir{data => data.toArray()}
+    static{data => data.map(static::compress).toArray()}
   }
 
   fun size(): Int {
@@ -130,7 +167,7 @@ class FixedDir<T: frozen> private {
   }
 
   fun get(idx: Int): FixedRow<T> {
-    this.data.unsafe_get(idx)
+    static::decompress(this.data.unsafe_get(idx))
   }
 
   fun getPos(key: Key): Int {
@@ -198,7 +235,7 @@ class FixedDir<T: frozen> private {
       return void;
     };
     pivot = i + (j - i) / 2;
-    elt = this.data[pivot];
+    elt = static::decompress(this.data[pivot]);
     tick = elt.tag;
     if (tick.max < after) return void;
     if (tick.current >= after) {
@@ -227,7 +264,7 @@ class FixedDir<T: frozen> private {
   ): void {
     if (i <= j) {
       pivot = i + (j - i) / 2;
-      elt = this.data[pivot];
+      elt = static::decompress(this.data[pivot]);
       tick = elt.tag;
       if (tick.max >= after) {
         if (key <= elt.key) {
@@ -256,7 +293,7 @@ class FixedDir<T: frozen> private {
       None()
     } else {
       middle = (this.data.size() - 1) / 2;
-      tick = this.data[middle].tag;
+      tick = static::decompress(this.data[middle]).tag;
       Some(tick.max)
     }
   }

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -414,15 +414,6 @@ fun execSessions(args: Cli.ParseResults, options: SKDB.Options): void {
   })
 }
 
-/*** DEBUG ***/
-class MyData(
-  value: Array<
-    (SKStore.Key, (SKStore.Source, Array<SKStore.File>), SKStore.TickRange),
-  >,
-) extends SKStore.File
-const myKey: SKStore.IID = SKStore.IID(0);
-/*** END OF DEBUG ***/
-
 fun execCompact(args: Cli.ParseResults, options: SKDB.Options): void {
   ensureContext(args);
   SKDB.runLockedSql(options, context ~> {
@@ -430,28 +421,6 @@ fun execCompact(args: Cli.ParseResults, options: SKDB.Options): void {
       dir match {
       | edir @ SKStore.EagerDir _ ->
         !edir = edir.purge(context, context.tick);
-        /*** DEBUG ***/
-        /*
-                debugSizeDirName = SKStore.DirName::create("/debugSize/");
-                debugSizeDir = context.maybeGetEagerDir(debugSizeDirName) match {
-                | None() -> context.mkdir(x ~> x, y ~> y, debugSizeDirName)
-                | Some(_) -> SKStore.EHandle(x ~> x, y ~> y, debugSizeDirName)
-                };
-                debugSizeDir.writeArray(
-                  context,
-                  SKStore.SID(edir.dirName.toString()),
-                  Array[
-                    MyData(
-                      edir.fixedData.data.data.map(frow -> {
-                        debug(frow.value.i1);
-                        (frow.key, (frow.value.i0, frow.value.i1), frow.tag)
-                      }),
-                    ),
-                  ],
-                );
-                !edir.fixedData = SKStore.FixedDataMap::create();
-        */
-        /*** END OF DEBUG ***/
         context.setDir(edir.dirName, edir)
       | _ -> void
       }

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -414,6 +414,15 @@ fun execSessions(args: Cli.ParseResults, options: SKDB.Options): void {
   })
 }
 
+/*** DEBUG ***/
+class MyData(
+  value: Array<
+    (SKStore.Key, (SKStore.Source, Array<SKStore.File>), SKStore.TickRange),
+  >,
+) extends SKStore.File
+const myKey: SKStore.IID = SKStore.IID(0);
+/*** END OF DEBUG ***/
+
 fun execCompact(args: Cli.ParseResults, options: SKDB.Options): void {
   ensureContext(args);
   SKDB.runLockedSql(options, context ~> {
@@ -421,6 +430,28 @@ fun execCompact(args: Cli.ParseResults, options: SKDB.Options): void {
       dir match {
       | edir @ SKStore.EagerDir _ ->
         !edir = edir.purge(context, context.tick);
+        /*** DEBUG ***/
+        /*
+                debugSizeDirName = SKStore.DirName::create("/debugSize/");
+                debugSizeDir = context.maybeGetEagerDir(debugSizeDirName) match {
+                | None() -> context.mkdir(x ~> x, y ~> y, debugSizeDirName)
+                | Some(_) -> SKStore.EHandle(x ~> x, y ~> y, debugSizeDirName)
+                };
+                debugSizeDir.writeArray(
+                  context,
+                  SKStore.SID(edir.dirName.toString()),
+                  Array[
+                    MyData(
+                      edir.fixedData.data.data.map(frow -> {
+                        debug(frow.value.i1);
+                        (frow.key, (frow.value.i0, frow.value.i1), frow.tag)
+                      }),
+                    ),
+                  ],
+                );
+                !edir.fixedData = SKStore.FixedDataMap::create();
+        */
+        /*** END OF DEBUG ***/
         context.setDir(edir.dirName, edir)
       | _ -> void
       }

--- a/sql/src/SqlCAst.sk
+++ b/sql/src/SqlCAst.sk
@@ -20,12 +20,7 @@ base class AggrKind uses Orderable {
   | Max()
 }
 
-base class CValue uses Orderable, Show {
-  children =
-  | CInt(value: Int)
-  | CFloat(value: Float)
-  | CString(value: String)
-
+extension base class CValue uses Show {
   fun getInt(): ?Int
   | CInt(n) -> Some(n)
   | _ -> None()

--- a/sql/src/SqlCompile.sk
+++ b/sql/src/SqlCompile.sk
@@ -2106,11 +2106,11 @@ mutable class Compiler{
               )
             }
           });
-          minKey = RowKey(
+          minKey = RowKey::create(
             RowValues::create(minKeyValues.map(x -> Some(x))),
             kinds,
           );
-          maxKey = RowKey(RowValues::create(maxValues), kinds);
+          maxKey = RowKey::create(RowValues::create(maxValues), kinds);
           SKStore.KeyRange(minKey, maxKey)
         });
         rangeMap![tableNbr] = (index.dirName, rowRanges)

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -262,13 +262,13 @@ fun lwwEdits(
     | None() -> continue
     | _ -> void
     };
-    if (rowKey.row.getValue(0) != primaryKey) break void;
+    if (rowKey.getRowValues().getValue(0) != primaryKey) break void;
 
     for ((tick, source, _) in dir.getDataIterWithoutTombs(mcontext, key)) {
       if (
         tick.value < snapshot ||
         source.path() == writer ||
-        rowKey.row < row
+        rowKey.getRowValues() < row
       ) {
         entries.push((key, (source.path(), writer, Array<SKStore.File>[])));
       } else {
@@ -281,7 +281,7 @@ fun lwwEdits(
   if (!keepingCurrent) {
     for (entry in entries) yield entry;
     yield (
-      SKDB.RowKey(row, table.kinds),
+      SKDB.RowKey::create(row, table.kinds),
       (writer, writer, Array<SKStore.File>[row]),
     );
   }
@@ -351,7 +351,12 @@ fun applyDiffStrategy(
       (file: SKStore.Key) -> {
         file match {
         | k @ SKDB.RowKey _ ->
-          SKDB.checkUserCanReadRow(context, userFile, table, k.row) match {
+          SKDB.checkUserCanReadRow(
+            context,
+            userFile,
+            table,
+            k.getRowValues(),
+          ) match {
           | SKDB.AROK() -> true
           | SKDB.ARError(_err) -> false
           }
@@ -379,7 +384,7 @@ fun applyDiffStrategy(
       dir,
       (optContext, row, newDir) ~> {
         ctx = optContext.fromSome();
-        key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
+        key: SKStore.Key = SKDB.RowKey::create(row.setRepeat(1), table.kinds);
         for ((tick, source, _) in newDir.unsafeGetDataIterWithoutTombs(key)) {
           if (tick.value < snapshot.default(0) || source.path() == writer) {
             !newDir = newDir.writeEntry(
@@ -397,7 +402,7 @@ fun applyDiffStrategy(
             ctx,
             writer,
             writer,
-            SKDB.RowKey(row, table.kinds),
+            SKDB.RowKey::create(row, table.kinds),
             Array[row],
           );
         };
@@ -435,7 +440,7 @@ fun applyDiffStrategy(
       rows.iterator(),
       dir,
       (optContext, row, newDir) ~> {
-        key: SKStore.Key = SKDB.RowKey(row, table.kinds);
+        key: SKStore.Key = SKDB.RowKey::create(row, table.kinds);
         keyRepeat = row.repeat;
         for ((tick, source, files) in newDir.unsafeGetDataIterWithoutTombs(
           key,
@@ -480,7 +485,7 @@ fun applyDiffStrategy(
       rows
         .iterator()
         .filter(row -> row.repeat != 0)
-        .map(x -> SKDB.RowKey(x.setRepeat(1), table.kinds))
+        .map(x -> SKDB.RowKey::create(x.setRepeat(1), table.kinds))
         .collect(SortedSet),
       isVisibleToUser(newRoot),
       isEligibleForTomb,
@@ -508,7 +513,7 @@ fun applyDiffStrategy(
       (optContext, row, newDir) ~> {
         ctx = optContext.fromSome();
         if (row.repeat < 1) {
-          key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
+          key: SKStore.Key = SKDB.RowKey::create(row.setRepeat(1), table.kinds);
           for ((tick, source, _) in newDir.unsafeGetDataIterWithoutTombs(key)) {
             if (tick.value < snapshot.default(0) || source.path() == writer) {
               !newDir = newDir.writeEntry(
@@ -600,7 +605,7 @@ fun applyDiffStrategy(
       rows
         .iterator()
         .filter(row -> row.repeat != 0)
-        .map(x -> SKDB.RowKey(x.setRepeat(1), table.kinds))
+        .map(x -> SKDB.RowKey::create(x.setRepeat(1), table.kinds))
         .collect(SortedSet),
       isVisibleToUser(newRoot),
       (tick, source) ~>

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -880,11 +880,11 @@ class Evaluator{options: Options, user: ?UserFile} {
         };
         !row = RowValues::create(values.chill(), row.repeat);
         kinds = key match {
-        | RowKey(_, kinds) -> kinds
+        | rowKey @ RowKey _ -> rowKey.getKinds()
         | _ -> invariant_violation("Unexpected row kind")
         };
 
-        writer.set(RowKey(row, kinds), row);
+        writer.set(RowKey::create(row, kinds), row);
       },
     );
     sinkDir = context.unsafeGetEagerDir(sinkDirName);
@@ -988,7 +988,7 @@ class Evaluator{options: Options, user: ?UserFile} {
                     SKStore.IID(SKStore.genSym(0)),
                   );
 
-                  key: SKStore.Key = RowKey(row, kinds);
+                  key: SKStore.Key = RowKey::create(row, kinds);
                   for ((_, source, _) in dir.getDataIterWithoutTombs(
                     context,
                     key,
@@ -1028,7 +1028,7 @@ class Evaluator{options: Options, user: ?UserFile} {
     newDir = context.unsafeGetEagerDir(dir.dirName);
     kinds = table.kinds;
     for (row in rows) {
-      key = RowKey(row, kinds);
+      key = RowKey::create(row, kinds);
       source = SKStore.Path(dir.dirName, SKStore.IID(SKStore.genSym(0)));
       !newDir = newDir.writeEntry(context, source, source, key, Array[row]);
     };
@@ -1842,7 +1842,7 @@ fun printReactiveQueryChanges(
         values = edir.getArrayRaw(key);
         if (values.size() == 0) {
           switchTo(UInt32::truncate(2));
-          row = (key as RowKey _).row;
+          row = (key as RowKey _).getRowValues();
           for (_ in Range(0, row.repeat)) {
             RowValues::printItem(format, row);
           }

--- a/sql/src/SqlExpr.sk
+++ b/sql/src/SqlExpr.sk
@@ -684,7 +684,7 @@ class ExprEvaluator(
       invariant(query.params.size() == 1);
       row = RowValues::create(Array[Some(CInt(v))], 1);
       kinds = Array[(0, P.IASC(), P.TEXT())];
-      ADef(btoi(dir.getArray(context, RowKey(row, kinds)).size() != 0))
+      ADef(btoi(dir.getArray(context, RowKey::create(row, kinds)).size() != 0))
 
     | CIIn(vExpr, set) ->
       v = this.evalCIExpr(context, vExpr);
@@ -727,7 +727,7 @@ class ExprEvaluator(
       invariant(query.params.size() == 1);
       row = RowValues::create(Array[Some(CFloat(v))], 1);
       kinds = Array[(0, P.IASC(), P.TEXT())];
-      ADef(btoi(dir.getArray(context, RowKey(row, kinds)).size() != 0))
+      ADef(btoi(dir.getArray(context, RowKey::create(row, kinds)).size() != 0))
 
     | CFIn(vExpr, set) ->
       v = this.evalCFExpr(context, vExpr);
@@ -770,7 +770,7 @@ class ExprEvaluator(
       invariant(query.params.size() == 1);
       row = RowValues::create(Array[Some(CString(v))], 1);
       kinds = Array[(0, P.IASC(), P.TEXT())];
-      ADef(btoi(dir.getArray(context, RowKey(row, kinds)).size() != 0))
+      ADef(btoi(dir.getArray(context, RowKey::create(row, kinds)).size() != 0))
 
     | CSIn(vExpr, set) ->
       v = this.evalCSExpr(context, vExpr);

--- a/sql/src/SqlIndex.sk
+++ b/sql/src/SqlIndex.sk
@@ -6,18 +6,37 @@ module alias P = SQLParser;
 
 module SKDB;
 
-class IndexProjKey(values: Array<(Int, ?CValue)>) extends SKStore.Key
-
-fun makeIndexProjKey(
-  v: RowValues,
+class IndexProjKey private (
+  row: RowValues,
   kinds: Array<(Int, P.IKind, P.Type)>,
-  size: Int,
-): IndexProjKey {
-  indexedValues = mutable Vector[];
-  for (i in Range(0, size)) {
-    indexedValues.push((kinds[i].i0, v.values[kinds[i].i0]));
-  };
-  IndexProjKey(indexedValues.toArray());
+) extends SKStore.Key {
+  static fun create(values: Array<(Int, P.Type, ?CValue)>): this {
+    row = RowValues::create(values.map(x -> x.i2));
+    kinds = values.map(x -> (x.i0, P.IASC(), x.i1));
+    static(row, kinds)
+  }
+
+  static fun createFromRowValues(
+    row: RowValues,
+    kinds: Array<(Int, P.IKind, P.Type)>,
+  ): IndexProjKey {
+    static(row, kinds)
+  }
+
+  fun toArray(): Array<(Int, ?CValue)> {
+    indexedValues = mutable Vector[];
+    for (i in Range(0, this.kinds.size())) {
+      indexedValues.push((this.kinds[i].i0, this.row.values[this.kinds[i].i0]));
+    };
+    indexedValues.toArray()
+  }
+
+  fun compare(other: SKStore.Key): Order {
+    other match {
+    | IndexProjKey(row2, _) -> compareRows(this.kinds, this.row, row2)
+    | _ -> this.getClassName().compare(other.getClassName())
+    }
+  }
 }
 
 fun createIndexName(
@@ -69,6 +88,7 @@ fun createIndex(
     )
   };
   if (unique) {
+    subKinds = kinds.slice(0, size);
     _ = index
       .map(
         x ~> x,
@@ -79,9 +99,14 @@ fun createIndex(
           result = SortedMap<IndexProjKey, mutable Vector<RowValues>>[];
           valuesArr = values.collect(Array);
           for (v in valuesArr) {
-            k = makeIndexProjKey(v, kinds, size);
+            k = IndexProjKey::createFromRowValues(v, subKinds);
             if (v.repeat != 1) {
-              throw Conflict(0, "UNIQUE constraint failed", k.values, valuesArr)
+              throw Conflict(
+                0,
+                "UNIQUE constraint failed",
+                k.toArray(),
+                valuesArr,
+              )
             };
             if (!result.containsKey(k)) {
               !result[k] = mutable Vector[];
@@ -109,7 +134,7 @@ fun createIndex(
               0,
               "UNIQUE constraint failed",
               key match {
-              | IndexProjKey(arr) -> arr
+              | projKey @ IndexProjKey _ -> projKey.toArray()
               | _ -> invariant_violation("Unexpected key type")
               },
               valuesArr,

--- a/sql/src/SqlPrivacy.sk
+++ b/sql/src/SqlPrivacy.sk
@@ -264,7 +264,9 @@ class SKDBUsersByName extends PredefinedTable {
   const indexedFields: Array<P.Name> = Array[P.Name::create("userID")];
 
   fun makeKey(userID: String): IndexProjKey {
-    IndexProjKey(Array[(this.getColNbr(userIDColName), Some(CString(userID)))])
+    IndexProjKey::create(
+      Array[(this.getColNbr(userIDColName), P.TEXT(), Some(CString(userID)))],
+    )
   }
 }
 
@@ -289,8 +291,10 @@ class SKDBUserPermissions extends PredefinedTable {
   const indexedFields: Array<P.Name> = Array[P.Name::create("userID")];
 
   fun makeKey(userID: ?String): IndexProjKey {
-    IndexProjKey(
-      Array[(this.getColNbr(userIDColName), userID.map(x -> CString(x)))],
+    IndexProjKey::create(
+      Array[
+        (this.getColNbr(userIDColName), P.TEXT(), userID.map(x -> CString(x))),
+      ],
     )
   }
 }
@@ -313,8 +317,8 @@ class SKDBGroups extends PredefinedTable {
 
   const indexedFields: Array<P.Name> = Array[groupIDColName];
   fun makeKey(groupID: String): IndexProjKey {
-    IndexProjKey(
-      Array[(this.getColNbr(groupIDColName), Some(CString(groupID)))],
+    IndexProjKey::create(
+      Array[(this.getColNbr(groupIDColName), P.TEXT(), Some(CString(groupID)))],
     )
   }
 }
@@ -340,10 +344,10 @@ class SKDBGroupPermissions extends PredefinedTable {
   ];
 
   fun makeKey(groupID: String, userID: ?String): IndexProjKey {
-    IndexProjKey(
+    IndexProjKey::create(
       Array[
-        (this.getColNbr(groupIDColName), Some(CString(groupID))),
-        (this.getColNbr(userIDColName), userID.map(x -> CString(x))),
+        (this.getColNbr(groupIDColName), P.TEXT(), Some(CString(groupID))),
+        (this.getColNbr(userIDColName), P.TEXT(), userID.map(x -> CString(x))),
       ],
     )
   }

--- a/sql/src/SqlPrivacy.sk
+++ b/sql/src/SqlPrivacy.sk
@@ -154,7 +154,8 @@ base class PredefinedTable private final {
     if (isReset) return true;
     for (change in changes) {
       change match {
-      | RowKey(row, _) ->
+      | rowKey @ RowKey _ ->
+        row = rowKey.getRowValues();
         row.getString(colNbr) match {
         | None() ->
           // The change affected every user
@@ -670,7 +671,8 @@ mutable class AccessSolver private {
     files: Array<SKStore.File>,
   ): void {
     key match {
-    | RowKey(rowValues, _) ->
+    | rowKey @ RowKey _ ->
+      rowValues = rowKey.getRowValues();
       if (files.size() == 0) {
         !rowValues = rowValues.setRepeat(0);
       };

--- a/sql/src/SqlSelect.sk
+++ b/sql/src/SqlSelect.sk
@@ -352,7 +352,7 @@ class SelectEvaluator{
           };
           evaluator = ExprEvaluator(Array[entry], select.from, up);
           row = static::evalRow(context, evaluator, select.params, repeat);
-          writer.set(RowKey(row, kinds), row)
+          writer.set(RowKey::create(row, kinds), row)
         },
       );
       SelectDir(childName, this.types)
@@ -1393,7 +1393,7 @@ fun makeGroupByKey(
   evaluator: ExprEvaluator,
   row: Row,
   groupBy: Array<CGroupByElt>,
-): RowKey {
+): RowKeyImpl {
   rowKey = mutable Vector[];
   kinds = mutable Vector[];
   for (idx => elt in groupBy) {
@@ -1412,7 +1412,7 @@ fun makeGroupByKey(
       kinds.push((idx, P.IASC(), ty))
     }
   };
-  result = RowKey(RowValues::create(rowKey.toArray()), kinds.toArray());
+  result = RowKey::create(RowValues::create(rowKey.toArray()), kinds.toArray());
   result
 }
 
@@ -1486,7 +1486,7 @@ fun makeJoinReducer(
           left.values.concat(right);
         };
         row = RowValues::create(values, left.repeat);
-        writer.set(RowKey(row, kinds), row);
+        writer.set(RowKey::create(row, kinds), row);
       };
       for (rkv in rightRows) {
         (_, right) = rkv;
@@ -1494,7 +1494,7 @@ fun makeJoinReducer(
           left.values.concat(right.values)
         };
         row = RowValues::create(values, left.repeat * right.repeat);
-        writer.set(RowKey(row, kinds), row);
+        writer.set(RowKey::create(row, kinds), row);
       }
     };
     if (
@@ -1507,7 +1507,7 @@ fun makeJoinReducer(
         left = Array::fill(kinds.size() - right.size(), None<CValue>());
         values = left.concat(right.values);
         row = RowValues::create(values, right.repeat);
-        writer.set(RowKey(row, kinds), row);
+        writer.set(RowKey::create(row, kinds), row);
       }
     }
   }

--- a/sql/src/SqlSelect.sk
+++ b/sql/src/SqlSelect.sk
@@ -1393,7 +1393,7 @@ fun makeGroupByKey(
   evaluator: ExprEvaluator,
   row: Row,
   groupBy: Array<CGroupByElt>,
-): RowKeyImpl {
+): RowKey {
   rowKey = mutable Vector[];
   kinds = mutable Vector[];
   for (idx => elt in groupBy) {

--- a/sql/src/SqlTailer.sk
+++ b/sql/src/SqlTailer.sk
@@ -33,7 +33,7 @@ fun buildTailFilter(
       conditionFilter = dirSub.filter(context, isReset);
       baseName -> {
         inputRow = baseName match {
-        | SKDB.RowKey(row, _) -> row
+        | rowKey @ SKDB.RowKey _ -> rowKey.getRowValues()
         | _ ->
           print_error("Unexpected table entry type");
           skipExit(2)
@@ -64,7 +64,8 @@ fun buildTailFilter(
       baseName -> {
         oldFilter(baseName) &&
           baseName match {
-          | SKDB.RowKey(row, _) ->
+          | rowKey @ SKDB.RowKey _ ->
+            row = rowKey.getRowValues();
             SKDB.checkUserCanReadRow(context, user, sqlTable, row) match {
             | SKDB.AROK() -> true
             | _ -> false

--- a/sql/src/SqlValue.sk
+++ b/sql/src/SqlValue.sk
@@ -67,15 +67,25 @@ fun compareRows(
   EQ()
 }
 
-class RowKey(
-  row: RowValues,
-  kinds: Array<(Int, P.IKind, P.Type)>,
-) extends SKStore.Key {
+class RowKey extends RowKeyImpl {
   static fun create(
     row: RowValues,
     kinds: Array<(Int, P.IKind, P.Type)>,
-  ): this {
+  ): RowKeyImpl {
     static(row, kinds)
+  }
+}
+
+base class RowKeyImpl protected (
+  private row: RowValues,
+  private kinds: Array<(Int, P.IKind, P.Type)>,
+) extends SKStore.Key {
+  fun getRowValues(): RowValues {
+    this.row
+  }
+
+  fun getKinds(): Array<(Int, P.IKind, P.Type)> {
+    this.kinds
   }
 
   fun compare(other: SKStore.Key): Order {

--- a/sql/src/SqlValue.sk
+++ b/sql/src/SqlValue.sk
@@ -67,19 +67,14 @@ fun compareRows(
   EQ()
 }
 
-class RowKey extends RowKeyImpl {
+extension class RowKey {
   static fun create(
     row: RowValues,
     kinds: Array<(Int, P.IKind, P.Type)>,
-  ): RowKeyImpl {
+  ): RowKey {
     static(row, kinds)
   }
-}
 
-base class RowKeyImpl protected (
-  private row: RowValues,
-  private kinds: Array<(Int, P.IKind, P.Type)>,
-) extends SKStore.Key {
   fun getRowValues(): RowValues {
     this.row
   }
@@ -172,10 +167,7 @@ base class Row extends SKStore.File {
   }
 }
 
-class RowValues private (
-  values: Array<?CValue>,
-  repeat: Int,
-) extends Row uses Orderable {
+extension class RowValues extends Row {
   static fun create(values: Array<?CValue>, repeat: Int = 1): this {
     invariant(repeat >= 0);
     static(values, repeat)

--- a/sqlparser/src/Ast.sk
+++ b/sqlparser/src/Ast.sk
@@ -136,13 +136,6 @@ base class InsertValues uses Equality, Show {
   | IDefault()
 }
 
-base class IKind uses Orderable, Show {
-  children =
-  | INONE()
-  | IASC()
-  | IDESC()
-}
-
 class Select{
   core: SelectCore,
   orderBy: ?Array<(Expr, IKind)>,
@@ -316,13 +309,6 @@ base class InValues uses Equality, Show {
   children =
   | InList(Array<Expr>)
   | InSelect(Select)
-}
-
-base class Type uses Orderable, Show {
-  children =
-  | FLOAT()
-  | INTEGER()
-  | TEXT()
 }
 
 base class TransactionKind uses Equality, Show {


### PR DESCRIPTION
This is not meant to be a merged as is ever. I am putting this draft together to help @bennostein get started on the space optimization thing. It's a bit tricky to find the places where to hook up, I am sure he would have figured this out, but since I have code laying there ... we may as well use it.

@bennostein: feel free to dismiss this draft if it is not helpful.

What is this about?

We are using too much space ...

The good news is: the places that we need to optimize are well identified in the code, because all the data holds in the same data-structures. There are all in EagerDir.sk: they are called data/fixedData and old/fixedOld, both made of 2 forms, one that comes in the form of a tree, the other as an array (which is nothing else than a flatten representation of the tree). The resulting map is the diff between the two, in other words, the tree part can override the entries that are in the array. This is not super smart by the way, it's a single level merge algorithm, we probably should switch to a multi-level merge (LSMT style) and get rid of the tree altogether. The two data-structure we need to optimize are:

- data/fixedData: the actual data of the table + tombs
- old/fixedOld: the map that associates a list of keys to a source. For every given source, we need to know which keys were emitted by this source, which directories were created and which individual keys were read. This data-structure tracks that.

I would, in both cases, start optimizing with the fixed version, because we don't know if we are going to keep the tree structure long term. Also, I would start with fixedData because it tends to be much bigger than fixedOld.

With that being said, what is in this diff? You can see there is an alternative representation of FixedDir, called CompressedDir (or something like that), they both implement the interface FixedData. The fixedata now has two additional methods (compress/decompress), which in the case of FixedDir don't do anything.

To make things easier, I declared the types that were necessary for SQL directly in the file (which obviously is wrong, SQL should not be a dependency). But it's just easier when trying things out. Once we know exactly what the compression functions look like, we can do the work of plumbing that through the SKStore API.

The CompressedDir is first initialized by computing a state. While building the initial state, we verify our invariants and we accumulate data that is useful. For example, if a particular piece of data is coming back over and over, it's useful to keep it in the state.

I spent some time optimizing the most basic case (in pseudo-bash):
create table t1 (a INTEGER);
for i in {1..10000}; do insert into t1 values($i); done
skdb compact
skdb size

The skdb compact step is to make sure that all the data is in the fixedMap, because compact performs a merge on every directory.

And then the aim of the game is to make that number (produced by skdb size) go down. The easiest thing to do is to add some debug in FixedDir creation to look at the representation of a FixedRow, and to find ways to make it smaller. In the case of an input table you will see something like this (this is from memory, so might be wrong):

rowValues = RowValues(Array[Some(CInt(n))], 1);
key = RowKey(rowValues, kinds);
fixedRow = (key, (Source(dirName, some_integer), rowValues), the_tags)

As you can see, there is a lot we can do to make things better. The key can be computed from the value, by saving the kinds into the state (they are always the same), the source always has the same dirname etc ... Every allocation saved is a win, and of course, a different representation of RowValues will also probably help at some point (not sure it's the right first thing to focus on though).

This is just for input dirs, next steps should be to add a primary key, that will make the "old/fixedOld" data-structure grow, I have a PR up to help a bit with that case, but there are probably other wins.

But if I was doing it, I would optimize things in that order:
- fixedData, for input directories
- fixedData, for input directories with a primary key
- fixedData, for input directories with a primary key and a few other fields (something realistic)
- virtual views, doing some sort of filtering
- virtual views, doing joins

And after all that, I would switch to the Tree part of the data-structures. Or, maybe just try to do a multi-layer array representation and give up on the Tree structure all together.

Voilà !

I hope this helps!