### PR TITLE
Fix: return any rather than Object

### DIFF
--- a/sql/ts/src/skdb_types.ts
+++ b/sql/ts/src/skdb_types.ts
@@ -130,7 +130,9 @@ export type ProtoResponseCreds = {
   privateKey: Uint8Array;
 };
 
-export type Params = Map<string, string | number> | Object;
+export type Params =
+  | Map<string, string | number>
+  | Record<string, string | number>;
 
 export interface RemoteSKDB {
   connectedAs(): Promise<string>;

--- a/sql/ts/src/skdb_util.ts
+++ b/sql/ts/src/skdb_util.ts
@@ -38,7 +38,7 @@ export class ExternalFuns {
 /* Class for query results, extending Array<Object> with some common selectors
    and utility functions for ease of use. */
 /* ***************************************************************************/
-export class SKDBTable extends Array<Object> {
+export class SKDBTable extends Array<Record<string, any>> {
   scalarValue(): any {
     const row = this.onlyRow();
     const cols = Object.keys(row);
@@ -47,11 +47,10 @@ export class SKDBTable extends Array<Object> {
         `Can't extract scalar: query yielded ${cols.length} columns`,
       );
     }
-    // @ts-ignore
     return row[cols[0]];
   }
 
-  onlyRow(): any {
+  onlyRow(): Record<string, any> {
     if (this.length != 1) {
       throw new Error(`Can't extract only row: got ${this.length} rows`);
     }
@@ -67,7 +66,6 @@ export class SKDBTable extends Array<Object> {
           `Can't extract only column: got ${cols.length} columns`,
         );
       }
-      // @ts-ignore
       result.push(row[cols[0]]);
     }
     return result;
@@ -75,11 +73,9 @@ export class SKDBTable extends Array<Object> {
 
   column(col: string): Array<any> {
     return this.map((row) => {
-      // @ts-ignore
       if (!row[col]) {
         throw new Error("Missing column: " + col);
       }
-      // @ts-ignore
       return row[col];
     });
   }

--- a/sql/ts/src/skdb_util.ts
+++ b/sql/ts/src/skdb_util.ts
@@ -51,7 +51,7 @@ export class SKDBTable extends Array<Object> {
     return row[cols[0]];
   }
 
-  onlyRow(): Object {
+  onlyRow(): any {
     if (this.length != 1) {
       throw new Error(`Can't extract only row: got ${this.length} rows`);
     }


### PR DESCRIPTION
Object is a pain to work with. Typescript doesn't allow it to be cast
easily, so you can't add typing info, and it doesn't like you using
properties as accessors, which makes code messy.