### PR TITLE
Fix: replication was broken when skdb_author column is defined

### DIFF
--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -1722,6 +1722,7 @@ class EagerDir{
     writerPath: Path,
     k: Key,
     rvalues: Array<File>,
+    force: Bool = false,
   ): this {
     origSource = Source::create(origSourcePath);
     oldValues = this.getArraySourceKey(origSource, k);
@@ -1731,13 +1732,13 @@ class EagerDir{
     };
 
     context.writeChecker match {
-    | None() -> void
-    | Some(checker) ->
+    | Some(checker) if (!force) ->
       checker.tables.maybeGet(this.dirName) match {
       | None() -> void
       | Some(indexes) ->
         checker.checkWrite(context, this.dirName, indexes, k, rvalues)
       }
+    | _ -> void
     };
 
     if (this.data.nbrEntries >= this.fixedData.size()) {

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -785,6 +785,7 @@ fun replayDiff(
       | None() -> break SKStore.CStop(None())
       };
       !state = state match {
+      | None() if (line == "") -> None()
       | None() if (String.getByte(line, 0) != 94) -> // !startsWith("^")
         None()
 

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -388,6 +388,7 @@ fun applyDiffStrategy(
               writer,
               key,
               Array<SKStore.File>[],
+              true,
             );
           }
         };
@@ -399,6 +400,7 @@ fun applyDiffStrategy(
             writer,
             SKDB.RowKey(row, table.kinds),
             Array[row],
+            true,
           );
         };
 
@@ -455,6 +457,7 @@ fun applyDiffStrategy(
               writer,
               key,
               Array[],
+              true,
             );
           } else {
             !keyRepeat = keyRepeat - srcRepeat;
@@ -468,6 +471,7 @@ fun applyDiffStrategy(
             writer,
             key,
             Array[row.setRepeat(keyRepeat)],
+            true,
           );
         };
         newDir
@@ -517,6 +521,7 @@ fun applyDiffStrategy(
                 writer,
                 key,
                 Array[],
+                true,
               );
             }
           };
@@ -537,6 +542,7 @@ fun applyDiffStrategy(
               editWriter,
               editKey,
               editFiles,
+              true,
             );
           };
         };
@@ -587,6 +593,7 @@ fun applyDiffStrategy(
               editWriter,
               editKey,
               editFiles,
+              true,
             );
           };
         };


### PR DESCRIPTION
Replication was working correctly and delivering the row but the local
write checker was preventing the write to the local dir. It's
safeguarding it in the same way it doesn't let you insert a row with
the wrong skdb_author.

The design of write-csv assumes that, on the client, it is operating
effectively as root and can do whatever it likes. writeChecker breaks
this assumption.

I fixed this by allowing write-csv to disable the write checker. See
the commit message for why I disable using a flag rather than some
other approach - I did put some thought in to this. :D

I disable the check rather than moving it higher in to the SQL layer
to ensure that with future changes we don't forget to check writes -
which although wouldn't be terrible - we don't trust the client and
bad writes are still rejected at the server - would create a very
annoying dev experience and be very confusing. In sum, I do agree that
this concept belongs in the skfs layer.