### PR TITLE
Fix UTF8 in JS getChar

### DIFF
--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -197,14 +197,32 @@ export interface WasmSupplier {
 }
 
 function utf8Encode(str: string): Array<number> {
-  const codePoints = new Array();
+  const utf8 = new Array();
 
-  for (const char of str) {
-    const codePoint = char.codePointAt(0);
-    codePoints.push(codePoint);
+  for (let i = 0; i < str.length; i++) {
+    let charcode = str.charCodeAt(i);
+
+    if (charcode < 0x80) {
+      utf8.push(charcode);
+    } else if (charcode < 0x800) {
+      utf8.push((charcode >> 6) | 0xc0);
+      utf8.push((charcode & 0x3f) | 0x80);
+    } else if (charcode < 0xd800 || charcode >= 0xe000) {
+      utf8.push((charcode >> 12) | 0xe0);
+      utf8.push(((charcode >> 6) & 0x3f) | 0x80);
+      utf8.push((charcode & 0x3f) | 0x80);
+    } else {
+      // surrogate pair
+      i++;
+      charcode = 0x10000 + (((charcode & 0x3ff) << 10) | (str.charCodeAt(i) & 0x3ff));
+      utf8.push((charcode >> 18) | 0xf0);
+      utf8.push(((charcode >> 12) & 0x3f) | 0x80);
+      utf8.push(((charcode >> 6) & 0x3f) | 0x80);
+      utf8.push((charcode & 0x3f) | 0x80);
+    }
   }
 
-  return codePoints;
+  return utf8;
 }
 
 export class Utils {


### PR DESCRIPTION
The way getChar was implemented in JS was not matching the native implementation. The native version return a codepoint, the JS version was supposed to do the same (using a construction called .codePointAt), but it was not working on some utf8 encoded examples (for reasons that I don't understand).

This diff mimics the logic that we have natively. It would be probably worth revisiting at some point, because it would be nicer to use JS primitives to do the work, but it's not urgent. Let's fix our JS first.

The diff also includes tests on utf8 strings to make sure we don't regress.