### PR TITLE
Make group ids visible in SKDBGroup

### DIFF
--- a/sql/ts/src/skdb_types.ts
+++ b/sql/ts/src/skdb_types.ts
@@ -169,6 +169,10 @@ export interface SKDBShared extends Shared {
 }
 
 export interface SKDBGroup {
+  ownerGroupID: string;
+  adminGroupID: string;
+  groupID: string;
+
   setDefaultPermission: (perm: string) => Promise<void>;
   setMemberPermission: (userID: string, perm: string) => Promise<void>;
 


### PR DESCRIPTION
These are needed, particularly groupID, for writing to skdb_access.
The implementation defines the fields - and they're used in our tests
- but type checking fails in downstream packages.