### PR TITLE
Represent stdin as a utf8 byte array and use TextEncoder

### DIFF
--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -218,56 +218,6 @@ uint32_t SKIP_read_line_get(uint32_t i) {
   return lineBuffer[i];
 }
 
-uint32_t SKIP_getchar(uint64_t) {
-  int c1 = (uint32_t)getc(stdin);
-
-  if (c1 == EOF) {
-    SKIP_throw_EndOfFile();
-  }
-
-  if ((c1 & 0x80) == 0) {
-    return c1;
-  }
-
-  int c2 = (uint32_t)getc(stdin);
-
-  if (c2 == EOF) {
-    fprintf(stderr, "Invalid utf8");
-    exit(ERROR_INVALID_STRING);
-  }
-
-  if ((c1 & 0x20) == 0) {
-    return (c1 - 192) * 64 + (c2 - 128);
-  }
-
-  int c3 = (uint32_t)getc(stdin);
-
-  if (c3 == EOF) {
-    fprintf(stderr, "Invalid utf8");
-    exit(ERROR_INVALID_STRING);
-  }
-
-  if ((c1 & 0x10) == 0) {
-    return (c1 - 224) * 4096 + (c2 - 128) * 64 + (c3 - 128);
-  }
-
-  int c4 = (uint32_t)getc(stdin);
-
-  if (c4 == EOF) {
-    fprintf(stderr, "Invalid utf8");
-    exit(ERROR_INVALID_STRING);
-  }
-
-  if ((c1 & 0x8) == 0) {
-    return (c1 - 240) * 262144 + (c2 - 128) * 4096 + (c3 - 128) * 64 +
-           (c4 - 128);
-  }
-
-  fprintf(stderr, "Invalid utf8");
-  exit(ERROR_INVALID_STRING);
-  return 0;
-}
-
 thread_local void* exn;
 
 void* SKIP_getExn() {

--- a/prelude/src/stdlib/other/System.sk
+++ b/prelude/src/stdlib/other/System.sk
@@ -142,10 +142,6 @@ fun throwEndOfFile(): void {
 }
 
 @debug
-@cpp_extern("SKIP_getchar")
-native fun getChar(): Char;
-
-@debug
 @no_throw
 @cpp_runtime
 native fun print_stack_trace(): void;

--- a/prelude/ts/src/sk_runtime.ts
+++ b/prelude/ts/src/sk_runtime.ts
@@ -26,7 +26,6 @@ class LinksImpl implements Links {
   SKIP_read_line_fill!: () => int;
   SKIP_read_to_end_fill!: () => int;
   SKIP_read_line_get!: (index: int) => ptr;
-  SKIP_getchar!: () => int;
 
   SKIP_print_error!: (strPtr: ptr) => void;
   SKIP_print_error_raw!: (strPtr: ptr) => void;
@@ -126,7 +125,6 @@ class LinksImpl implements Links {
     this.SKIP_read_line_get = (i: int) => {
       return this.lineBuffer[i];
     };
-    this.SKIP_getchar = utils.getStdInChar;
     this.SKIP_FileSystem_appendTextFile = (path: ptr, contents: ptr) => {
       let strPath = utils.importString(path);
       let strContents = utils.importString(contents);
@@ -234,7 +232,6 @@ class Manager implements ToWasmManager {
     toWasm.SKIP_read_line_fill = () => links.SKIP_read_line_fill();
     toWasm.SKIP_read_to_end_fill = () => links.SKIP_read_to_end_fill();
     toWasm.SKIP_read_line_get = (index: int) => links.SKIP_read_line_get(index);
-    toWasm.SKIP_getchar = () => links.SKIP_getchar();
     toWasm.SKIP_setenv = (skName: ptr, skValue: ptr) =>
       links.SKIP_setenv(skName, skValue);
     toWasm.SKIP_getenv = (skName: ptr) => links.SKIP_getenv(skName);
@@ -289,7 +286,6 @@ interface ToWasm {
   SKIP_read_line_fill: () => int;
   SKIP_read_to_end_fill: () => int;
   SKIP_read_line_get: (index: int) => ptr;
-  SKIP_getchar: () => int;
   SKIP_setenv: (skName: ptr, skvalue: ptr) => void;
   SKIP_getenv: (skName: ptr) => ptr | null;
   SKIP_unsetenv: (skName: ptr) => void;

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -552,15 +552,6 @@ export class Utils {
     return lineBuffer;
   };
 
-  getStdInChar = () => {
-    if (this.current_stdin >= this.stdin.length) {
-      this.exports.SKIP_throw_EndOfFile();
-    }
-    let result = this.stdin[this.current_stdin];
-    this.current_stdin++;
-    return result;
-  };
-
   runWithGc = <T>(fn: () => T) => {
     let obsPos = this.exports.SKIP_new_Obstack();
     try {

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -196,33 +196,8 @@ export interface WasmSupplier {
   completeWasm: (wasm: object, utils: Utils) => void;
 }
 
-function utf8Encode(str: string): Array<number> {
-  const utf8 = new Array();
-
-  for (let i = 0; i < str.length; i++) {
-    let charcode = str.charCodeAt(i);
-
-    if (charcode < 0x80) {
-      utf8.push(charcode);
-    } else if (charcode < 0x800) {
-      utf8.push((charcode >> 6) | 0xc0);
-      utf8.push((charcode & 0x3f) | 0x80);
-    } else if (charcode < 0xd800 || charcode >= 0xe000) {
-      utf8.push((charcode >> 12) | 0xe0);
-      utf8.push(((charcode >> 6) & 0x3f) | 0x80);
-      utf8.push((charcode & 0x3f) | 0x80);
-    } else {
-      // surrogate pair
-      i++;
-      charcode = 0x10000 + (((charcode & 0x3ff) << 10) | (str.charCodeAt(i) & 0x3ff));
-      utf8.push((charcode >> 18) | 0xf0);
-      utf8.push(((charcode >> 12) & 0x3f) | 0x80);
-      utf8.push(((charcode >> 6) & 0x3f) | 0x80);
-      utf8.push((charcode & 0x3f) | 0x80);
-    }
-  }
-
-  return utf8;
+function utf8Encode(str: string): Uint8Array {
+  return new TextEncoder().encode(str)
 }
 
 export class Utils {
@@ -233,7 +208,7 @@ export class Utils {
 
   args: Array<string>;
   private current_stdin: number;
-  private stdin: Array<number>;
+  private stdin: Uint8Array;
   private stdout: Array<string>;
   private stderr: Array<string>;
   private stddebug: Array<string>;

--- a/skfs/src/Write.sk
+++ b/skfs/src/Write.sk
@@ -187,18 +187,4 @@ fun getWriteKeyValuesIter(
   }
 }
 
-fun writeFromStdin(context: mutable Context, dirNameStr: String): void {
-  dirName = SKStore.DirName::create(dirNameStr);
-  dir = context.unsafeGetEagerDir(dirName);
-  dir.writeArrayMany(
-    context,
-    getWriteKeyValuesIter(getChar).map(kv ->
-      (
-        (SKStore.SID(kv.i0) : SKStore.Key),
-        kv.i1.map(x ~> (SKStore.StringFile(x) : SKStore.File)),
-      )
-    ),
-  );
-}
-
 module end;

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -150,13 +150,6 @@ untracked fun main(): void {
           Cli.StringArg("field").positional().required().about("Field number"),
         ),
     )
-    .subcommand(
-      Cli.Command("load-csv")
-        .about("Load CSV values into table")
-        .arg(Cli.StringArg("table").positional().required().about("Table name"))
-        // TODO: Why is `--user` only offered for CSV variants?
-        .arg(Cli.StringArg("user").about("Name of the user")),
-    )
     .subcommand(Cli.Command("size").about("Output the size of the db"))
     .subcommand(
       Cli.Command("diff")
@@ -317,12 +310,9 @@ untracked fun main(): void {
       | "dump-views" -> execDumpViews
       | "dump" -> execDump
       | "migrate" -> execMigrate
-      | "load-csv" -> execLoadCsv
-      | "csv-field" -> execCsvField
       | "size" -> execSize
       | "diff" -> execDiff
       | "disconnect" -> execDisconnect
-      | "write" -> execWrite
       | "tail" -> execTail
       | "watermark" -> execWatermark
       | "replication-id" -> execReplicationId
@@ -504,50 +494,6 @@ fun execMigrate(args: Cli.ParseResults, options: SKDB.Options): void {
   })
 }
 
-fun execLoadCsv(args: Cli.ParseResults, options: SKDB.Options): void {
-  name = P.Name::create(args.getString("table"));
-  SKDB.runSql(options, context ~> {
-    table = context.getGlobal("CSV_TABLE") match {
-    | None() ->
-      tableDescr = SKDB.getTable(context, 0, name);
-      context.setGlobal("CSV_TABLE", tableDescr);
-      tableDescr
-    | Some(x) -> SKDB.DirDescr::type(x)
-    };
-    line = context.getGlobal("Line") match {
-    | None() -> mutable Ref(1)
-    | Some(file) -> mutable Ref(SKStore.IntFile::type(file).value)
-    };
-    user = args.maybeGetString("user") match {
-    | None() -> None()
-    | Some(userID) -> Some(SKDB.UserFile::create(context, userID))
-    };
-    try {
-      contextOp = SKCSV.insert(context, line, options, table, user);
-      context.setGlobal("Line", SKStore.IntFile(line.get()));
-      contextOp
-    } catch {
-    | exn ->
-      print_error("Error, line " + line.get() + ": " + exn.getMessage());
-      skipExit(23)
-    };
-  })
-}
-
-fun execCsvField(args: Cli.ParseResults, _options: SKDB.Options): void {
-  fieldNbr = args.getString("field").toInt();
-  line = mutable Ref(1);
-  loop {
-    (eof, rows) = SKCSV.parseCsv(line, x ~> x);
-    for (row in rows) {
-      if (fieldNbr < 0 || fieldNbr >= row.size()) continue;
-      str = row[fieldNbr].i1;
-      print_string(str);
-    };
-    if (eof) return void;
-  }
-}
-
 fun execSize(args: Cli.ParseResults, options: SKDB.Options): void {
   ensureContext(args);
   SKDB.runSql(options, _context ~> {
@@ -604,15 +550,6 @@ fun execDisconnect(args: Cli.ParseResults, options: SKDB.Options): void {
       skipExit(2)
     | Some(_) -> context.!sessions = context.sessions.remove(sessionID)
     };
-  })
-}
-
-fun execWrite(args: Cli.ParseResults, options: SKDB.Options): void {
-  ensureContext(args);
-  dirNameStr = args.getString("directory");
-  SKDB.runSql(options, context ~> {
-    SKStore.writeFromStdin(context, dirNameStr);
-    SKStore.CStop(None())
   })
 }
 

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -105,33 +105,6 @@ fun lex(next: () -> Char): mutable Iterator<(Bool, String)> {
   }
 }
 
-fun parseCsv<T>(
-  line: mutable Ref<Int>,
-  f: ((Bool, String)) ~> T,
-): (Bool, Array<Array<T>>) {
-  array = mutable Vector[];
-  eof = false;
-  try {
-    for (_ in Range(0, 1000)) {
-      values = mutable Vector[];
-      for (value in lex(() -> getChar())) {
-        values.push(value);
-      };
-      cvalues = values.map(f);
-      array.push(cvalues.toArray());
-      line.set(line.get() + 1);
-    }
-  } catch {
-  | EndOfFile _ ->
-    !eof = true;
-    void
-  | exn ->
-    print_error("Error, line " + line.get() + ": " + exn.getMessage());
-    skipExit(23)
-  };
-  (eof, array.toArray())
-}
-
 fun parseCSVValue(kv: (Bool, String)): P.Value {
   (isStr, str) = kv;
   if (isStr) return P.VString(str);
@@ -144,34 +117,6 @@ fun parseCSVValue(kv: (Bool, String)): P.Value {
     }
   | Some(x) -> P.VInt(x)
   }
-}
-
-fun insert(
-  context: mutable SKStore.Context,
-  line: mutable Ref<Int>,
-  options: SKDB.Options,
-  table: SKDB.DirDescr,
-  user: ?SKDB.UserFile,
-): SKStore.ContextOp {
-  // empty params since no placeholders in input to skdb load-csv
-  params: Map<String, P.Value> = Map[];
-  eval = SKDB.Evaluator{options, user};
-  pos = 0;
-  inTransaction = false;
-  paramsOpt = None();
-  (eof, array) = parseCsv(line, parseCSVValue);
-  f = eval.insert(
-    context,
-    params,
-    pos,
-    None(),
-    inTransaction,
-    table,
-    paramsOpt,
-    array,
-  );
-  if (!eof) return SKStore.CContinue(f);
-  SKStore.CStop(f)
 }
 
 fun reasonSchemaUnsupported(


### PR DESCRIPTION
stdin is a byte stream and in my opinion should assume utf8. This
seems to be the assumption we have everywhere else. So I changed the
type to reflect this and then can use the built in TextEncoder to
convert strings.

Now this is JS so all bets are off, but I would hope this is likely
more correct and more efficient than anything we've hand rolled. But
it should definitely produce (slightly) smaller code.

All tests pass locally, including those added in pr #111.