### PR TITLE
Increase synchronization timeout for JS tests

### DIFF
--- a/sql/ts/tests/apitests.ts
+++ b/sql/ts/tests/apitests.ts
@@ -243,7 +243,7 @@ function waitSynch(
   check: (v: any) => boolean,
   query_params: Params = new Map(),
   server: boolean = false,
-  max: number = 6,
+  max: number = 10,
 ) {
   let count = 0;
   const test = (resolve, reject) => {
@@ -252,7 +252,7 @@ function waitSynch(
         resolve(value);
       } else {
         count++;
-        setTimeout(() => test(resolve, reject), 100);
+        setTimeout(() => test(resolve, reject), 200);
       }
     };
     if (server) {


### PR DESCRIPTION
We're seeing flaky test failures in CI that don't occur locally for some timing-dependent JS tests that are looking at synchronization of state between multiple clients.

My operating assumption is that this is because of contention or other inconsistent environment behaviour in CircleCI, so this PR increases the default timeout on synchronization in an attempt to smooth such things out.  If we keep seeing flakes, some deeper investigation/fix may be in order.