### PR TITLE
[skc] Clean up verbose (`-v`) mode.

### DIFF
--- a/compiler/src/AsmOutput.sk
+++ b/compiler/src/AsmOutput.sk
@@ -805,7 +805,7 @@ private fun defsIsomorphic(
 
 fun mergeIdenticalAsmDefs(
   defs: mutable AsmOutput.AsmDefIDToAsmDef,
-  verbose: Bool,
+  debug: Bool,
 ): void {
   hash1 = Array::mfill(defs.size(), 0);
   hash2 = Array::mfill(defs.size(), 0);
@@ -904,7 +904,7 @@ fun mergeIdenticalAsmDefs(
     }
   };
 
-  if (verbose) {
+  if (debug) {
     print_error_ln(`Merged ${numMerged} out of ${numVisited} defs.`)
   };
 

--- a/compiler/src/Config.sk
+++ b/compiler/src/Config.sk
@@ -15,6 +15,7 @@ private fun hostTarget(): String {
 private class Config{
   release: Bool,
   verbose: Bool,
+  debug: Bool,
   optConfig: Optimize.Config,
   unknown: Array<String>,
   exportedFunctions: UnorderedSet<String>,
@@ -58,7 +59,8 @@ private class Config{
     );
 
     release = results.getBool("release");
-    verbose = results.getBool("verbose");
+    debug = results.getBool("debug");
+    verbose = debug || results.getBool("verbose");
     // preserve legacy behavior of capturing all unmatched args in a single array
     unknown = results.getArray("files");
 
@@ -157,6 +159,7 @@ private class Config{
     static{
       release,
       verbose,
+      debug,
       optConfig,
       unknown,
       exportedFunctions,

--- a/compiler/src/compile.sk
+++ b/compiler/src/compile.sk
@@ -291,7 +291,7 @@ fun compile(
         });
 
         runCompilerPhase("native/merge_asm_graph", () -> {
-          AsmOutput.mergeIdenticalAsmDefs(defs, conf.verbose)
+          AsmOutput.mergeIdenticalAsmDefs(defs, conf.debug)
         });
 
         runCompilerPhase("native/create_asm_symbols", () -> {

--- a/compiler/src/lower.sk
+++ b/compiler/src/lower.sk
@@ -1234,7 +1234,7 @@ fun lowerFunctions(env: GlobalEnv, config: Config.Config): GlobalEnv {
 
   runPass = (name: String, f: Function, pass: Function -> Function) -> {
     f2 = pass(f);
-    if (config.verbose) {
+    if (config.debug) {
       print_error(`Finished ${name} pass for ${f2}.\n`);
       f2.dump(env, config);
     };
@@ -1243,7 +1243,7 @@ fun lowerFunctions(env: GlobalEnv, config: Config.Config): GlobalEnv {
 
   for (f in env.sfuns) {
     if (f.hasImplementation()) {
-      if (config.verbose) {
+      if (config.debug) {
         print_error(`\nAbout to run lower passes for ${f}.\n`);
         f.dump(env, config);
       };

--- a/compiler/src/main.sk
+++ b/compiler/src/main.sk
@@ -29,6 +29,7 @@ fun main(): void {
     // Global config flags
     .arg(Cli.BoolArg("release"))
     .arg(Cli.BoolArg("verbose").short("v").long("verbose"))
+    .arg(Cli.BoolArg("debug"))
     // Optimization config flags
     // .arg(Cli.BoolArg("localopts").default(true).negatable())
     .arg(Cli.BoolArg("dce").default(true).negatable())
@@ -42,7 +43,6 @@ fun main(): void {
     // .arg(Cli.BoolArg("noopt"))
     // These are handled in skipUtils.sk
     // Just allow them to be ignored here
-    .arg(Cli.ArrayArg("debug"))
     .arg(Cli.BoolArg("profile"))
     .arg(Cli.StringArg("data"))
     .arg(Cli.StringArg("init"))

--- a/compiler/src/optimize.sk
+++ b/compiler/src/optimize.sk
@@ -166,8 +166,6 @@ private fun optimizeOne(
   >,
   opts: Int,
 ): OptimizeOneResult {
-  verbose = config.verbose;
-
   // Grab a bit mask of which optimizations are already applied.
   donePasses = f.status match {
   | p @ OptPartial _ -> p.donePasses
@@ -204,7 +202,7 @@ private fun optimizeOne(
         } else {
           oldFunction = f;
 
-          if (verbose) {
+          if (config.debug) {
             print_error(
               "\nAbout to run " + passName + " pass for " + f + ".\n",
             );
@@ -233,7 +231,7 @@ private fun optimizeOne(
                 )
               };
 
-              if (verbose) {
+              if (config.debug) {
                 print_error(
                   "Finished " + passName + " iteration " + subIterations + "\n",
                 );
@@ -277,7 +275,7 @@ private fun optimizeOne(
 
           !donePasses = donePasses.or(mask);
 
-          if (verbose) {
+          if (config.debug) {
             if (thisChanged) {
               oldFunction.dump(env, config)
             };
@@ -460,7 +458,7 @@ private fun findUnfinishedDependencyCycleMember(
     b != a
   }) void;
 
-  if (config.verbose) {
+  if (config.debug) {
     bestFunction match {
     | Some(best) ->
       print_error_ln(
@@ -498,8 +496,6 @@ private fun optimizeAll(
   config: Config.Config,
   opts: Int,
 ): GlobalEnv {
-  verbose = config.verbose;
-
   passes = Array[
     ("ready", Config::kOptReady, checkReady),
     ("intrinsics", Config::kOptIntrinsics, IntrinsicsInliner::run),
@@ -595,7 +591,7 @@ private fun optimizeAll(
       }
     };
 
-    if (verbose) {
+    if (config.debug) {
       print_error(
         `Beginning round ${round} with ${unoptimized.size()} ` +
           `functions remaining. ${ready.size()} are ` +
@@ -674,7 +670,7 @@ private fun optimizeAll(
         }
       };
 
-      if (verbose) {
+      if (config.debug) {
         // First list the ones we failed to optimize.
         for (fid in unoptimized) {
           f = allFuns[fid];


### PR DESCRIPTION
This commit cleans up the output of verbose mode. The formerly displayed information is now kept behind `--debug`. Moreover, the new verbose mode displays the linker invocation and its output.