### PR TITLE
[skargo] Compute the default number of jobs

### DIFF
--- a/skargo/src/main.sk
+++ b/skargo/src/main.sk
@@ -138,6 +138,18 @@ fun execBuildContext(
 
 /********* Test **********/
 
+fun nproc(): Int {
+  p = System.subprocess(Array["nproc"]);
+  p.exitstatus match {
+  | Posix.WExited(0) ->
+    p.stdout.trim().toIntOption() match {
+    | Some(n) -> n
+    | None() -> 8
+    }
+  | _ -> 8
+  };
+}
+
 fun test(): (Cli.Command, Cli.ParseResults ~> void) {
   (
     Cli.Command("test")
@@ -152,7 +164,7 @@ fun test(): (Cli.Command, Cli.ParseResults ~> void) {
         Cli.IntArg("jobs")
           .long("jobs")
           .short("j")
-          .default(8)
+          .default(nproc())
           .about("Number of parallel jobs, defaults to # of CPUs"),
       )
       .arg(Cli.StringArg("target").about("Check for the target triple"))


### PR DESCRIPTION
On linux or macos machines with coreutils, `nproc` returns the number
processors. This PR changes skargo to use this to compute the default
number of parallel jobs.

For potential future reference, if we want to support vanilla macos,
we could first test if `uname -s` is `Darwin` and then execute `sysctl
hw.ncpu | cut -d' ' -f2` instead.