### PR TITLE
Introduce compact FixedDir and FixedSingle representations for SKDB

### DIFF
--- a/skfs/src/Context.sk
+++ b/skfs/src/Context.sk
@@ -961,9 +961,9 @@ mutable class Context{
         !last = Some(key)
       | Some(oldKey) if (oldKey == key) -> valueAcc.extend(values)
       | Some(oldKey) ->
-        path = Source::create(Path::create(dirName, oldKey));
+        source = Path::create(dirName, oldKey);
         vector.push(
-          FixedRow(oldKey, (path, valueAcc.toArray()), TickRange::create(tick)),
+          FixedRow(oldKey, valueAcc.toArray(), source, TickRange::create(tick)),
         );
         !last = Some(key);
         valueAcc.clear();
@@ -973,9 +973,9 @@ mutable class Context{
     last match {
     | None() -> void
     | Some(key) ->
-      path = Source::create(Path::create(dirName, key));
+      source = Path::create(dirName, key);
       vector.push(
-        FixedRow(key, (path, valueAcc.toArray()), TickRange::create(tick)),
+        FixedRow(key, valueAcc.toArray(), source, TickRange::create(tick)),
       )
     };
     fixedData = FixedDataMap::create(vector);
@@ -1167,7 +1167,7 @@ fun import(
         for (key in changedKeys) {
           for (srcValue in dir.unsafeGetAllDataIterAfter(tick, key)) {
             (_, source, writer, values) = srcValue;
-            entries.push((key, (source.path(), writer.path(), values)));
+            entries.push((key, (source, writer, values)));
           }
         };
         targetCtx.unsafeMaybeGetEagerDir(dir.dirName) match {

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -530,9 +530,9 @@ class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Path>} {
     vec: mutable Vector<FixedRow<Array<File>>> = mutable Vector[],
     tombs: mutable Vector<FixedRow<Path>> = mutable Vector[],
   ): this {
-    data = FixedDirImpl::getDirInfo(vec) match {
+    data = IFixedDir::getMetadata(vec) match {
     | None() -> FixedDir::create(vec)
-    | Some(dirInfo) -> CompactFixedDir::create(vec, dirInfo)
+    | Some(metadata) -> CompactFixedDir::create(vec, metadata)
     };
     static{data, tombs => FixedDir::create(tombs)}
   }

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -530,10 +530,9 @@ class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Source>} {
     vec: mutable Vector<FixedRow<Array<File>>> = mutable Vector[],
     tombs: mutable Vector<FixedRow<Source>> = mutable Vector[],
   ): this {
-    data = if (FixedDirImpl::isCompressable(vec)) {
-      CompressedFixedDir::create(vec)
-    } else {
-      FixedDir::create(vec)
+    data = FixedDirImpl::isCompressable(vec) match {
+    | None() -> FixedDir::create(vec)
+    | state @ Some(_) -> CompressedFixedDir::create(state, vec)
     };
     static{data, tombs => FixedDir::create(tombs)}
   }

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -525,12 +525,17 @@ class DataMap{
   }
 }
 
-class FixedDataMap{data: FixedDir<Array<File>>, tombs: FixedDir<Source>} {
+class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Source>} {
   static fun create(
     vec: mutable Vector<FixedRow<Array<File>>> = mutable Vector[],
     tombs: mutable Vector<FixedRow<Source>> = mutable Vector[],
   ): this {
-    static{data => FixedDir::create(vec), tombs => FixedDir::create(tombs)}
+    data = if (FixedDirImpl::isCompressable(vec)) {
+      CompressedFixedDir::create(vec)
+    } else {
+      FixedDir::create(vec)
+    };
+    static{data, tombs => FixedDir::create(tombs)}
   }
 
   fun size(): Int {
@@ -554,7 +559,7 @@ class FixedDataMap{data: FixedDir<Array<File>>, tombs: FixedDir<Source>} {
   }
 
   fun getIterAll(): mutable Iterator<(Tick, Source, Source, Key, Array<File>)> {
-    iter1 = this.data.data.iterator();
+    iter1 = this.data.iterator();
     iter2 = this.tombs.data.iterator();
     left = iter1.next();
     right = iter2.next();

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -530,9 +530,9 @@ class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Source>} {
     vec: mutable Vector<FixedRow<Array<File>>> = mutable Vector[],
     tombs: mutable Vector<FixedRow<Source>> = mutable Vector[],
   ): this {
-    data = FixedDirImpl::isCompressable(vec) match {
+    data = FixedDirImpl::getDirInfo(vec) match {
     | None() -> FixedDir::create(vec)
-    | state @ Some(_) -> CompressedFixedDir::create(state, vec)
+    | Some(dirInfo) -> CompactFixedDir::create(vec, dirInfo)
     };
     static{data, tombs => FixedDir::create(tombs)}
   }

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -825,26 +825,24 @@ class EagerDir{
       lastOpt: ?(Tick, Path, Path, Key, Array<File>) = None();
 
       addHelper = lastRow -> {
-        if (lastRow.i4.size() > 0 || lastRow.i0 > limit) {
-          if (lastRow.i4.size() > 0) {
-            data.push(
-              FixedRow(
-                lastRow.i3,
-                lastRow.i4,
-                lastRow.i1,
-                TickRange::create(lastRow.i0),
-              ),
-            );
-          } else {
-            tombs.push(
-              FixedRow(
-                lastRow.i3,
-                lastRow.i2,
-                lastRow.i1,
-                TickRange::create(lastRow.i0),
-              ),
-            );
-          }
+        if (lastRow.i4.size() > 0) {
+          data.push(
+            FixedRow(
+              lastRow.i3,
+              lastRow.i4,
+              lastRow.i1,
+              TickRange::create(lastRow.i0),
+            ),
+          );
+        } else if (lastRow.i0 > limit) {
+          tombs.push(
+            FixedRow(
+              lastRow.i3,
+              lastRow.i2,
+              lastRow.i1,
+              TickRange::create(lastRow.i0),
+            ),
+          );
         }
       };
 

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -680,7 +680,7 @@ class EagerDir{
   fixedData: FixedDataMap,
   totalSize: Int,
   creator: ?ArrowKey,
-  fixedOld: FixedSingle<Path, MInfo> = FixedSingle::empty(),
+  fixedOld: FixedSourceMap = FixedSourceMap::empty(),
   data: DataMap = DataMap::empty(),
   old: SortedMap<Path, MInfo> = SortedMap[],
   parents: FixedSingle<
@@ -780,7 +780,7 @@ class EagerDir{
     changesWritten > 0
   }
 
-  fun purgeOld(): FixedSingle<Path, MInfo> {
+  fun purgeOld(): FixedSourceMap {
     current = 0;
     acc = mutable Vector[];
     add = minfo -> {
@@ -810,7 +810,10 @@ class EagerDir{
       add(this.fixedOld[current]);
       !current = current + 1;
     };
-    FixedSingle(acc.toArray());
+    FixedSourceMap::getMetadata(acc) match {
+    | Some(metadata) -> CompactFSMImpl::create(acc, metadata)
+    | None() -> FSMImpl::create(acc)
+    }
   }
 
   private fun flattenData(limit: Tick): FixedDataMap {
@@ -1371,6 +1374,11 @@ class EagerDir{
 
       data = DataMap::empty();
 
+      fixedOld = FixedSourceMap::getMetadata(oldVec) match {
+      | Some(metadata) -> CompactFSMImpl::create(oldVec, metadata, true)
+      | None() -> FSMImpl::create(oldVec, true)
+      };
+
       EagerDir{
         time,
         dirName => childName,
@@ -1380,7 +1388,7 @@ class EagerDir{
         data,
         totalSize,
         creator => context.currentArrow(),
-        fixedOld => FixedSingle::create(oldVec, true),
+        fixedOld,
         childDirs => SortedSet[],
         reducer,
       }

--- a/skfs/src/EagerDir.sk
+++ b/skfs/src/EagerDir.sk
@@ -140,7 +140,7 @@ class Reducer{
       current.value < fixedData.size() &&
       fixedData[current.value].key == key
     ) {
-      for (file in fixedData[current.value].value.i1) {
+      for (file in fixedData[current.value].value) {
         result.push(file);
       };
       current.incr();
@@ -274,8 +274,8 @@ native fun unixNotify(String, Int32): Int32;
 /*****************************************************************************/
 
 class DataMapValue{
-  map: DMap<Source, (Source, Array<File>)> = DMap::empty(),
-  tombs: DMap<Source, Source> = DMap::empty(),
+  map: DMap<Path, (Path, Array<File>)> = DMap::empty(),
+  tombs: DMap<Path, Path> = DMap::empty(),
 } {
   static fun empty(): this {
     static{}
@@ -288,8 +288,8 @@ class DataMapValue{
   fun set(
     tick: Tick,
     isMasking: Bool,
-    origSource: Source,
-    writer: Source, // different to origSource when explicitly tombstoning
+    origSource: Path,
+    writer: Path, // different to origSource when explicitly tombstoning
     files: Array<File>,
   ): this {
     invariant(files.isEmpty() || origSource == writer);
@@ -323,7 +323,7 @@ class DataMapValue{
 
   fun itemsAfter(
     limit: Tick,
-  ): mutable Iterator<(Tick, Source, Source, Array<File>)> {
+  ): mutable Iterator<(Tick, Path, Path, Array<File>)> {
     mapIter = this.map.getChangesAfterIter(limit);
     tombsIter = this.tombs.getChangesAfterIter(limit);
     left = mapIter.next();
@@ -351,7 +351,7 @@ class DataMapValue{
     }
   }
 
-  fun items(): mutable Iterator<((Tick, Source, Source), Array<File>)> {
+  fun items(): mutable Iterator<((Tick, Path, Path), Array<File>)> {
     mapIter = this.map.itemsWithTick();
     tombsIter = this.tombs.itemsWithTick();
     left = mapIter.next();
@@ -379,7 +379,7 @@ class DataMapValue{
     }
   }
 
-  fun maybeGet(source: Source): ?Array<File> {
+  fun maybeGet(source: Path): ?Array<File> {
     this.map.maybeGet(source) match {
     | None() -> if (this.tombs.containsKey(source)) Some(Array[]) else None()
     | Some(x) -> Some(x.i1)
@@ -388,8 +388,8 @@ class DataMapValue{
 }
 
 class DataMap{
-  data: DMap<Key, DMap<Source, (Source, Array<File>)>> = Nil(),
-  tombs: DMap<Key, DMap<Source, Source>> = Nil(),
+  data: DMap<Key, DMap<Path, (Path, Array<File>)>> = Nil(),
+  tombs: DMap<Key, DMap<Path, Path>> = Nil(),
   nbrEntries: Int = 0,
 } {
   static fun empty(): this {
@@ -504,13 +504,13 @@ class DataMap{
 
   fun itemsAfterKeyHelper(
     lastSkippedOpt: ?Boundary<Key>,
-  ): mutable Iterator<(Key, DMap<Source, (Source, Array<File>)>)> {
+  ): mutable Iterator<(Key, DMap<Path, (Path, Array<File>)>)> {
     this.data.itemsAfterKey(lastSkippedOpt).iter
   }
 
   fun itemsAfterKey(
     lastSkippedOpt: ?Boundary<Key>,
-  ): mutable IterHolder<Key, DMap<Source, (Source, Array<File>)>> {
+  ): mutable IterHolder<Key, DMap<Path, (Path, Array<File>)>> {
     mutable IterHolder(this.itemsAfterKeyHelper(lastSkippedOpt))
   }
 
@@ -525,10 +525,10 @@ class DataMap{
   }
 }
 
-class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Source>} {
+class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Path>} {
   static fun create(
     vec: mutable Vector<FixedRow<Array<File>>> = mutable Vector[],
-    tombs: mutable Vector<FixedRow<Source>> = mutable Vector[],
+    tombs: mutable Vector<FixedRow<Path>> = mutable Vector[],
   ): this {
     data = FixedDirImpl::getDirInfo(vec) match {
     | None() -> FixedDir::create(vec)
@@ -557,7 +557,7 @@ class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Source>} {
     this.data.getChangesAfter(tick).union(this.tombs.getChangesAfter(tick))
   }
 
-  fun getIterAll(): mutable Iterator<(Tick, Source, Source, Key, Array<File>)> {
+  fun getIterAll(): mutable Iterator<(Tick, Path, Path, Key, Array<File>)> {
     iter1 = this.data.iterator();
     iter2 = this.tombs.data.iterator();
     left = iter1.next();
@@ -567,17 +567,17 @@ class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Source>} {
       | (None(), None()) -> break void
       | (Some(x), None()) ->
         !left = iter1.next();
-        yield (x.tag.current, x.value.i0, x.value.i0, x.key, x.value.i1)
+        yield (x.tag.current, x.source, x.source, x.key, x.value)
       | (None(), Some(y)) ->
         !right = iter2.next();
-        yield (y.tag.current, y.value.i0, y.value.i1, y.key, Array[])
+        yield (y.tag.current, y.source, y.value, y.key, Array[])
       | (Some(x), Some(y)) ->
-        if ((x.key, x.value.i0) < (y.key, y.value.i0)) {
+        if ((x.key, x.source) < (y.key, y.source)) {
           !left = iter1.next();
-          yield (x.tag.current, x.value.i0, x.value.i0, x.key, x.value.i1)
-        } else if ((x.key, x.value.i0) > (y.key, y.value.i0)) {
+          yield (x.tag.current, x.source, x.source, x.key, x.value)
+        } else if ((x.key, x.source) > (y.key, y.source)) {
           !right = iter2.next();
-          yield (y.tag.current, y.value.i0, y.value.i1, y.key, Array[])
+          yield (y.tag.current, y.source, y.value, y.key, Array[])
         } else {
           invariant_violation("Found a non-empty tomb (getIterAll)");
         }
@@ -585,7 +585,7 @@ class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Source>} {
     }
   }
 
-  fun getIter(key: Key): mutable Iterator<(Tick, Source, Source, Array<File>)> {
+  fun getIter(key: Key): mutable Iterator<(Tick, Path, Path, Array<File>)> {
     iter1 = this.data.getIter(key);
     iter2 = this.tombs.getIter(key);
     left = iter1.next();
@@ -616,7 +616,7 @@ class FixedDataMap{data: FixedData<Array<File>>, tombs: FixedDir<Source>} {
   fun getIterAfter(
     tick: Tick,
     key: Key,
-  ): mutable Iterator<(Tick, Source, Source, Array<File>)> {
+  ): mutable Iterator<(Tick, Path, Path, Array<File>)> {
     iter1 = this.data.getIterAfter(tick, key);
     iter2 = this.tombs.getIterAfter(tick, key);
     left = iter1.next();
@@ -680,9 +680,9 @@ class EagerDir{
   fixedData: FixedDataMap,
   totalSize: Int,
   creator: ?ArrowKey,
-  fixedOld: FixedSingle<Source, MInfo> = FixedSingle::empty(),
+  fixedOld: FixedSingle<Path, MInfo> = FixedSingle::empty(),
   data: DataMap = DataMap::empty(),
-  old: SortedMap<Source, MInfo> = SortedMap[],
+  old: SortedMap<Path, MInfo> = SortedMap[],
   parents: FixedSingle<
     DirName,
     Array<
@@ -697,10 +697,10 @@ class EagerDir{
 } extends Dir {
   fun reset(
     context: mutable SKStore.Context,
-    writerPath: Path,
+    writer: Path,
     keep: SortedSet<Key>,
     isVisible: Key -> Bool = _ -> true,
-    wasSeen: (Tick, Source) ~> Bool = (_, _) ~> true,
+    wasSeen: (Tick, Path) ~> Bool = (_, _) ~> true,
   ): this {
     this.unsafeGetFileIter().each(kv -> {
       (key, valueIter) = kv;
@@ -712,13 +712,7 @@ class EagerDir{
             (tick, source, _values) = kv;
             // do not wipe out data that has not yet been seen
             if (wasSeen(tick, source)) {
-              !this = this.writeEntry(
-                context,
-                source.path(),
-                writerPath,
-                key,
-                Array[],
-              )
+              !this = this.writeEntry(context, source, writer, key, Array[])
             }
           })
         }
@@ -786,7 +780,7 @@ class EagerDir{
     changesWritten > 0
   }
 
-  fun purgeOld(): FixedSingle<Source, MInfo> {
+  fun purgeOld(): FixedSingle<Path, MInfo> {
     current = 0;
     acc = mutable Vector[];
     add = minfo -> {
@@ -828,7 +822,7 @@ class EagerDir{
       tombs = Vector::mcreate(
         this.fixedData.tombs.size() + 1.shl(this.data.tombs.getHeight()),
       );
-      lastOpt: ?(Tick, Source, Source, Key, Array<File>) = None();
+      lastOpt: ?(Tick, Path, Path, Key, Array<File>) = None();
 
       addHelper = lastRow -> {
         if (lastRow.i4.size() > 0 || lastRow.i0 > limit) {
@@ -836,7 +830,8 @@ class EagerDir{
             data.push(
               FixedRow(
                 lastRow.i3,
-                (lastRow.i1, lastRow.i4),
+                lastRow.i4,
+                lastRow.i1,
                 TickRange::create(lastRow.i0),
               ),
             );
@@ -844,7 +839,8 @@ class EagerDir{
             tombs.push(
               FixedRow(
                 lastRow.i3,
-                (lastRow.i1, lastRow.i2),
+                lastRow.i2,
+                lastRow.i1,
                 TickRange::create(lastRow.i0),
               ),
             );
@@ -974,7 +970,7 @@ class EagerDir{
 
   private static fun fixedMapData(
     context: mutable Context,
-    oldVec: mutable Vector<(Source, MInfo)>,
+    oldVec: mutable Vector<(Path, MInfo)>,
     parent: EagerDir,
     childName: DirName,
     f: MapFun,
@@ -988,7 +984,7 @@ class EagerDir{
       current.value + 1 < parent.fixedData.data.size() &&
       parent.fixedData.data[current.value + 1].key != key
     ) {
-      fixedFiles = parent.fixedData.data[current.value].value.i1.iterator();
+      fixedFiles = parent.fixedData.data[current.value].value.iterator();
       static::mapRow(
         context,
         acc,
@@ -1008,7 +1004,7 @@ class EagerDir{
       current.value < parent.fixedData.data.size() &&
       parent.fixedData.data[current.value].key == key
     ) {
-      for (elt in parent.fixedData.data[current.value].value.i1) {
+      for (elt in parent.fixedData.data[current.value].value) {
         valueAcc.push(elt);
       };
       current.incr();
@@ -1041,7 +1037,7 @@ class EagerDir{
     end: ?Key,
   ): (
     readonly Vector<FixedRow<Array<File>>>,
-    readonly Vector<(Source, MInfo)>,
+    readonly Vector<(Path, MInfo)>,
     ?Key,
     Int,
   ) {
@@ -1110,7 +1106,7 @@ class EagerDir{
 
   private static fun mapData(
     context: mutable Context,
-    oldVec: mutable Vector<(Source, MInfo)>,
+    oldVec: mutable Vector<(Path, MInfo)>,
     parent: EagerDir,
     childName: DirName,
     f: MapFun,
@@ -1175,7 +1171,7 @@ class EagerDir{
   private static fun mapRow(
     context: mutable Context,
     acc: mutable Vector<FixedRow<Array<File>>>,
-    oldVec: mutable Vector<(Source, MInfo)>,
+    oldVec: mutable Vector<(Path, MInfo)>,
     parentName: DirName,
     childName: DirName,
     key: Key,
@@ -1206,12 +1202,11 @@ class EagerDir{
 
     context.updateNewDeps(ArrowKey(parentName, childName, key), reads);
 
-    path = Path::create(parentName, key);
-    source = Source::create(path);
+    source = Path(parentName, key);
 
     for (kv in kvArray) {
       (k, v) = kv;
-      acc.push(FixedRow(k, (source, v), TickRange::create(context.tick)))
+      acc.push(FixedRow(k, v, source, TickRange::create(context.tick)))
     };
 
     if (!kvArray.isEmpty() || !newDirs.isEmpty()) {
@@ -1433,7 +1428,7 @@ class EagerDir{
   fun unsafeGetAllDataIterAfter(
     limit: Tick,
     key: Key,
-  ): mutable Iterator<(Tick, Source, Source, Array<File>)> {
+  ): mutable Iterator<(Tick, Path, Path, Array<File>)> {
     this.data.maybeGet(key) match {
     | None() ->
       fixedIter = this.fixedData.getIterAfter(limit, key);
@@ -1465,7 +1460,7 @@ class EagerDir{
 
   fun unsafeGetAllDataIter(
     key: Key,
-  ): mutable Iterator<(Tick, Source, Source, Array<File>)> {
+  ): mutable Iterator<(Tick, Path, Path, Array<File>)> {
     fixedIter = this.fixedData.getIter(key);
     this.data.maybeGet(key) match {
     | None() ->
@@ -1495,7 +1490,7 @@ class EagerDir{
 
   fun unsafeGetDataIterWithoutTombs(
     key: Key,
-  ): mutable Iterator<(Tick, Source, Array<File>)> {
+  ): mutable Iterator<(Tick, Path, Array<File>)> {
     fixedIter = this.fixedData.getIter(key);
     this.data.maybeGet(key) match {
     | None() ->
@@ -1547,7 +1542,7 @@ class EagerDir{
     }
   }
 
-  private fun getArraySourceKey(source: Source, key: Key): Array<File> {
+  private fun getArraySourceKey(source: Path, key: Key): Array<File> {
     this.data.maybeGet(key) match {
     | None() -> this.fixedData.data.getArraySourceKey(source, key).flatten()
     | Some(modified) ->
@@ -1623,8 +1618,7 @@ class EagerDir{
         ctx = contextOpt.fromSome();
         ctx.enter(ArrowKey(parentName, childName, key));
         path = Path::create(parentName, key);
-        source = Source::create(path);
-        oldInfo = static::getOld(child, source);
+        oldInfo = static::getOld(child, path);
         oldKeys = SortedSet<Key>::createFromItems(oldInfo.getKeys());
         newDirsCopy = ctx.newDirs;
         readsCopy = ctx.reads;
@@ -1659,7 +1653,7 @@ class EagerDir{
         ctx.!newDirs = newDirsCopy;
         ctx.!reads = readsCopy;
 
-        !child = child.updateNewDirs(ctx, source, newDirs);
+        !child = child.updateNewDirs(ctx, path, newDirs);
 
         for (read in reads) {
           arrowKey = ArrowKey(parentName, child.dirName, key);
@@ -1690,7 +1684,7 @@ class EagerDir{
         );
         // The source cannot be removed from old here
         // => prevent getting fixed data minfo on multiple call durring update
-        !child.old[source] = minfo;
+        !child.old[path] = minfo;
         ctx.leave(ArrowKey(parentName, childName, key));
         child
       },
@@ -1719,13 +1713,12 @@ class EagerDir{
 
   fun writeEntry(
     context: mutable Context,
-    origSourcePath: Path,
-    writerPath: Path,
+    origSource: Path,
+    writer: Path,
     k: Key,
     rvalues: Array<File>,
     force: Bool = false,
   ): this {
-    origSource = Source::create(origSourcePath);
     oldValues = this.getArraySourceKey(origSource, k);
 
     if (native_eq(rvalues, oldValues) == 0) {
@@ -1763,7 +1756,6 @@ class EagerDir{
       origSource,
       k,
     ).next() is Some _;
-    writer = Source::create(writerPath);
     !map = map.set(context.tick, isMasking, origSource, writer, rvalues);
 
     tag = TickRange::create(context.tick);
@@ -1915,7 +1907,7 @@ class EagerDir{
       idx < this.fixedData.data.size() &&
       this.fixedData.data[idx].key == key
     ) {
-      fixedValues = this.fixedData.data[idx].value.i1;
+      fixedValues = this.fixedData.data[idx].value;
       if (this.reducer is None()) {
         for (elt in fixedValues) {
           yield elt;
@@ -2047,7 +2039,7 @@ class EagerDir{
     for (newKey => newValues in this.data) {
       while (current < fixedData.size() && fixedData[current].key < newKey) {
         row = fixedData[current];
-        if (row.value.i1.size() > 0) {
+        if (row.value.size() > 0) {
           !keys = keys.set(row.key);
         };
         !current = current + 1;
@@ -2058,7 +2050,7 @@ class EagerDir{
     };
     while (current < fixedData.size()) {
       row = fixedData[current];
-      if (row.value.i1.size() > 0) {
+      if (row.value.size() > 0) {
         !keys = keys.set(row.key);
       };
       !current = current + 1;
@@ -2070,7 +2062,7 @@ class EagerDir{
     this.dirName
   }
 
-  static fun getOld(child: EagerDir, key: Source): MInfo {
+  static fun getOld(child: EagerDir, key: Path): MInfo {
     if (child.old.containsKey(key)) {
       child.old[key]
     } else {
@@ -2083,7 +2075,7 @@ class EagerDir{
 
   fun updateNewDirs(
     context: mutable Context,
-    source: Source,
+    source: Path,
     newDirs: SortedSet<DirName>,
   ): this {
     minfo = static::getOld(this, source);
@@ -2198,7 +2190,7 @@ class EagerDir{
   fun getAllDataIter(
     context: mutable Context,
     key: Key,
-  ): mutable Iterator<(Tick, Source, Source, Array<File>)> {
+  ): mutable Iterator<(Tick, Path, Path, Array<File>)> {
     path = Path::create(this.dirName, key);
     context.addDep(path);
     this.unsafeGetAllDataIter(key)
@@ -2207,7 +2199,7 @@ class EagerDir{
   fun getDataIterWithoutTombs(
     context: mutable Context,
     key: Key,
-  ): mutable Iterator<(Tick, Source, Array<File>)> {
+  ): mutable Iterator<(Tick, Path, Array<File>)> {
     path = Path::create(this.dirName, key);
     context.addDep(path);
     this.unsafeGetDataIterWithoutTombs(key)

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -140,66 +140,7 @@ class FixedDir<T: frozen> extends IFixedDir<T, FixedRow<T>> {
     row
   }
 }
-/*****************************************************************************/
-/* SQL. */
-/*****************************************************************************/
 
-
-module end;
-module SQLParser;
-
-base class Type uses Orderable {
-  children =
-  | FLOAT()
-  | INTEGER()
-  | TEXT()
-  | JSON()
-  | SCHEMA()
-}
-
-base class IKind uses Orderable {
-  children =
-  | INONE()
-  | IASC()
-  | IDESC()
-}
-
-module end;
-module SKDB;
-
-base class CValue uses Orderable {
-  children =
-  | CInt(value: Int)
-  | CFloat(value: Float)
-  | CString(value: String)
-}
-
-class RowKey(
-  row: RowValues,
-  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
-) extends SKStore.Key
-
-class RowValues(
-  values: Array<?CValue>,
-  repeat: Int,
-) uses Orderable extends SKStore.File
-
-class IndexProjKey(
-  row: RowValues,
-  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
-) extends SKStore.Key
-
-class ProjKey(
-  value: ?CValue,
-  colNbr: Int,
-  leftShard: Int,
-  rightShard: Int,
-) extends SKStore.Key
-
-module end;
-module SKStore;
-
-/*****************************************************************************/
 value class CompactRow<T>(
   values: Array<T>,
   repeat: Int,

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -98,45 +98,7 @@ fun binSearch<T: Orderable>(get: Int ~> T, key: T, i: Int, j: Int): Int {
 }
 
 class FixedDir<T: frozen> extends FixedDirImpl<T, FixedRow<T>> {
-  static fun compress(x: FixedRow<T>): FixedRow<T> {
-    x
-  }
-  static fun decompress(x: FixedRow<T>): FixedRow<T> {
-    x
-  }
-}
-
-class CompressedFixedDir extends FixedDirImpl<Array<File>, FixedRow<File>> {
-  static fun compress(row: FixedRow<Array<File>>): FixedRow<File> {
-    size = row.value.i1.size();
-    invariant(size == 1);
-    FixedRow(row.key, (row.value.i0, row.value.i1[0]), row.tag);
-  }
-  static fun decompress(row: FixedRow<File>): FixedRow<Array<File>> {
-    FixedRow(row.key, (row.value.i0, Array[row.value.i1]), row.tag)
-  }
-}
-
-base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
-  data: Array<Compressed> = Array[],
-} extends FixedData<T> {
-  static fun compress(FixedRow<T>): Compressed;
-  static fun decompress(Compressed): FixedRow<T>;
-
-  fun iterator(): mutable Iterator<FixedRow<T>> {
-    for (elt in this.data.iterator()) {
-      yield static::decompress(elt)
-    }
-  }
-
-  static fun isCompressable(data: mutable Vector<FixedRow<Array<File>>>): Bool {
-    for (elt in data) {
-      if (elt.value.i1.size() != 1) return false;
-    };
-    true
-  }
-
-  static deferred fun create<C: FixedDirImpl<T, Compressed>>(
+  static fun create(
     data: mutable Vector<FixedRow<T>> = mutable Vector[],
   ): this {
     i = 0;
@@ -159,7 +121,207 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
       data.sortBy(row ~> (row.key, row.value.i0));
     };
     _ = static::computeTags(data, 0, data.size() - 1);
-    static{data => data.map(static::compress).toArray()}
+    static{
+      state => None(),
+      data => data.map(x -> static::compress(None(), x)).toArray(),
+    }
+  }
+
+  static fun compress(?CompressState, x: FixedRow<T>): FixedRow<T> {
+    x
+  }
+  static fun decompress(?CompressState, x: FixedRow<T>): FixedRow<T> {
+    x
+  }
+}
+/*****************************************************************************/
+/* SQL. */
+/*****************************************************************************/
+
+
+module end;
+module SQLParser;
+
+base class Type uses Orderable {
+  children =
+  | FLOAT()
+  | INTEGER()
+  | TEXT()
+  | JSON()
+  | SCHEMA()
+}
+
+base class IKind uses Orderable {
+  children =
+  | INONE()
+  | IASC()
+  | IDESC()
+}
+
+module end;
+module SKDB;
+
+base class CValue uses Orderable {
+  children =
+  | CInt(value: Int)
+  | CFloat(value: Float)
+  | CString(value: String)
+}
+
+class RowKey(
+  row: RowValues,
+  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+) extends SKStore.Key
+
+class RowValues(
+  values: Array<?CValue>,
+  repeat: Int,
+) uses Orderable extends SKStore.File
+
+module end;
+module SKStore;
+
+/*****************************************************************************/
+value class CompressedRow(
+  sourceID: SKStore.Key,
+  values: Array<?SKDB.CValue>,
+  tag: TickRange,
+)
+
+class CompressState{
+  sourceDirs: SortedSet<DirName>,
+  keyIsSameAsValue: Bool,
+  isAlwaysSize1: Bool,
+  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+}
+
+class CompressedFixedDir extends FixedDirImpl<Array<File>, CompressedRow> {
+  static fun compress(
+    state: ?CompressState,
+    row: FixedRow<Array<File>>,
+  ): CompressedRow {
+    st = state match {
+    | None() -> invariant_violation("Expected a state")
+    | Some(x) -> x
+    };
+    invariant(st.sourceDirs.size() == 1);
+    invariant(row.value.i1.size() == 1);
+    // TODO check that source key == key
+    // TODO check that values in key == rowValues
+    // TODO check kinds are canonical
+    // TODO check repeat is 1
+    //    invariant(row.key.getRowValues() == row.value.i0.baseName);
+    result = CompressedRow(
+      row.value.i0.baseName,
+      row.value.i1[0] match {
+      | SKDB.RowValues(values, _kinds) -> values
+      | _ -> invariant_violation("Unexpected type")
+      },
+      row.tag,
+    );
+    //    debug(row);
+    //    debug(static::decompress(state, result));
+    invariant(inspect(static::decompress(state, result)) == inspect(row));
+    result
+  }
+  static fun decompress(
+    state: ?CompressState,
+    row: CompressedRow,
+  ): FixedRow<Array<File>> {
+    st = state match {
+    | None() -> invariant_violation("Expected a state")
+    | Some(x) -> x
+    };
+    rowValues = SKDB.RowValues(row.values, 1);
+    rowKey = SKDB.RowKey(rowValues, st.kinds);
+    FixedRow(
+      rowKey,
+      (
+        Source(st.sourceDirs.min().fromSome(), row.sourceID),
+        Array[(rowValues : File)],
+      ),
+      row.tag,
+    )
+  }
+
+  static fun create(
+    stateOption: ?CompressState,
+    data: mutable Vector<FixedRow<Array<File>>> = mutable Vector[],
+  ): this {
+    state = stateOption match {
+    | None() -> invariant_violation("Expected a state")
+    | Some(x) -> x
+    };
+    i = 0;
+    sz = data.size();
+    sorted = loop {
+      !i = i + 1;
+      if (i >= sz) break true;
+      keyComparison = data[i - 1].key.compare(data[i].key);
+      keyComparison match {
+      | LT() -> continue
+      | GT() -> break false
+      | EQ() -> data[i - 1].value.i0.compare(data[i].value.i0)
+      } match {
+      | LT() -> continue
+      | EQ() -> continue
+      | GT() -> break false
+      };
+    };
+    if (!sorted) {
+      data.sortBy(row ~> (row.key, row.value.i0));
+    };
+    _ = static::computeTags(data, 0, data.size() - 1);
+    invariant(state.keyIsSameAsValue);
+    static{
+      state => stateOption,
+      data => data.map(x -> static::compress(stateOption, x)).toArray(),
+    }
+  }
+}
+
+base class FixedDirImpl<T: frozen, Compressed: frozen> protected {
+  state: ?CompressState,
+  data: Array<Compressed> = Array[],
+} extends FixedData<T> {
+  static fun compress(?CompressState, FixedRow<T>): Compressed;
+  static fun decompress(?CompressState, Compressed): FixedRow<T>;
+
+  fun iterator(): mutable Iterator<FixedRow<T>> {
+    for (elt in this.data.iterator()) {
+      yield static::decompress(this.state, elt)
+    }
+  }
+
+  static fun isCompressable(
+    data: mutable Vector<FixedRow<Array<File>>>,
+  ): ?CompressState {
+    if (data.size() == 0) return None();
+    sourceDirs = SortedSet[];
+    kinds: ?Array<(Int, SQLParser.IKind, SQLParser.Type)> = None();
+
+    keyIsSameAsValue = true;
+    for (elt in data) {
+      if (elt.value.i1.size() != 1) return None();
+      (elt.key, elt.value.i1[0]) match {
+      | (SKDB.RowKey(row1, k), row2 @ SKDB.RowValues _) ->
+        kinds match {
+        | None() -> !kinds = Some(k)
+        | Some(k2) -> invariant(k == k2)
+        };
+        !sourceDirs = sourceDirs.set(elt.value.i0.dirName);
+        if (row1 != row2) return None()
+      | _ -> return None()
+      }
+    };
+    Some(
+      CompressState{
+        sourceDirs,
+        kinds => kinds.fromSome(),
+        keyIsSameAsValue,
+        isAlwaysSize1 => true,
+      },
+    )
   }
 
   fun size(): Int {
@@ -167,7 +329,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
   }
 
   fun get(idx: Int): FixedRow<T> {
-    static::decompress(this.data.unsafe_get(idx))
+    static::decompress(this.state, this.data.unsafe_get(idx))
   }
 
   fun getPos(key: Key): Int {
@@ -235,7 +397,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
       return void;
     };
     pivot = i + (j - i) / 2;
-    elt = static::decompress(this.data[pivot]);
+    elt = static::decompress(this.state, this.data[pivot]);
     tick = elt.tag;
     if (tick.max < after) return void;
     if (tick.current >= after) {
@@ -264,7 +426,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
   ): void {
     if (i <= j) {
       pivot = i + (j - i) / 2;
-      elt = static::decompress(this.data[pivot]);
+      elt = static::decompress(this.state, this.data[pivot]);
       tick = elt.tag;
       if (tick.max >= after) {
         if (key <= elt.key) {
@@ -293,7 +455,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
       None()
     } else {
       middle = (this.data.size() - 1) / 2;
-      tick = static::decompress(this.data[middle]).tag;
+      tick = static::decompress(this.state, this.data[middle]).tag;
       Some(tick.max)
     }
   }

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -184,7 +184,7 @@ value class CompactRow<T>(
 )
 
 class DirInfo{
-  sourceDirs: SortedSet<DirName>,
+  sourceDir: DirName,
   keyIsSameAsValue: Bool,
   isAlwaysSize1: Bool,
   kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
@@ -200,7 +200,6 @@ class CompactFixedDir{
     data: mutable Vector<FixedRow<Array<File>>>,
     dirInfo: DirInfo,
   ): this {
-    invariant(dirInfo.sourceDirs.size() == 1);
     i = 0;
     sz = data.size();
     sorted = loop {
@@ -259,10 +258,7 @@ class CompactFixedDir{
     };
     FixedRow(
       rowKey,
-      (
-        Source(this.dirInfo.sourceDirs.min().fromSome(), sourceKey),
-        Array[(rowValues : File)],
-      ),
+      (Source(this.dirInfo.sourceDir, sourceKey), Array[(rowValues : File)]),
       compactRow.tag,
     )
   }
@@ -283,7 +279,7 @@ base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
 
   static fun getDirInfo(data: mutable Vector<FixedRow<Array<File>>>): ?DirInfo {
     if (data.size() == 0) return None();
-    sourceDirs = SortedSet[];
+    sourceDir: ?DirName = None();
     kinds: ?Array<(Int, SQLParser.IKind, SQLParser.Type)> = None();
 
     keyIsSameAsValue = true;
@@ -299,18 +295,22 @@ base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
             "Mismatched kinds in table " + elt.value.i0.dirName,
           )
         };
-        !sourceDirs = sourceDirs.set(elt.value.i0.dirName);
+        !sourceDir = sourceDir match {
+        | None() -> Some(elt.source.path.dirName)
+        | sd @ Some(dir) if (dir == elt.source.path.dirName) -> sd
+        | _ -> return None()
+        };
         if (row1 != row2) return None()
       | _ -> return None()
       }
     };
-    Some(
+    sourceDir.map(sourceDir ->
       DirInfo{
-        sourceDirs,
+        sourceDir,
         kinds => kinds.fromSome(),
         keyIsSameAsValue,
         isAlwaysSize1 => true,
-      },
+      }
     )
   }
 

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -771,7 +771,7 @@ class CompactFSMImpl protected (
     key.baseName match {
     | rowKey @ SKDB.RowKey(row, _kinds) ->
       idx = binSearch(this.data.get, row, 0, this.size() - 1);
-      if (idx >= this.data.size()) None() else {
+      if (idx >= this.data.size() || row != this.data.get(idx)) None() else {
         Some(this.reconstructMInfo(rowKey))
       }
     | _ -> None()

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -728,16 +728,26 @@ class FSMImpl(protected data: FixedSingle<Path, MInfo>) extends FixedSourceMap {
   }
 }
 
+// Each FSMMInfoType class encodes a relationship between Paths' baseNames and
+// corresponding MInfoSingles' keys in a CompactFSMImpl
 base class FSMMInfoType
+
+// Each RowKey maps to itself
+class FullRow() extends FSMMInfoType
+
+// Each RowKey maps to an IndexProjKey with the same rowValues but the specified
+// kinds array
 class IndexProjection(
   kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
 ) extends FSMMInfoType
+
+// Each RowKey maps to a ProjKey with the specified left/right shard and the
+// scalar value at position col in the rowKey.
 class Projection(
   col: Int,
   leftShard: Int,
   rightShard: Int,
 ) extends FSMMInfoType
-class FullRow() extends FSMMInfoType
 
 class FSMMetadata{
   dir: DirName,

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -87,6 +87,28 @@ fun binSearch<T: Orderable>(get: Int ~> T, key: T, i: Int, j: Int): Int {
   findFirstBy(idx ~> key.compare(get(idx)), i, j)
 }
 
+// Assuming that the elements of `sortedData` are in fact sorted by `f`,
+// checks that the elements are unique under `f` and throws otherwise
+fun assertUnique<T, U: Orderable>(
+  sortedData: mutable Vector<T>,
+  f: T ~> U,
+): void {
+  lastOpt: ?U = None();
+  for (t in sortedData) {
+    u = f(t);
+    lastOpt match {
+    | None() -> !lastOpt = Some(u)
+    | Some(last_u) ->
+      if (last_u == u) {
+        debug((last_u, u));
+        invariant_violation("Unexpected duplicate elements found")
+      } else {
+        !lastOpt = Some(u)
+      }
+    }
+  };
+}
+
 class FixedDir<T: frozen> extends IFixedDir<T, FixedRow<T>> {
   static fun create(
     data: mutable Vector<FixedRow<T>> = mutable Vector[],
@@ -161,6 +183,11 @@ class RowValues(
   values: Array<?CValue>,
   repeat: Int,
 ) uses Orderable extends SKStore.File
+
+class IndexProjKey(
+  row: RowValues,
+  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+) extends SKStore.Key
 
 module end;
 module SKStore;
@@ -578,22 +605,7 @@ class FixedSingle<K: Orderable, +V: frozen>(data: Array<(K, V)> = Array[]) {
   ): FixedSingle<K, V> {
     data.sortBy(x ~> x.i0);
 
-    if (!allowDuplicates) {
-      lastOpt: ?K = None();
-      for (kv in data) {
-        (k, _) = kv;
-        lastOpt match {
-        | None() -> !lastOpt = Some(k)
-        | Some(last) ->
-          if (last == k) {
-            debug((last, k));
-            invariant_violation("Duplicate value in single")
-          } else {
-            !lastOpt = Some(k)
-          }
-        }
-      }
-    };
+    if (!allowDuplicates) assertUnique(data, x ~> x.i0);
 
     FixedSingle(data.toArray())
   }
@@ -616,6 +628,150 @@ class FixedSingle<K: Orderable, +V: frozen>(data: Array<(K, V)> = Array[]) {
     elt = this.get(pos);
     if (elt.i0 != key) return None();
     Some(elt.i1);
+  }
+}
+
+// Mapping from source paths to MInfo
+base class FixedSourceMap {
+  fun maybeGet(key: Path): ?MInfo;
+  fun get(idx: Int): (Path, MInfo);
+  fun size(): Int;
+  fun items(): mutable Iterator<(Path, MInfo)>;
+  overridable static fun empty(): FixedSourceMap {
+    FSMImpl::empty()
+  }
+  static fun getMetadata(data: readonly Vector<(Path, MInfo)>): ?FSMMetadata {
+    seenDirOpt: ?DirName = None();
+    seenRowKindsOpt: ?Array<(Int, SQLParser.IKind, SQLParser.Type)> = None();
+    seenIndexKindsOpt: ?Array<(Int, SQLParser.IKind, SQLParser.Type)> = None();
+
+    for ((path, minfo) in data) {
+      !seenDirOpt = seenDirOpt match {
+      | None() -> Some(path.dirName)
+      | Some(seenDir) if (seenDir != path.dirName) -> return None()
+      | _ -> seenDirOpt
+      };
+      minfo match {
+      | MInfoSingle(SKDB.IndexProjKey(minfoRow, indexKinds)) ->
+        !seenIndexKindsOpt = seenIndexKindsOpt match {
+        | None() -> Some(indexKinds)
+        | Some(seenIndexKinds) if (indexKinds != seenIndexKinds) ->
+          return None()
+        | _ -> seenIndexKindsOpt
+        };
+        path.baseName match {
+        | SKDB.RowKey(pathRow, rowKinds) ->
+          if (minfoRow != pathRow) return None();
+          !seenRowKindsOpt = seenRowKindsOpt match {
+          | None() -> Some(rowKinds)
+          | Some(seenRowKinds) if (rowKinds != seenRowKinds) -> return None()
+          | _ -> seenRowKindsOpt
+          }
+        | _ -> return None()
+        }
+      | _ -> return None()
+      };
+    };
+    seenDirOpt.flatMap(dir ->
+      seenRowKindsOpt.flatMap(rowKinds ->
+        seenIndexKindsOpt.map(indexKinds ->
+          FSMMetadata{dir, rowKinds, indexKinds}
+        )
+      )
+    )
+  }
+}
+// Direct implementation of a FixedSourceMap as a (sorted) array of Path/MInfo pairs
+class FSMImpl(protected data: FixedSingle<Path, MInfo>) extends FixedSourceMap {
+  static fun create(
+    data: mutable Vector<(Path, MInfo)>,
+    allowDuplicates: Bool = false,
+  ): this {
+    static(FixedSingle::create(data, allowDuplicates))
+  }
+  fun maybeGet(key: Path): ?MInfo {
+    this.data.maybeGet(key)
+  }
+  fun get(idx: Int): (Path, MInfo) {
+    this.data.get(idx)
+  }
+  fun size(): Int {
+    this.data.size()
+  }
+  fun items(): mutable Iterator<(Path, MInfo)> {
+    this.data.items()
+  }
+  static fun empty(): this {
+    static::create(Vector::mcreate(0))
+  }
+}
+
+class FSMMetadata{
+  dir: DirName,
+  rowKinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+  indexKinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+}
+// More-compact representation of a FixedSourceMap, with shared information
+// extracted out of the individual key/val pairs and reconstructed on demand
+class CompactFSMImpl protected (
+  metadata: FSMMetadata,
+  data: Array<SKDB.RowValues>,
+) extends FixedSourceMap {
+  private fun reconstructPath(row: SKDB.RowValues): Path {
+    Path(this.metadata.dir, SKDB.RowKey(row, this.metadata.rowKinds))
+  }
+
+  private fun reconstructMInfo(row: SKDB.RowValues): MInfo {
+    MInfoSingle(SKDB.IndexProjKey(row, this.metadata.indexKinds))
+  }
+
+  fun maybeGet(key: Path): ?MInfo {
+    key.baseName match {
+    | SKDB.RowKey(row, _kinds) ->
+      idx = binSearch(this.data.get, row, 0, this.size() - 1);
+      if (idx >= this.data.size()) None() else Some(this.reconstructMInfo(row))
+    | _ -> None()
+    }
+  }
+
+  fun get(idx: Int): (Path, MInfo) {
+    row = this.data.get(idx);
+    path = this.reconstructPath(row);
+    minfo = this.reconstructMInfo(row);
+    (path, minfo)
+  }
+
+  fun size(): Int {
+    this.data.size()
+  }
+
+  fun items(): mutable Iterator<(Path, MInfo)> {
+    for (row in this.data.iterator()) {
+      path = this.reconstructPath(row);
+      minfo = this.reconstructMInfo(row);
+      yield (path, minfo)
+    }
+  }
+
+  static fun create(
+    data: mutable Vector<(Path, MInfo)>,
+    metadata: FSMMetadata,
+    allowDuplicates: Bool = false,
+  ): this {
+    baseNames = Vector::mcreateFromItems(
+      data.map(datum ->
+        datum.i0.baseName match {
+        | SKDB.RowKey(values, _kinds) -> values
+        | _ ->
+          invariant_violation(
+            "getMetadata ensures all path basenames are RowKeys",
+          )
+        }
+      ),
+    );
+    baseNames.sortBy(x ~> x);
+    if (!allowDuplicates) assertUnique(baseNames, x ~> x);
+    static(metadata, baseNames.toArray())
   }
 }
 

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -666,11 +666,42 @@ base class FixedSourceMap {
         | _ -> seenRowKindsOpt
         };
         minfo match {
-        | MInfoSingle(minfoKey @ SKDB.RowKey _) if (minfoKey == rowKey) ->
-          !seenMInfoTypeOpt = seenMInfoTypeOpt match {
-          | None() -> Some(FullRow())
-          | Some(FullRow()) -> seenMInfoTypeOpt
-          | _ -> return None()
+        | MInfoSingle(
+          minfoKey @ SKDB.RowKey(SKDB.RowValues(minfoRow, _), minfoKinds),
+        ) ->
+          if (minfoKey == rowKey) {
+            !seenMInfoTypeOpt = seenMInfoTypeOpt match {
+            | None() -> Some(FullRow())
+            | Some(FullRow()) -> seenMInfoTypeOpt
+            | _ -> return None()
+            }
+          } else if (pathRow.values.size() == 1) {
+            pathVal = pathRow.values[0];
+            !seenMInfoTypeOpt = seenMInfoTypeOpt match {
+            | None() ->
+              col: ?Int = None();
+              for (idx in Range(0, minfoRow.size())) {
+                if (pathVal == minfoRow[idx]) {
+                  !col = Some(idx);
+                  break void
+                }
+              };
+              col match {
+              | Some(x) -> Some(Extension(x, rowKinds))
+              | _ -> return None()
+              }
+            | Some(
+              Extension(col, extKinds),
+            ) if (
+              col < minfoRow.size() &&
+              pathVal == minfoRow[col] &&
+              extKinds == minfoKinds
+            ) ->
+              seenMInfoTypeOpt
+            | _ -> return None()
+            }
+          } else {
+            return None()
           }
         | MInfoSingle(SKDB.IndexProjKey(minfoRow, indexKinds)) ->
           if (minfoRow != pathRow) return None();
@@ -749,6 +780,13 @@ class Projection(
   rightShard: Int,
 ) extends FSMMInfoType
 
+// Each RowKey is a singleton and maps to some larger RowKey with that singleton
+// value at position col
+class Extension(
+  col: Int,
+  extKinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+) extends FSMMInfoType
+
 class FSMMetadata{
   dir: DirName,
   rowKinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
@@ -766,23 +804,47 @@ class CompactFSMImpl protected (
     | IndexProjection(indexKinds) -> SKDB.IndexProjKey(rowKey.row, indexKinds)
     | Projection(col, leftShard, rightShard) ->
       SKDB.ProjKey(rowKey.row.values[col], col, leftShard, rightShard)
+    | Extension _ -> return this.extendKey(rowKey).fromSome()
     };
     MInfoSingle(minfoKey)
+  }
+
+  private fun extendKey(rowKey: SKDB.RowKey): ?MInfo {
+    this.metadata.minfoType match {
+    | Extension(col, extKinds) ->
+      idx = binSearch(
+        i ~> this.data.get(i).values[col],
+        rowKey.row.values[0],
+        0,
+        this.size() - 1,
+      );
+      if (idx >= this.data.size()) None() else {
+        Some(MInfoSingle(SKDB.RowKey(this.data.get(idx), extKinds)))
+      }
+    | _ -> invariant_violation("Can't extend a key without extension metadata")
+    }
   }
 
   private fun reconstructKVPair(row: SKDB.RowValues): (Path, MInfo) {
     rowKey = SKDB.RowKey(row, this.metadata.rowKinds);
     path = Path(this.metadata.dir, rowKey);
-    minfo = this.reconstructMInfo(rowKey);
+    minfo = this.metadata.minfoType match {
+    | Extension _ -> this.extendKey(rowKey).fromSome()
+    | _ -> this.reconstructMInfo(rowKey)
+    };
     (path, minfo)
   }
 
   fun maybeGet(key: Path): ?MInfo {
     key.baseName match {
     | rowKey @ SKDB.RowKey(row, _kinds) ->
-      idx = binSearch(this.data.get, row, 0, this.size() - 1);
-      if (idx >= this.data.size() || row != this.data.get(idx)) None() else {
-        Some(this.reconstructMInfo(rowKey))
+      this.metadata.minfoType match {
+      | Extension _ -> this.extendKey(rowKey)
+      | _ ->
+        idx = binSearch(this.data.get, row, 0, this.size() - 1);
+        if (idx >= this.data.size() || row != this.data.get(idx)) None() else {
+          Some(this.reconstructMInfo(rowKey))
+        }
       }
     | _ -> None()
     }
@@ -807,20 +869,27 @@ class CompactFSMImpl protected (
     metadata: FSMMetadata,
     allowDuplicates: Bool = false,
   ): this {
-    baseNames = Vector::mcreateFromItems(
+    strippedData = Vector::mcreateFromItems(
       data.map(datum ->
-        datum.i0.baseName match {
-        | SKDB.RowKey(values, _kinds) -> values
-        | _ ->
-          invariant_violation(
-            "getMetadata ensures all path basenames are RowKeys",
-          )
+        if (metadata.minfoType is Extension _) {
+          datum.i1 match {
+          | MInfoSingle(SKDB.RowKey(values, _kinds)) -> values
+          | _ -> invariant_violation("malformed data for Extension metadata")
+          }
+        } else {
+          datum.i0.baseName match {
+          | SKDB.RowKey(values, _kinds) -> values
+          | _ ->
+            invariant_violation(
+              "getMetadata ensures all path basenames are RowKeys",
+            )
+          }
         }
       ),
     );
-    baseNames.sortBy(x ~> x);
-    if (!allowDuplicates) assertUnique(baseNames, x ~> x);
-    static(metadata, baseNames.toArray())
+    strippedData.sortBy(x ~> x);
+    if (!allowDuplicates) assertUnique(strippedData, x ~> x);
+    static(metadata, strippedData.toArray())
   }
 }
 

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -687,7 +687,7 @@ base class FixedSourceMap {
                 }
               };
               col match {
-              | Some(x) -> Some(Extension(x, rowKinds))
+              | Some(x) -> Some(Extension(x, minfoKinds))
               | _ -> return None()
               }
             | Some(
@@ -784,7 +784,7 @@ class Projection(
 // value at position col
 class Extension(
   col: Int,
-  extKinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
 ) extends FSMMInfoType
 
 class FSMMetadata{
@@ -804,24 +804,20 @@ class CompactFSMImpl protected (
     | IndexProjection(indexKinds) -> SKDB.IndexProjKey(rowKey.row, indexKinds)
     | Projection(col, leftShard, rightShard) ->
       SKDB.ProjKey(rowKey.row.values[col], col, leftShard, rightShard)
-    | Extension _ -> return this.extendKey(rowKey).fromSome()
+    | ext @ Extension _ -> return this.extendKey(rowKey, ext).fromSome()
     };
     MInfoSingle(minfoKey)
   }
 
-  private fun extendKey(rowKey: SKDB.RowKey): ?MInfo {
-    this.metadata.minfoType match {
-    | Extension(col, extKinds) ->
-      idx = binSearch(
-        i ~> this.data.get(i).values[col],
-        rowKey.row.values[0],
-        0,
-        this.size() - 1,
-      );
-      if (idx >= this.data.size()) None() else {
-        Some(MInfoSingle(SKDB.RowKey(this.data.get(idx), extKinds)))
-      }
-    | _ -> invariant_violation("Can't extend a key without extension metadata")
+  private fun extendKey(rowKey: SKDB.RowKey, extMetadata: Extension): ?MInfo {
+    idx = binSearch(
+      i ~> this.data.get(i).values[extMetadata.col],
+      rowKey.row.values[0],
+      0,
+      this.size() - 1,
+    );
+    if (idx >= this.data.size()) None() else {
+      Some(MInfoSingle(SKDB.RowKey(this.data.get(idx), extMetadata.kinds)))
     }
   }
 
@@ -829,7 +825,7 @@ class CompactFSMImpl protected (
     rowKey = SKDB.RowKey(row, this.metadata.rowKinds);
     path = Path(this.metadata.dir, rowKey);
     minfo = this.metadata.minfoType match {
-    | Extension _ -> this.extendKey(rowKey).fromSome()
+    | ext @ Extension _ -> this.extendKey(rowKey, ext).fromSome()
     | _ -> this.reconstructMInfo(rowKey)
     };
     (path, minfo)
@@ -839,7 +835,7 @@ class CompactFSMImpl protected (
     key.baseName match {
     | rowKey @ SKDB.RowKey(row, _kinds) ->
       this.metadata.minfoType match {
-      | Extension _ -> this.extendKey(rowKey)
+      | ext @ Extension _ -> this.extendKey(rowKey, ext)
       | _ ->
         idx = binSearch(this.data.get, row, 0, this.size() - 1);
         if (idx >= this.data.size() || row != this.data.get(idx)) None() else {

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -177,10 +177,10 @@ module SKStore;
 
 /*****************************************************************************/
 value class CompactRow<T>(
-  sourceID: SKStore.Key,
   values: Array<T>,
   repeat: Int,
   tag: TickRange,
+  sourceKey: ?SKStore.Key,
 )
 
 class DirInfo{
@@ -232,28 +232,35 @@ class CompactFixedDir{
     row: FixedRow<Array<File>>,
   ): CompactRow<?SKDB.CValue> {
     invariant(row.value.i1.size() == 1);
+    sourceKey = if (row.value.i0.baseName != row.key) {
+      Some(row.value.i0.baseName)
+    } else {
+      None()
+    };
+
     // TODO check that source key == key
     // TODO check that values in key == rowValues
     // TODO check kinds are canonical
     // TODO check repeat is 1
-    //    invariant(row.key.getRowValues() == row.value.i0.baseName);
-    result = row.value.i1[0] match {
+    row.value.i1[0] match {
     | SKDB.RowValues(values, repeat) ->
-      CompactRow(row.value.i0.baseName, values, repeat, row.tag)
+      CompactRow(values, repeat, row.tag, sourceKey)
     | _ -> invariant_violation("Unexpected type")
     };
-
-    result
   }
   protected fun decode(
     compactRow: CompactRow<?SKDB.CValue>,
   ): FixedRow<Array<File>> {
     rowValues = SKDB.RowValues(compactRow.values, compactRow.repeat);
     rowKey = SKDB.RowKey(rowValues, this.dirInfo.kinds);
+    sourceKey = compactRow.sourceKey match {
+    | None() -> rowKey
+    | Some(otherKey) -> otherKey
+    };
     FixedRow(
       rowKey,
       (
-        Source(this.dirInfo.sourceDirs.min().fromSome(), compactRow.sourceID),
+        Source(this.dirInfo.sourceDirs.min().fromSome(), sourceKey),
         Array[(rowValues : File)],
       ),
       compactRow.tag,

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -189,6 +189,13 @@ class IndexProjKey(
   kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
 ) extends SKStore.Key
 
+class ProjKey(
+  value: ?CValue,
+  colNbr: Int,
+  leftShard: Int,
+  rightShard: Int,
+) extends SKStore.Key
+
 module end;
 module SKStore;
 
@@ -643,7 +650,7 @@ base class FixedSourceMap {
   static fun getMetadata(data: readonly Vector<(Path, MInfo)>): ?FSMMetadata {
     seenDirOpt: ?DirName = None();
     seenRowKindsOpt: ?Array<(Int, SQLParser.IKind, SQLParser.Type)> = None();
-    seenIndexKindsOpt: ?Array<(Int, SQLParser.IKind, SQLParser.Type)> = None();
+    seenMInfoTypeOpt: ?FSMMInfoType = None();
 
     for ((path, minfo) in data) {
       !seenDirOpt = seenDirOpt match {
@@ -651,21 +658,38 @@ base class FixedSourceMap {
       | Some(seenDir) if (seenDir != path.dirName) -> return None()
       | _ -> seenDirOpt
       };
-      minfo match {
-      | MInfoSingle(SKDB.IndexProjKey(minfoRow, indexKinds)) ->
-        !seenIndexKindsOpt = seenIndexKindsOpt match {
-        | None() -> Some(indexKinds)
-        | Some(seenIndexKinds) if (indexKinds != seenIndexKinds) ->
-          return None()
-        | _ -> seenIndexKindsOpt
+      path.baseName match {
+      | rowKey @ SKDB.RowKey(pathRow, rowKinds) ->
+        !seenRowKindsOpt = seenRowKindsOpt match {
+        | None() -> Some(rowKinds)
+        | Some(seenRowKinds) if (rowKinds != seenRowKinds) -> return None()
+        | _ -> seenRowKindsOpt
         };
-        path.baseName match {
-        | SKDB.RowKey(pathRow, rowKinds) ->
+        minfo match {
+        | MInfoSingle(minfoKey @ SKDB.RowKey _) if (minfoKey == rowKey) ->
+          !seenMInfoTypeOpt = seenMInfoTypeOpt match {
+          | None() -> Some(FullRow())
+          | Some(FullRow()) -> seenMInfoTypeOpt
+          | _ -> return None()
+          }
+        | MInfoSingle(SKDB.IndexProjKey(minfoRow, indexKinds)) ->
           if (minfoRow != pathRow) return None();
-          !seenRowKindsOpt = seenRowKindsOpt match {
-          | None() -> Some(rowKinds)
-          | Some(seenRowKinds) if (rowKinds != seenRowKinds) -> return None()
-          | _ -> seenRowKindsOpt
+          !seenMInfoTypeOpt = seenMInfoTypeOpt match {
+          | None() -> Some(IndexProjection(indexKinds))
+          | Some(
+            IndexProjection(seenIndexKinds),
+          ) if (indexKinds == seenIndexKinds) ->
+            seenMInfoTypeOpt
+          | _ -> None()
+          }
+        | MInfoSingle(SKDB.ProjKey(_value, col, left, right)) ->
+          !seenMInfoTypeOpt = seenMInfoTypeOpt match {
+          | None() -> Some(Projection(col, left, right))
+          | Some(
+            Projection(pCol, pLeft, pRight),
+          ) if (col == pCol && left == pLeft && right == pRight) ->
+            seenMInfoTypeOpt
+          | _ -> None()
           }
         | _ -> return None()
         }
@@ -674,9 +698,7 @@ base class FixedSourceMap {
     };
     seenDirOpt.flatMap(dir ->
       seenRowKindsOpt.flatMap(rowKinds ->
-        seenIndexKindsOpt.map(indexKinds ->
-          FSMMetadata{dir, rowKinds, indexKinds}
-        )
+        seenMInfoTypeOpt.map(minfoType -> FSMMetadata{dir, rowKinds, minfoType})
       )
     )
   }
@@ -706,10 +728,21 @@ class FSMImpl(protected data: FixedSingle<Path, MInfo>) extends FixedSourceMap {
   }
 }
 
+base class FSMMInfoType
+class IndexProjection(
+  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+) extends FSMMInfoType
+class Projection(
+  col: Int,
+  leftShard: Int,
+  rightShard: Int,
+) extends FSMMInfoType
+class FullRow() extends FSMMInfoType
+
 class FSMMetadata{
   dir: DirName,
   rowKinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
-  indexKinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+  minfoType: FSMMInfoType,
 }
 // More-compact representation of a FixedSourceMap, with shared information
 // extracted out of the individual key/val pairs and reconstructed on demand
@@ -717,28 +750,36 @@ class CompactFSMImpl protected (
   metadata: FSMMetadata,
   data: Array<SKDB.RowValues>,
 ) extends FixedSourceMap {
-  private fun reconstructPath(row: SKDB.RowValues): Path {
-    Path(this.metadata.dir, SKDB.RowKey(row, this.metadata.rowKinds))
+  private fun reconstructMInfo(rowKey: SKDB.RowKey): MInfo {
+    minfoKey = this.metadata.minfoType match {
+    | FullRow() -> rowKey
+    | IndexProjection(indexKinds) -> SKDB.IndexProjKey(rowKey.row, indexKinds)
+    | Projection(col, leftShard, rightShard) ->
+      SKDB.ProjKey(rowKey.row.values[col], col, leftShard, rightShard)
+    };
+    MInfoSingle(minfoKey)
   }
 
-  private fun reconstructMInfo(row: SKDB.RowValues): MInfo {
-    MInfoSingle(SKDB.IndexProjKey(row, this.metadata.indexKinds))
+  private fun reconstructKVPair(row: SKDB.RowValues): (Path, MInfo) {
+    rowKey = SKDB.RowKey(row, this.metadata.rowKinds);
+    path = Path(this.metadata.dir, rowKey);
+    minfo = this.reconstructMInfo(rowKey);
+    (path, minfo)
   }
 
   fun maybeGet(key: Path): ?MInfo {
     key.baseName match {
-    | SKDB.RowKey(row, _kinds) ->
+    | rowKey @ SKDB.RowKey(row, _kinds) ->
       idx = binSearch(this.data.get, row, 0, this.size() - 1);
-      if (idx >= this.data.size()) None() else Some(this.reconstructMInfo(row))
+      if (idx >= this.data.size()) None() else {
+        Some(this.reconstructMInfo(rowKey))
+      }
     | _ -> None()
     }
   }
 
   fun get(idx: Int): (Path, MInfo) {
-    row = this.data.get(idx);
-    path = this.reconstructPath(row);
-    minfo = this.reconstructMInfo(row);
-    (path, minfo)
+    this.reconstructKVPair(this.data.get(idx))
   }
 
   fun size(): Int {
@@ -747,9 +788,7 @@ class CompactFSMImpl protected (
 
   fun items(): mutable Iterator<(Path, MInfo)> {
     for (row in this.data.iterator()) {
-      path = this.reconstructPath(row);
-      minfo = this.reconstructMInfo(row);
-      yield (path, minfo)
+      yield this.reconstructKVPair(row)
     }
   }
 

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -121,17 +121,11 @@ class FixedDir<T: frozen> extends FixedDirImpl<T, FixedRow<T>> {
       data.sortBy(row ~> (row.key, row.value.i0));
     };
     _ = static::computeTags(data, 0, data.size() - 1);
-    static{
-      state => None(),
-      data => data.map(x -> static::compress(None(), x)).toArray(),
-    }
+    static{data => data.toArray()}
   }
 
-  static fun compress(?CompressState, x: FixedRow<T>): FixedRow<T> {
-    x
-  }
-  static fun decompress(?CompressState, x: FixedRow<T>): FixedRow<T> {
-    x
+  protected fun decode(row: FixedRow<T>): FixedRow<T> {
+    row
   }
 }
 /*****************************************************************************/
@@ -182,76 +176,31 @@ module end;
 module SKStore;
 
 /*****************************************************************************/
-value class CompressedRow(
+value class CompactRow<T>(
   sourceID: SKStore.Key,
-  values: Array<?SKDB.CValue>,
+  values: Array<T>,
+  repeat: Int,
   tag: TickRange,
 )
 
-class CompressState{
+class DirInfo{
   sourceDirs: SortedSet<DirName>,
   keyIsSameAsValue: Bool,
   isAlwaysSize1: Bool,
   kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
 }
 
-class CompressedFixedDir extends FixedDirImpl<Array<File>, CompressedRow> {
-  static fun compress(
-    state: ?CompressState,
-    row: FixedRow<Array<File>>,
-  ): CompressedRow {
-    st = state match {
-    | None() -> invariant_violation("Expected a state")
-    | Some(x) -> x
-    };
-    invariant(st.sourceDirs.size() == 1);
-    invariant(row.value.i1.size() == 1);
-    // TODO check that source key == key
-    // TODO check that values in key == rowValues
-    // TODO check kinds are canonical
-    // TODO check repeat is 1
-    //    invariant(row.key.getRowValues() == row.value.i0.baseName);
-    result = CompressedRow(
-      row.value.i0.baseName,
-      row.value.i1[0] match {
-      | SKDB.RowValues(values, _kinds) -> values
-      | _ -> invariant_violation("Unexpected type")
-      },
-      row.tag,
-    );
-    //    debug(row);
-    //    debug(static::decompress(state, result));
-    invariant(inspect(static::decompress(state, result)) == inspect(row));
-    result
-  }
-  static fun decompress(
-    state: ?CompressState,
-    row: CompressedRow,
-  ): FixedRow<Array<File>> {
-    st = state match {
-    | None() -> invariant_violation("Expected a state")
-    | Some(x) -> x
-    };
-    rowValues = SKDB.RowValues(row.values, 1);
-    rowKey = SKDB.RowKey(rowValues, st.kinds);
-    FixedRow(
-      rowKey,
-      (
-        Source(st.sourceDirs.min().fromSome(), row.sourceID),
-        Array[(rowValues : File)],
-      ),
-      row.tag,
-    )
-  }
-
+// This is a more compact representation of a FixedDir, keeping some shared
+// info about the directory (dirInfo) and stripping redundant repeated data
+// out of the rows themselves.
+class CompactFixedDir{
+  dirInfo: DirInfo,
+} extends FixedDirImpl<Array<File>, CompactRow<?SKDB.CValue>> {
   static fun create(
-    stateOption: ?CompressState,
-    data: mutable Vector<FixedRow<Array<File>>> = mutable Vector[],
+    data: mutable Vector<FixedRow<Array<File>>>,
+    dirInfo: DirInfo,
   ): this {
-    state = stateOption match {
-    | None() -> invariant_violation("Expected a state")
-    | Some(x) -> x
-    };
+    invariant(dirInfo.sourceDirs.size() == 1);
     i = 0;
     sz = data.size();
     sorted = loop {
@@ -272,30 +221,60 @@ class CompressedFixedDir extends FixedDirImpl<Array<File>, CompressedRow> {
       data.sortBy(row ~> (row.key, row.value.i0));
     };
     _ = static::computeTags(data, 0, data.size() - 1);
-    invariant(state.keyIsSameAsValue);
-    static{
-      state => stateOption,
-      data => data.map(x -> static::compress(stateOption, x)).toArray(),
-    }
+    invariant(dirInfo.keyIsSameAsValue);
+    res: CompactFixedDir = static{
+      data => data.map(static::stripDirInfo).toArray(),
+      dirInfo => dirInfo,
+    };
+    res
+  }
+  protected static fun stripDirInfo(
+    row: FixedRow<Array<File>>,
+  ): CompactRow<?SKDB.CValue> {
+    invariant(row.value.i1.size() == 1);
+    // TODO check that source key == key
+    // TODO check that values in key == rowValues
+    // TODO check kinds are canonical
+    // TODO check repeat is 1
+    //    invariant(row.key.getRowValues() == row.value.i0.baseName);
+    result = row.value.i1[0] match {
+    | SKDB.RowValues(values, repeat) ->
+      CompactRow(row.value.i0.baseName, values, repeat, row.tag)
+    | _ -> invariant_violation("Unexpected type")
+    };
+
+    result
+  }
+  protected fun decode(
+    compactRow: CompactRow<?SKDB.CValue>,
+  ): FixedRow<Array<File>> {
+    rowValues = SKDB.RowValues(compactRow.values, compactRow.repeat);
+    rowKey = SKDB.RowKey(rowValues, this.dirInfo.kinds);
+    FixedRow(
+      rowKey,
+      (
+        Source(this.dirInfo.sourceDirs.min().fromSome(), compactRow.sourceID),
+        Array[(rowValues : File)],
+      ),
+      compactRow.tag,
+    )
   }
 }
 
-base class FixedDirImpl<T: frozen, Compressed: frozen> protected {
-  state: ?CompressState,
-  data: Array<Compressed> = Array[],
+//Defines the public interface of a FixedDir, allowing for some alternative
+// internal RowRepresentation of conceptually-FixedRow<T> rows.
+base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
+  data: Array<RowRepresentation> = Array[],
 } extends FixedData<T> {
-  static fun compress(?CompressState, FixedRow<T>): Compressed;
-  static fun decompress(?CompressState, Compressed): FixedRow<T>;
+  protected fun decode(repr: RowRepresentation): FixedRow<T>;
 
   fun iterator(): mutable Iterator<FixedRow<T>> {
     for (elt in this.data.iterator()) {
-      yield static::decompress(this.state, elt)
+      yield this.decode(elt)
     }
   }
 
-  static fun isCompressable(
-    data: mutable Vector<FixedRow<Array<File>>>,
-  ): ?CompressState {
+  static fun getDirInfo(data: mutable Vector<FixedRow<Array<File>>>): ?DirInfo {
     if (data.size() == 0) return None();
     sourceDirs = SortedSet[];
     kinds: ?Array<(Int, SQLParser.IKind, SQLParser.Type)> = None();
@@ -307,7 +286,11 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> protected {
       | (SKDB.RowKey(row1, k), row2 @ SKDB.RowValues _) ->
         kinds match {
         | None() -> !kinds = Some(k)
-        | Some(k2) -> invariant(k == k2)
+        | Some(k2) ->
+          invariant(
+            k == k2,
+            "Mismatched kinds in table " + elt.value.i0.dirName,
+          )
         };
         !sourceDirs = sourceDirs.set(elt.value.i0.dirName);
         if (row1 != row2) return None()
@@ -315,7 +298,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> protected {
       }
     };
     Some(
-      CompressState{
+      DirInfo{
         sourceDirs,
         kinds => kinds.fromSome(),
         keyIsSameAsValue,
@@ -329,7 +312,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> protected {
   }
 
   fun get(idx: Int): FixedRow<T> {
-    static::decompress(this.state, this.data.unsafe_get(idx))
+    this.decode(this.data.unsafe_get(idx))
   }
 
   fun getPos(key: Key): Int {
@@ -397,7 +380,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> protected {
       return void;
     };
     pivot = i + (j - i) / 2;
-    elt = static::decompress(this.state, this.data[pivot]);
+    elt = this.decode(this.data[pivot]);
     tick = elt.tag;
     if (tick.max < after) return void;
     if (tick.current >= after) {
@@ -426,7 +409,7 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> protected {
   ): void {
     if (i <= j) {
       pivot = i + (j - i) / 2;
-      elt = static::decompress(this.state, this.data[pivot]);
+      elt = this.decode(this.data[pivot]);
       tick = elt.tag;
       if (tick.max >= after) {
         if (key <= elt.key) {
@@ -455,8 +438,8 @@ base class FixedDirImpl<T: frozen, Compressed: frozen> protected {
       None()
     } else {
       middle = (this.data.size() - 1) / 2;
-      tick = static::decompress(this.state, this.data[middle]).tag;
-      Some(tick.max)
+      tickRange = this.decode(this.data[middle]).tag;
+      Some(tickRange.max)
     }
   }
 }

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -48,6 +48,7 @@ base class FixedData<T> {
   fun getIterSourceKey(source: Source, key: Key): mutable Iterator<T>;
   fun getChangesAfter(tick: Tick): SortedSet<Key>;
   fun getTick(): ?Tick;
+  fun iterator(): mutable Iterator<FixedRow<T>>;
 }
 
 // Assuming delta is monotone, that is, i <= j implies delta(i) <= delta(j),
@@ -96,10 +97,46 @@ fun binSearch<T: Orderable>(get: Int ~> T, key: T, i: Int, j: Int): Int {
   findFirstBy(idx ~> key.compare(get(idx)), i, j)
 }
 
-class FixedDir<T: frozen> private {
-  data: Array<FixedRow<T>> = Array[],
+class FixedDir<T: frozen> extends FixedDirImpl<T, FixedRow<T>> {
+  static fun compress(x: FixedRow<T>): FixedRow<T> {
+    x
+  }
+  static fun decompress(x: FixedRow<T>): FixedRow<T> {
+    x
+  }
+}
+
+class CompressedFixedDir extends FixedDirImpl<Array<File>, FixedRow<File>> {
+  static fun compress(row: FixedRow<Array<File>>): FixedRow<File> {
+    size = row.value.i1.size();
+    invariant(size == 1);
+    FixedRow(row.key, (row.value.i0, row.value.i1[0]), row.tag);
+  }
+  static fun decompress(row: FixedRow<File>): FixedRow<Array<File>> {
+    FixedRow(row.key, (row.value.i0, Array[row.value.i1]), row.tag)
+  }
+}
+
+base class FixedDirImpl<T: frozen, Compressed: frozen> private final {
+  data: Array<Compressed> = Array[],
 } extends FixedData<T> {
-  static fun create(
+  static fun compress(FixedRow<T>): Compressed;
+  static fun decompress(Compressed): FixedRow<T>;
+
+  fun iterator(): mutable Iterator<FixedRow<T>> {
+    for (elt in this.data.iterator()) {
+      yield static::decompress(elt)
+    }
+  }
+
+  static fun isCompressable(data: mutable Vector<FixedRow<Array<File>>>): Bool {
+    for (elt in data) {
+      if (elt.value.i1.size() != 1) return false;
+    };
+    true
+  }
+
+  static deferred fun create<C: FixedDirImpl<T, Compressed>>(
     data: mutable Vector<FixedRow<T>> = mutable Vector[],
   ): this {
     i = 0;
@@ -122,7 +159,7 @@ class FixedDir<T: frozen> private {
       data.sortBy(row ~> (row.key, row.value.i0));
     };
     _ = static::computeTags(data, 0, data.size() - 1);
-    FixedDir{data => data.toArray()}
+    static{data => data.map(static::compress).toArray()}
   }
 
   fun size(): Int {
@@ -130,7 +167,7 @@ class FixedDir<T: frozen> private {
   }
 
   fun get(idx: Int): FixedRow<T> {
-    this.data.unsafe_get(idx)
+    static::decompress(this.data.unsafe_get(idx))
   }
 
   fun getPos(key: Key): Int {
@@ -198,7 +235,7 @@ class FixedDir<T: frozen> private {
       return void;
     };
     pivot = i + (j - i) / 2;
-    elt = this.data[pivot];
+    elt = static::decompress(this.data[pivot]);
     tick = elt.tag;
     if (tick.max < after) return void;
     if (tick.current >= after) {
@@ -227,7 +264,7 @@ class FixedDir<T: frozen> private {
   ): void {
     if (i <= j) {
       pivot = i + (j - i) / 2;
-      elt = this.data[pivot];
+      elt = static::decompress(this.data[pivot]);
       tick = elt.tag;
       if (tick.max >= after) {
         if (key <= elt.key) {
@@ -256,7 +293,7 @@ class FixedDir<T: frozen> private {
       None()
     } else {
       middle = (this.data.size() - 1) / 2;
-      tick = this.data[middle].tag;
+      tick = static::decompress(this.data[middle]).tag;
       Some(tick.max)
     }
   }

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -150,8 +150,6 @@ value class CompactRow<T>(
 
 class FixedDirMetadata{
   sourceDir: DirName,
-  keyIsSameAsValue: Bool,
-  isAlwaysSize1: Bool,
   kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
 }
 
@@ -185,7 +183,6 @@ class CompactFixedDir{
       data.sortBy(row ~> (row.key, row.source));
     };
     _ = static::computeTags(data, 0, data.size() - 1);
-    invariant(metadata.keyIsSameAsValue);
     static{
       data => data.map(static::stripMetadata).toArray(),
       metadata => metadata,
@@ -245,7 +242,6 @@ base class IFixedDir<T: frozen, RowRepresentation: frozen> protected {
     sourceDir: ?DirName = None();
     kinds: ?Array<(Int, SQLParser.IKind, SQLParser.Type)> = None();
 
-    keyIsSameAsValue = true;
     for (elt in data) {
       if (elt.value.size() != 1) return None();
       (elt.key, elt.value[0]) match {
@@ -265,12 +261,7 @@ base class IFixedDir<T: frozen, RowRepresentation: frozen> protected {
       }
     };
     sourceDir.map(sourceDir ->
-      FixedDirMetadata{
-        sourceDir,
-        kinds => kinds.fromSome(),
-        keyIsSameAsValue,
-        isAlwaysSize1 => true,
-      }
+      FixedDirMetadata{sourceDir, kinds => kinds.fromSome()}
     )
   }
 

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -87,7 +87,7 @@ fun binSearch<T: Orderable>(get: Int ~> T, key: T, i: Int, j: Int): Int {
   findFirstBy(idx ~> key.compare(get(idx)), i, j)
 }
 
-class FixedDir<T: frozen> extends FixedDirImpl<T, FixedRow<T>> {
+class FixedDir<T: frozen> extends IFixedDir<T, FixedRow<T>> {
   static fun create(
     data: mutable Vector<FixedRow<T>> = mutable Vector[],
   ): this {
@@ -173,7 +173,7 @@ value class CompactRow<T>(
   sourceKey: ?SKStore.Key,
 )
 
-class DirInfo{
+class FixedDirMetadata{
   sourceDir: DirName,
   keyIsSameAsValue: Bool,
   isAlwaysSize1: Bool,
@@ -181,14 +181,14 @@ class DirInfo{
 }
 
 // This is a more compact representation of a FixedDir, keeping some shared
-// info about the directory (dirInfo) and stripping redundant repeated data
+// metadata about the directory and stripping redundant repeated data
 // out of the rows themselves.
 class CompactFixedDir{
-  dirInfo: DirInfo,
-} extends FixedDirImpl<Array<File>, CompactRow<?SKDB.CValue>> {
+  metadata: FixedDirMetadata,
+} extends IFixedDir<Array<File>, CompactRow<?SKDB.CValue>> {
   static fun create(
     data: mutable Vector<FixedRow<Array<File>>>,
-    dirInfo: DirInfo,
+    metadata: FixedDirMetadata,
   ): this {
     i = 0;
     sz = data.size();
@@ -210,14 +210,13 @@ class CompactFixedDir{
       data.sortBy(row ~> (row.key, row.source));
     };
     _ = static::computeTags(data, 0, data.size() - 1);
-    invariant(dirInfo.keyIsSameAsValue);
-    res: CompactFixedDir = static{
-      data => data.map(static::stripDirInfo).toArray(),
-      dirInfo => dirInfo,
-    };
-    res
+    invariant(metadata.keyIsSameAsValue);
+    static{
+      data => data.map(static::stripMetadata).toArray(),
+      metadata => metadata,
+    }
   }
-  protected static fun stripDirInfo(
+  protected static fun stripMetadata(
     row: FixedRow<Array<File>>,
   ): CompactRow<?SKDB.CValue> {
     invariant(row.value.size() == 1);
@@ -227,10 +226,6 @@ class CompactFixedDir{
       None()
     };
 
-    // TODO check that source key == key
-    // TODO check that values in key == rowValues
-    // TODO check kinds are canonical
-    // TODO check repeat is 1
     row.value[0] match {
     | SKDB.RowValues(values, repeat) ->
       CompactRow(values, repeat, row.tag, sourceKey)
@@ -241,7 +236,7 @@ class CompactFixedDir{
     compactRow: CompactRow<?SKDB.CValue>,
   ): FixedRow<Array<File>> {
     rowValues = SKDB.RowValues(compactRow.values, compactRow.repeat);
-    rowKey = SKDB.RowKey(rowValues, this.dirInfo.kinds);
+    rowKey = SKDB.RowKey(rowValues, this.metadata.kinds);
     sourceKey = compactRow.sourceKey match {
     | None() -> rowKey
     | Some(otherKey) -> otherKey
@@ -249,7 +244,7 @@ class CompactFixedDir{
     FixedRow(
       rowKey,
       Array[(rowValues : File)],
-      Path(this.dirInfo.sourceDir, sourceKey),
+      Path(this.metadata.sourceDir, sourceKey),
       compactRow.tag,
     )
   }
@@ -257,7 +252,7 @@ class CompactFixedDir{
 
 //Defines the public interface of a FixedDir, allowing for some alternative
 // internal RowRepresentation of conceptually-FixedRow<T> rows.
-base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
+base class IFixedDir<T: frozen, RowRepresentation: frozen> protected {
   data: Array<RowRepresentation> = Array[],
 } extends FixedData<T> {
   protected fun decode(repr: RowRepresentation): FixedRow<T>;
@@ -268,7 +263,9 @@ base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
     }
   }
 
-  static fun getDirInfo(data: mutable Vector<FixedRow<Array<File>>>): ?DirInfo {
+  static fun getMetadata(
+    data: mutable Vector<FixedRow<Array<File>>>,
+  ): ?FixedDirMetadata {
     if (data.size() == 0) return None();
     sourceDir: ?DirName = None();
     kinds: ?Array<(Int, SQLParser.IKind, SQLParser.Type)> = None();
@@ -293,7 +290,7 @@ base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
       }
     };
     sourceDir.map(sourceDir ->
-      DirInfo{
+      FixedDirMetadata{
         sourceDir,
         kinds => kinds.fromSome(),
         keyIsSameAsValue,

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -575,20 +575,25 @@ class FixedSingle<K: Orderable, +V: frozen>(data: Array<(K, V)> = Array[]) {
     static::create(Vector::mcreateFromItems(items));
   }
 
-  static fun create(data: mutable Vector<(K, V)>, dedup: Bool = false): this {
+  static fun create(
+    data: mutable Vector<(K, V)>,
+    allowDuplicates: Bool = false,
+  ): FixedSingle<K, V> {
     data.sortBy(x ~> x.i0);
 
-    lastOpt: ?K = None();
-    for (kv in data) {
-      (k, _) = kv;
-      lastOpt match {
-      | None() -> !lastOpt = Some(k)
-      | Some(last) ->
-        if (last == k && !dedup) {
-          debug((last, k));
-          invariant_violation("Duplicate value in single")
-        } else {
-          !lastOpt = Some(k)
+    if (!allowDuplicates) {
+      lastOpt: ?K = None();
+      for (kv in data) {
+        (k, _) = kv;
+        lastOpt match {
+        | None() -> !lastOpt = Some(k)
+        | Some(last) ->
+          if (last == k) {
+            debug((last, k));
+            invariant_violation("Duplicate value in single")
+          } else {
+            !lastOpt = Some(k)
+          }
         }
       }
     };

--- a/skfs/src/FixedDir.sk
+++ b/skfs/src/FixedDir.sk
@@ -20,19 +20,9 @@
 /*****************************************************************************/
 module SKStore;
 
-value class Source(dirName: DirName, baseName: Key) uses Orderable {
-  static fun create(value: Path): this {
-    static(value.dirName, value.baseName)
-  }
-
-  fun path(): Path {
-    Path(this.dirName, this.baseName)
-  }
-}
-
-value class FixedRow<T>(key: Key, value: (Source, T), tag: TickRange) {
-  fun changeSource(source: Source): this {
-    !this.value.i0 = source;
+value class FixedRow<T>(key: Key, value: T, source: Path, tag: TickRange) {
+  fun changeSource(source: Path): this {
+    !this.source = source;
     this
   }
 }
@@ -41,11 +31,11 @@ base class FixedData<T> {
   fun size(): Int;
   fun get(idx: Int): FixedRow<T>;
   fun getPos(key: Key): Int;
-  fun getArray(key: Key): Array<(Source, T)>;
-  fun getIter(key: Key): mutable Iterator<(Tick, Source, T)>;
-  fun getIterAfter(tick: Tick, key: Key): mutable Iterator<(Tick, Source, T)>;
-  fun getArraySourceKey(source: Source, key: Key): Array<T>;
-  fun getIterSourceKey(source: Source, key: Key): mutable Iterator<T>;
+  fun getArray(key: Key): Array<T>;
+  fun getIter(key: Key): mutable Iterator<(Tick, Path, T)>;
+  fun getIterAfter(tick: Tick, key: Key): mutable Iterator<(Tick, Path, T)>;
+  fun getArraySourceKey(source: Path, key: Key): Array<T>;
+  fun getIterSourceKey(source: Path, key: Key): mutable Iterator<T>;
   fun getChangesAfter(tick: Tick): SortedSet<Key>;
   fun getTick(): ?Tick;
   fun iterator(): mutable Iterator<FixedRow<T>>;
@@ -110,7 +100,7 @@ class FixedDir<T: frozen> extends FixedDirImpl<T, FixedRow<T>> {
       keyComparison match {
       | LT() -> continue
       | GT() -> break false
-      | EQ() -> data[i - 1].value.i0.compare(data[i].value.i0)
+      | EQ() -> data[i - 1].source.compare(data[i].source)
       } match {
       | LT() -> continue
       | EQ() -> continue
@@ -118,7 +108,7 @@ class FixedDir<T: frozen> extends FixedDirImpl<T, FixedRow<T>> {
       };
     };
     if (!sorted) {
-      data.sortBy(row ~> (row.key, row.value.i0));
+      data.sortBy(row ~> (row.key, row.source));
     };
     _ = static::computeTags(data, 0, data.size() - 1);
     static{data => data.toArray()}
@@ -209,7 +199,7 @@ class CompactFixedDir{
       keyComparison match {
       | LT() -> continue
       | GT() -> break false
-      | EQ() -> data[i - 1].value.i0.compare(data[i].value.i0)
+      | EQ() -> data[i - 1].source.compare(data[i].source)
       } match {
       | LT() -> continue
       | EQ() -> continue
@@ -217,7 +207,7 @@ class CompactFixedDir{
       };
     };
     if (!sorted) {
-      data.sortBy(row ~> (row.key, row.value.i0));
+      data.sortBy(row ~> (row.key, row.source));
     };
     _ = static::computeTags(data, 0, data.size() - 1);
     invariant(dirInfo.keyIsSameAsValue);
@@ -230,9 +220,9 @@ class CompactFixedDir{
   protected static fun stripDirInfo(
     row: FixedRow<Array<File>>,
   ): CompactRow<?SKDB.CValue> {
-    invariant(row.value.i1.size() == 1);
-    sourceKey = if (row.value.i0.baseName != row.key) {
-      Some(row.value.i0.baseName)
+    invariant(row.value.size() == 1);
+    sourceKey = if (row.source.baseName != row.key) {
+      Some(row.source.baseName)
     } else {
       None()
     };
@@ -241,7 +231,7 @@ class CompactFixedDir{
     // TODO check that values in key == rowValues
     // TODO check kinds are canonical
     // TODO check repeat is 1
-    row.value.i1[0] match {
+    row.value[0] match {
     | SKDB.RowValues(values, repeat) ->
       CompactRow(values, repeat, row.tag, sourceKey)
     | _ -> invariant_violation("Unexpected type")
@@ -258,7 +248,8 @@ class CompactFixedDir{
     };
     FixedRow(
       rowKey,
-      (Source(this.dirInfo.sourceDir, sourceKey), Array[(rowValues : File)]),
+      Array[(rowValues : File)],
+      Path(this.dirInfo.sourceDir, sourceKey),
       compactRow.tag,
     )
   }
@@ -284,20 +275,17 @@ base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
 
     keyIsSameAsValue = true;
     for (elt in data) {
-      if (elt.value.i1.size() != 1) return None();
-      (elt.key, elt.value.i1[0]) match {
+      if (elt.value.size() != 1) return None();
+      (elt.key, elt.value[0]) match {
       | (SKDB.RowKey(row1, k), row2 @ SKDB.RowValues _) ->
         kinds match {
         | None() -> !kinds = Some(k)
         | Some(k2) ->
-          invariant(
-            k == k2,
-            "Mismatched kinds in table " + elt.value.i0.dirName,
-          )
+          invariant(k == k2, "Mismatched kinds in table " + elt.source.dirName)
         };
         !sourceDir = sourceDir match {
-        | None() -> Some(elt.source.path.dirName)
-        | sd @ Some(dir) if (dir == elt.source.path.dirName) -> sd
+        | None() -> Some(elt.source.dirName)
+        | sd @ Some(dir) if (dir == elt.source.dirName) -> sd
         | _ -> return None()
         };
         if (row1 != row2) return None()
@@ -330,32 +318,32 @@ base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
     findAll(i ~> this.get(i).key, key, 0, this.size() - 1)
   }
 
-  fun getAllSourceKey(source: Source, key: Key): mutable Iterator<Int> {
+  fun getAllSourceKey(source: Path, key: Key): mutable Iterator<Int> {
     delta = i ~> {
       entry = this.get(i);
       c = key.compare(entry.key);
       if (c != EQ()) return c;
-      source.compare(entry.value.i0)
+      source.compare(entry.source)
     };
     findAllBy(delta, 0, this.size() - 1)
   }
 
-  fun getArray(key: Key): Array<(Source, T)> {
+  fun getArray(key: Key): Array<T> {
     this.getAll(key).map(i ~> this.get(i).value).collect(Array)
   }
 
-  fun getIter(key: Key): mutable Iterator<(Tick, Source, T)> {
+  fun getIter(key: Key): mutable Iterator<(Tick, Path, T)> {
     this.getAll(key).map(i -> {
       elt = this.get(i);
-      (elt.tag.current, elt.value.i0, elt.value.i1)
+      (elt.tag.current, elt.source, elt.value)
     })
   }
 
-  fun getIterSourceKey(source: Source, key: Key): mutable Iterator<T> {
-    this.getAllSourceKey(source, key).map(i -> this.get(i).value.i1)
+  fun getIterSourceKey(source: Path, key: Key): mutable Iterator<T> {
+    this.getAllSourceKey(source, key).map(i -> this.get(i).value)
   }
 
-  fun getArraySourceKey(source: Source, key: Key): Array<T> {
+  fun getArraySourceKey(source: Path, key: Key): Array<T> {
     this.getIterSourceKey(source, key).collect(Array)
   }
 
@@ -412,7 +400,7 @@ base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
     key: Key,
     i: Int,
     j: Int,
-    acc: mutable Vector<(Tick, Source, T)>,
+    acc: mutable Vector<(Tick, Path, T)>,
   ): void {
     if (i <= j) {
       pivot = i + (j - i) / 2;
@@ -424,7 +412,7 @@ base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
         };
         if (tick.current >= after) {
           if (elt.key.compare(key) is EQ()) {
-            acc.push((tick.current, elt.value.i0, elt.value.i1));
+            acc.push((tick.current, elt.source, elt.value));
           }
         };
         if (key >= elt.key) {
@@ -434,7 +422,7 @@ base class FixedDirImpl<T: frozen, RowRepresentation: frozen> protected {
     }
   }
 
-  fun getIterAfter(limit: Tick, key: Key): mutable Iterator<(Tick, Source, T)> {
+  fun getIterAfter(limit: Tick, key: Key): mutable Iterator<(Tick, Path, T)> {
     acc = mutable Vector[];
     this.getKeyChangesAfter(limit, key, 0, this.data.size() - 1, acc);
     acc.iterator()

--- a/skfs/src/SKDBTypes.sk
+++ b/skfs/src/SKDBTypes.sk
@@ -1,0 +1,57 @@
+/*****************************************************************************/
+/* Some SQL types are exposed here to enable specializing SKFS operations to */
+/* structures/patterns found in SKDB without inducing any cyclic dependency */
+/* in the build process. */
+/*****************************************************************************/
+
+module SQLParser;
+
+base class Type uses Orderable {
+  children =
+  | FLOAT()
+  | INTEGER()
+  | TEXT()
+  | JSON()
+  | SCHEMA()
+}
+
+base class IKind uses Orderable {
+  children =
+  | INONE()
+  | IASC()
+  | IDESC()
+}
+
+module end;
+module SKDB;
+
+base class CValue uses Orderable {
+  children =
+  | CInt(value: Int)
+  | CFloat(value: Float)
+  | CString(value: String)
+}
+
+class RowKey(
+  row: RowValues,
+  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+) extends SKStore.Key
+
+class RowValues(
+  values: Array<?CValue>,
+  repeat: Int,
+) uses Orderable extends SKStore.File
+
+class IndexProjKey(
+  row: RowValues,
+  kinds: Array<(Int, SQLParser.IKind, SQLParser.Type)>,
+) extends SKStore.Key
+
+class ProjKey(
+  value: ?CValue,
+  colNbr: Int,
+  leftShard: Int,
+  rightShard: Int,
+) extends SKStore.Key
+
+module end;

--- a/skfs/tests/StressTest.sk
+++ b/skfs/tests/StressTest.sk
@@ -399,7 +399,7 @@ fun compareContext(
           for (fixed in fixedData.getIter(key)) {
             (_, k, _, files) = fixed;
             intFiles = files.map(file -> SKStore.IntFile::type(file));
-            print_string(`FIXED  ${k.path()} => ${intFiles}`)
+            print_string(`FIXED  ${k} => ${intFiles}`)
           }
         | _ -> void
         };
@@ -423,7 +423,7 @@ fun compareContext(
             for (tickSource => files in sources) {
               (_, k, _) = tickSource;
               intFiles = files.map(file -> SKStore.IntFile::type(file));
-              print_string(`       ${k.path()} => ${intFiles}`)
+              print_string(`       ${k} => ${intFiles}`)
             }
           }
         | _ -> void
@@ -435,7 +435,7 @@ fun compareContext(
           for (fixed in fixedData.getIter(key)) {
             (_, k, _, files) = fixed;
             intFiles = files.map(file -> SKStore.IntFile::type(file));
-            print_string(`FIXED  ${k.path()} => ${intFiles}`)
+            print_string(`FIXED  ${k} => ${intFiles}`)
           }
         | _ -> void
         };

--- a/skfs/tests/TestFixedDirTime.sk
+++ b/skfs/tests/TestFixedDirTime.sk
@@ -15,8 +15,7 @@ fun testFixedDirTime(): void {
     for (i in Range(0, valueSize)) {
       baseName = SKStore.IID(i);
       path = SKStore.Path::create(dirName, baseName);
-      source = SKStore.Source::create(path);
-      !map[source] = Array[
+      !map[path] = Array[
         (SKStore.IntFile(rand.random(0, valueSize)) : SKStore.File),
       ];
     };
@@ -30,7 +29,7 @@ fun testFixedDirTime(): void {
   dmap.itemsWithTick().each(item -> {
     (key, valueMap, tick) = item;
     for (source => value in valueMap) {
-      acc.push(SKStore.FixedRow(key, (source, value), tick))
+      acc.push(SKStore.FixedRow(key, value, source, tick))
     }
   });
   farr = SKStore.FixedDir::create(acc);

--- a/sktest/Skargo.toml
+++ b/sktest/Skargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 
 [dependencies]
 cli = { "path" = "../cli" }
-std = { "path" = "../prelude" }

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -393,6 +393,15 @@ fun execSessions(args: Cli.ParseResults, options: SKDB.Options): void {
   })
 }
 
+/*** DEBUG ***/
+class MyData(
+  value: Array<
+    (SKStore.Key, (SKStore.Source, Array<SKStore.File>), SKStore.TickRange),
+  >,
+) extends SKStore.File
+const myKey: SKStore.IID = SKStore.IID(0);
+/*** END OF DEBUG ***/
+
 fun execCompact(args: Cli.ParseResults, options: SKDB.Options): void {
   ensureContext(args);
   SKDB.runLockedSql(options, context ~> {
@@ -400,6 +409,28 @@ fun execCompact(args: Cli.ParseResults, options: SKDB.Options): void {
       dir match {
       | edir @ SKStore.EagerDir _ ->
         !edir = edir.purge(context, context.tick);
+        /*** DEBUG ***/
+        /*
+                debugSizeDirName = SKStore.DirName::create("/debugSize/");
+                debugSizeDir = context.maybeGetEagerDir(debugSizeDirName) match {
+                | None() -> context.mkdir(x ~> x, y ~> y, debugSizeDirName)
+                | Some(_) -> SKStore.EHandle(x ~> x, y ~> y, debugSizeDirName)
+                };
+                debugSizeDir.writeArray(
+                  context,
+                  SKStore.SID(edir.dirName.toString()),
+                  Array[
+                    MyData(
+                      edir.fixedData.data.data.map(frow -> {
+                        debug(frow.value.i1);
+                        (frow.key, (frow.value.i0, frow.value.i1), frow.tag)
+                      }),
+                    ),
+                  ],
+                );
+                !edir.fixedData = SKStore.FixedDataMap::create();
+        */
+        /*** END OF DEBUG ***/
         context.setDir(edir.dirName, edir)
       | _ -> void
       }

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -393,15 +393,6 @@ fun execSessions(args: Cli.ParseResults, options: SKDB.Options): void {
   })
 }
 
-/*** DEBUG ***/
-class MyData(
-  value: Array<
-    (SKStore.Key, (SKStore.Source, Array<SKStore.File>), SKStore.TickRange),
-  >,
-) extends SKStore.File
-const myKey: SKStore.IID = SKStore.IID(0);
-/*** END OF DEBUG ***/
-
 fun execCompact(args: Cli.ParseResults, options: SKDB.Options): void {
   ensureContext(args);
   SKDB.runLockedSql(options, context ~> {
@@ -409,28 +400,6 @@ fun execCompact(args: Cli.ParseResults, options: SKDB.Options): void {
       dir match {
       | edir @ SKStore.EagerDir _ ->
         !edir = edir.purge(context, context.tick);
-        /*** DEBUG ***/
-        /*
-                debugSizeDirName = SKStore.DirName::create("/debugSize/");
-                debugSizeDir = context.maybeGetEagerDir(debugSizeDirName) match {
-                | None() -> context.mkdir(x ~> x, y ~> y, debugSizeDirName)
-                | Some(_) -> SKStore.EHandle(x ~> x, y ~> y, debugSizeDirName)
-                };
-                debugSizeDir.writeArray(
-                  context,
-                  SKStore.SID(edir.dirName.toString()),
-                  Array[
-                    MyData(
-                      edir.fixedData.data.data.map(frow -> {
-                        debug(frow.value.i1);
-                        (frow.key, (frow.value.i0, frow.value.i1), frow.tag)
-                      }),
-                    ),
-                  ],
-                );
-                !edir.fixedData = SKStore.FixedDataMap::create();
-        */
-        /*** END OF DEBUG ***/
         context.setDir(edir.dirName, edir)
       | _ -> void
       }

--- a/sql/src/SqlCAst.sk
+++ b/sql/src/SqlCAst.sk
@@ -173,12 +173,7 @@ base class AggrKind uses Orderable {
   | InferSchema()
 }
 
-base class CValue uses Orderable, Show {
-  children =
-  | CInt(value: Int)
-  | CFloat(value: Float)
-  | CString(value: String)
-
+extension base class CValue uses Show {
   fun getInt(): ?Int
   | CInt(n) -> Some(n)
   | _ -> None()

--- a/sql/src/SqlCompile.sk
+++ b/sql/src/SqlCompile.sk
@@ -2259,11 +2259,11 @@ mutable class Compiler{
               )
             }
           });
-          minKey = RowKey(
+          minKey = RowKey::create(
             RowValues::create(minKeyValues.map(x -> Some(x))),
             kinds,
           );
-          maxKey = RowKey(RowValues::create(maxValues), kinds);
+          maxKey = RowKey::create(RowValues::create(maxValues), kinds);
           SKStore.KeyRange(minKey, maxKey)
         });
         rangeMap![tableNbr] = (index.dirName, rowRanges)

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -250,10 +250,10 @@ fun lwwEdits(
     for ((tick, source, _) in dir.getDataIterWithoutTombs(context, key)) {
       if (
         tick.value < snapshot ||
-        source.path() == writer ||
+        source == writer ||
         rowKey.getRowValues() < row
       ) {
-        entries.push((key, (source.path(), writer, Array<SKStore.File>[])));
+        entries.push((key, (source, writer, Array<SKStore.File>[])));
       } else {
         !keepingCurrent = true;
         break void;
@@ -370,10 +370,10 @@ fun applyDiffStrategy(
         ctx = optContext.fromSome();
         key: SKStore.Key = SKDB.RowKey::create(row.setRepeat(1), table.kinds);
         for ((tick, source, _) in newDir.unsafeGetDataIterWithoutTombs(key)) {
-          if (tick.value < snapshot.default(0) || source.path() == writer) {
+          if (tick.value < snapshot.default(0) || source == writer) {
             !newDir = newDir.writeEntry(
               ctx,
-              source.path(),
+              source,
               writer,
               key,
               Array<SKStore.File>[],
@@ -420,7 +420,7 @@ fun applyDiffStrategy(
 
     // we may only affect rows that have been seen
     isEligibleForTomb = (tick, source) ~>
-      tick.value < snapshot.default(0) || source.path() == writer;
+      tick.value < snapshot.default(0) || source == writer;
 
     !dir = SKStore.withRegionFold(
       Some(newRoot),
@@ -443,7 +443,7 @@ fun applyDiffStrategy(
           if (keyRepeat - srcRepeat < 0) {
             !newDir = newDir.writeEntry(
               optContext.fromSome(),
-              source.path(),
+              source,
               writer,
               key,
               Array[],
@@ -505,10 +505,10 @@ fun applyDiffStrategy(
         if (row.repeat < 1) {
           key: SKStore.Key = SKDB.RowKey::create(row.setRepeat(1), table.kinds);
           for ((tick, source, _) in newDir.unsafeGetDataIterWithoutTombs(key)) {
-            if (tick.value < snapshot.default(0) || source.path() == writer) {
+            if (tick.value < snapshot.default(0) || source == writer) {
               !newDir = newDir.writeEntry(
                 ctx,
-                source.path(),
+                source,
                 writer,
                 key,
                 Array[],
@@ -602,9 +602,7 @@ fun applyDiffStrategy(
         .map(x -> SKDB.RowKey::create(x.setRepeat(1), table.kinds))
         .collect(SortedSet),
       isVisibleToUser(newRoot),
-      (tick, source) ~>
-        tick.value < snapshot.default(0) || source.path() == writer
-      ,
+      (tick, source) ~> tick.value < snapshot.default(0) || source == writer,
     );
 
     newRoot.setDir(dir.dirName, dir);

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -245,13 +245,13 @@ fun lwwEdits(
     | None() -> continue
     | _ -> void
     };
-    if (rowKey.row.getValue(0) != primaryKey) break void;
+    if (rowKey.getRowValues().getValue(0) != primaryKey) break void;
 
     for ((tick, source, _) in dir.getDataIterWithoutTombs(context, key)) {
       if (
         tick.value < snapshot ||
         source.path() == writer ||
-        rowKey.row < row
+        rowKey.getRowValues() < row
       ) {
         entries.push((key, (source.path(), writer, Array<SKStore.File>[])));
       } else {
@@ -264,7 +264,7 @@ fun lwwEdits(
   if (!keepingCurrent) {
     for (entry in entries) yield entry;
     yield (
-      SKDB.RowKey(row, table.kinds),
+      SKDB.RowKey::create(row, table.kinds),
       (writer, writer, Array<SKStore.File>[row]),
     );
   }
@@ -334,7 +334,12 @@ fun applyDiffStrategy(
       (file: SKStore.Key) -> {
         file match {
         | k @ SKDB.RowKey _ ->
-          SKDB.checkUserCanReadRow(context, userFile, table, k.row) match {
+          SKDB.checkUserCanReadRow(
+            context,
+            userFile,
+            table,
+            k.getRowValues(),
+          ) match {
           | SKDB.AROK() -> true
           | SKDB.ARError(_err) -> false
           }
@@ -363,7 +368,7 @@ fun applyDiffStrategy(
       dir,
       (optContext, row, newDir) ~> {
         ctx = optContext.fromSome();
-        key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
+        key: SKStore.Key = SKDB.RowKey::create(row.setRepeat(1), table.kinds);
         for ((tick, source, _) in newDir.unsafeGetDataIterWithoutTombs(key)) {
           if (tick.value < snapshot.default(0) || source.path() == writer) {
             !newDir = newDir.writeEntry(
@@ -382,7 +387,7 @@ fun applyDiffStrategy(
             ctx,
             writer,
             writer,
-            SKDB.RowKey(row, table.kinds),
+            SKDB.RowKey::create(row, table.kinds),
             Array[row],
             true,
           );
@@ -422,7 +427,7 @@ fun applyDiffStrategy(
       rows.iterator(),
       dir,
       (optContext, row, newDir) ~> {
-        key: SKStore.Key = SKDB.RowKey(row, table.kinds);
+        key: SKStore.Key = SKDB.RowKey::create(row, table.kinds);
         keyRepeat = row.repeat;
         for ((tick, source, files) in newDir.unsafeGetDataIterWithoutTombs(
           key,
@@ -469,7 +474,7 @@ fun applyDiffStrategy(
       rows
         .iterator()
         .filter(row -> row.repeat != 0)
-        .map(x -> SKDB.RowKey(x.setRepeat(1), table.kinds))
+        .map(x -> SKDB.RowKey::create(x.setRepeat(1), table.kinds))
         .collect(SortedSet),
       isVisibleToUser(newRoot),
       isEligibleForTomb,
@@ -498,7 +503,7 @@ fun applyDiffStrategy(
       (optContext, row, newDir) ~> {
         ctx = optContext.fromSome();
         if (row.repeat < 1) {
-          key: SKStore.Key = SKDB.RowKey(row.setRepeat(1), table.kinds);
+          key: SKStore.Key = SKDB.RowKey::create(row.setRepeat(1), table.kinds);
           for ((tick, source, _) in newDir.unsafeGetDataIterWithoutTombs(key)) {
             if (tick.value < snapshot.default(0) || source.path() == writer) {
               !newDir = newDir.writeEntry(
@@ -594,7 +599,7 @@ fun applyDiffStrategy(
       rows
         .iterator()
         .filter(row -> row.repeat != 0)
-        .map(x -> SKDB.RowKey(x.setRepeat(1), table.kinds))
+        .map(x -> SKDB.RowKey::create(x.setRepeat(1), table.kinds))
         .collect(SortedSet),
       isVisibleToUser(newRoot),
       (tick, source) ~>

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -535,7 +535,7 @@ class Evaluator{options: Options, user: ?UserFile} {
           selectDir.dirName,
           sinkDirName,
           (context, _writer, key, valueIter) ~> {
-            src = SKStore.Path::create(selectDir.dirName, key);
+            src = SKStore.Path(selectDir.dirName, key);
             entries = Vector[(key, (src, src, valueIter.collect(Array)))];
             inputDir = context.unsafeGetEagerDir(dir.dirName);
             inputDir.writeArraySourceMany(context, entries.iterator());
@@ -1134,7 +1134,7 @@ class Evaluator{options: Options, user: ?UserFile} {
         deleteDir,
         sinkDirName,
         (context, _writer, key, valueIter) ~> {
-          src = SKStore.Path::create(deleteDir, key);
+          src = SKStore.Path(deleteDir, key);
           entries = Vector[(key, (src, src, valueIter.collect(Array)))];
           inputDir = context.unsafeGetEagerDir(dir.dirName);
           inputDir.writeArraySourceMany(context, entries.iterator());
@@ -1227,9 +1227,7 @@ class Evaluator{options: Options, user: ?UserFile} {
           SKStore.IID(SKStore.genSym(0)),
         );
         for ((_, source, _) in dir.getDataIterWithoutTombs(context, key)) {
-          entries.push(
-            (key, (source.path(), writerPath, Array<SKStore.File>[])),
-          );
+          entries.push((key, (source, writerPath, Array<SKStore.File>[])));
         };
         dir.writeArraySourceMany(context, entries.iterator());
         if (select.sets.isEmpty()) return void;
@@ -1381,7 +1379,7 @@ class Evaluator{options: Options, user: ?UserFile} {
                     key,
                   )) {
                     entries.push(
-                      (key, (source.path(), writerPath, Array<SKStore.File>[])),
+                      (key, (source, writerPath, Array<SKStore.File>[])),
                     );
                   };
                 };
@@ -1894,7 +1892,7 @@ fun importNext(
         for (key in changedKeys) {
           for (srcValue in dir.unsafeGetAllDataIterAfter(tick, key)) {
             (_, source, writer, values) = srcValue;
-            entries.push((key, (source.path(), writer.path(), values)));
+            entries.push((key, (source, writer, values)));
           }
         };
         updates![targetDirName] = (isReset, changedKeys, dir, version, entries)

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -1267,11 +1267,11 @@ class Evaluator{options: Options, user: ?UserFile} {
         };
         !row = RowValues::create(values.chill(), row.repeat);
         kinds = key match {
-        | RowKey(_, kinds) -> kinds
+        | rowKey @ RowKey _ -> rowKey.getKinds()
         | _ -> invariant_violation("Unexpected row kind")
         };
 
-        writer.set(RowKey(row, kinds), row);
+        writer.set(RowKey::create(row, kinds), row);
       },
     );
     sinkDir = context.unsafeGetEagerDir(sinkDirName);
@@ -1375,7 +1375,7 @@ class Evaluator{options: Options, user: ?UserFile} {
                     SKStore.IID(SKStore.genSym(0)),
                   );
 
-                  key: SKStore.Key = RowKey(row, kinds);
+                  key: SKStore.Key = RowKey::create(row, kinds);
                   for ((_, source, _) in dir.getDataIterWithoutTombs(
                     context,
                     key,
@@ -1415,7 +1415,7 @@ class Evaluator{options: Options, user: ?UserFile} {
     newDir = context.unsafeGetEagerDir(dir.dirName);
     kinds = table.kinds;
     for (row in rows) {
-      key = RowKey(row, kinds);
+      key = RowKey::create(row, kinds);
       source = SKStore.Path(dir.dirName, SKStore.IID(SKStore.genSym(0)));
       !newDir = newDir.writeEntry(context, source, source, key, Array[row]);
     };
@@ -2235,7 +2235,7 @@ fun printReactiveQueryChanges(
         values = edir.getArrayRaw(key);
         if (values.size() == 0) {
           switchTo(UInt32::truncate(2));
-          row = (key as RowKey _).row;
+          row = (key as RowKey _).getRowValues();
           for (_ in Range(0, row.repeat)) {
             RowValues::printItem(format, row);
           }

--- a/sql/src/SqlExpr.sk
+++ b/sql/src/SqlExpr.sk
@@ -823,7 +823,7 @@ class ExprEvaluator(
       invariant(query.params.size() == 1);
       row = RowValues::create(Array[Some(CInt(v))], 1);
       kinds = Array[(0, P.IASC(), P.TEXT())];
-      ADef(btoi(dir.getArray(context, RowKey(row, kinds)).size() != 0))
+      ADef(btoi(dir.getArray(context, RowKey::create(row, kinds)).size() != 0))
 
     | CIIn(vExpr, set) ->
       v = this.evalCIExpr(context, vExpr);
@@ -866,7 +866,7 @@ class ExprEvaluator(
       invariant(query.params.size() == 1);
       row = RowValues::create(Array[Some(CFloat(v))], 1);
       kinds = Array[(0, P.IASC(), P.TEXT())];
-      ADef(btoi(dir.getArray(context, RowKey(row, kinds)).size() != 0))
+      ADef(btoi(dir.getArray(context, RowKey::create(row, kinds)).size() != 0))
 
     | CFIn(vExpr, set) ->
       v = this.evalCFExpr(context, vExpr);
@@ -909,7 +909,7 @@ class ExprEvaluator(
       invariant(query.params.size() == 1);
       row = RowValues::create(Array[Some(CString(v))], 1);
       kinds = Array[(0, P.IASC(), P.TEXT())];
-      ADef(btoi(dir.getArray(context, RowKey(row, kinds)).size() != 0))
+      ADef(btoi(dir.getArray(context, RowKey::create(row, kinds)).size() != 0))
 
     | CSIn(vExpr, set) ->
       v = this.evalCSExpr(context, vExpr);

--- a/sql/src/SqlIndex.sk
+++ b/sql/src/SqlIndex.sk
@@ -6,20 +6,39 @@ module alias P = SQLParser;
 
 module SKDB;
 
-const systemIndexPrefix: String =  "__skdb__";
+const systemIndexPrefix: String = "__skdb__";
 
-class IndexProjKey(values: Array<(Int, ?CValue)>) extends SKStore.Key
-
-fun makeIndexProjKey(
-  v: RowValues,
+class IndexProjKey private (
+  row: RowValues,
   kinds: Array<(Int, P.IKind, P.Type)>,
-  size: Int,
-): IndexProjKey {
-  indexedValues = mutable Vector[];
-  for (i in Range(0, size)) {
-    indexedValues.push((kinds[i].i0, v.values[kinds[i].i0]));
-  };
-  IndexProjKey(indexedValues.toArray());
+) extends SKStore.Key {
+  static fun create(values: Array<(Int, P.Type, ?CValue)>): this {
+    row = RowValues::create(values.map(x -> x.i2));
+    kinds = values.map(x -> (x.i0, P.IASC(), x.i1));
+    static(row, kinds)
+  }
+
+  static fun createFromRowValues(
+    row: RowValues,
+    kinds: Array<(Int, P.IKind, P.Type)>,
+  ): IndexProjKey {
+    static(row, kinds)
+  }
+
+  fun toArray(): Array<(Int, ?CValue)> {
+    indexedValues = mutable Vector[];
+    for (i in Range(0, this.kinds.size())) {
+      indexedValues.push((this.kinds[i].i0, this.row.values[this.kinds[i].i0]));
+    };
+    indexedValues.toArray()
+  }
+
+  fun compare(other: SKStore.Key): Order {
+    other match {
+    | IndexProjKey(row2, _) -> compareRows(this.kinds, this.row, row2)
+    | _ -> this.getClassName().compare(other.getClassName())
+    }
+  }
 }
 
 fun createIndexName(
@@ -71,6 +90,7 @@ fun createIndex(
     )
   };
   if (unique) {
+    subKinds = kinds.slice(0, size);
     _ = index
       .map(
         x ~> x,
@@ -81,9 +101,14 @@ fun createIndex(
           result = SortedMap<IndexProjKey, mutable Vector<RowValues>>[];
           valuesArr = values.collect(Array);
           for (v in valuesArr) {
-            k = makeIndexProjKey(v, kinds, size);
+            k = IndexProjKey::createFromRowValues(v, subKinds);
             if (v.repeat != 1) {
-              throw Conflict(0, "UNIQUE constraint failed", k.values, valuesArr)
+              throw Conflict(
+                0,
+                "UNIQUE constraint failed",
+                k.toArray(),
+                valuesArr,
+              )
             };
             if (!result.containsKey(k)) {
               !result[k] = mutable Vector[];
@@ -111,7 +136,7 @@ fun createIndex(
               0,
               "UNIQUE constraint failed",
               key match {
-              | IndexProjKey(arr) -> arr
+              | projKey @ IndexProjKey _ -> projKey.toArray()
               | _ -> invariant_violation("Unexpected key type")
               },
               valuesArr,

--- a/sql/src/SqlIndex.sk
+++ b/sql/src/SqlIndex.sk
@@ -32,7 +32,11 @@ extension class IndexProjKey extends SKStore.Key {
 
   fun compare(other: SKStore.Key): Order {
     other match {
-    | IndexProjKey(row2, _) -> compareRows(this.kinds, this.row, row2)
+    | IndexProjKey(row2, kinds2) ->
+      this.kinds.compare(kinds2) match {
+      | EQ() -> compareRows(this.kinds, this.row, row2)
+      | diseq -> diseq
+      }
     | _ -> this.getClassName().compare(other.getClassName())
     }
   }

--- a/sql/src/SqlIndex.sk
+++ b/sql/src/SqlIndex.sk
@@ -8,10 +8,7 @@ module SKDB;
 
 const systemIndexPrefix: String = "__skdb__";
 
-class IndexProjKey private (
-  row: RowValues,
-  kinds: Array<(Int, P.IKind, P.Type)>,
-) extends SKStore.Key {
+extension class IndexProjKey extends SKStore.Key {
   static fun create(values: Array<(Int, P.Type, ?CValue)>): this {
     row = RowValues::create(values.map(x -> x.i2));
     kinds = values.map(x -> (x.i0, P.IASC(), x.i1));

--- a/sql/src/SqlPrivacy.sk
+++ b/sql/src/SqlPrivacy.sk
@@ -169,7 +169,8 @@ base class PredefinedTable private final {
     if (isReset) return true;
     for (change in changes) {
       change match {
-      | RowKey(row, _) ->
+      | rowKey @ RowKey _ ->
+        row = rowKey.getRowValues();
         row.getString(colNbr) match {
         | None() ->
           // The change affected every user
@@ -720,7 +721,8 @@ mutable class AccessSolver private {
     files: Array<SKStore.File>,
   ): void {
     key match {
-    | RowKey(rowValues, _) ->
+    | rowKey @ RowKey _ ->
+      rowValues = rowKey.getRowValues();
       if (files.size() == 0) {
         !rowValues = rowValues.setRepeat(0);
       };

--- a/sql/src/SqlPrivacy.sk
+++ b/sql/src/SqlPrivacy.sk
@@ -279,7 +279,9 @@ class SKDBUsersByName extends PredefinedTable {
   const indexedFields: Array<P.Name> = Array[P.Name::create("userID")];
 
   fun makeKey(userID: String): IndexProjKey {
-    IndexProjKey(Array[(this.getColNbr(userIDColName), Some(CString(userID)))])
+    IndexProjKey::create(
+      Array[(this.getColNbr(userIDColName), P.TEXT(), Some(CString(userID)))],
+    )
   }
 }
 
@@ -304,8 +306,10 @@ class SKDBUserPermissions extends PredefinedTable {
   const indexedFields: Array<P.Name> = Array[P.Name::create("userID")];
 
   fun makeKey(userID: ?String): IndexProjKey {
-    IndexProjKey(
-      Array[(this.getColNbr(userIDColName), userID.map(x -> CString(x)))],
+    IndexProjKey::create(
+      Array[
+        (this.getColNbr(userIDColName), P.TEXT(), userID.map(x -> CString(x))),
+      ],
     )
   }
 }
@@ -328,8 +332,8 @@ class SKDBGroups extends PredefinedTable {
 
   const indexedFields: Array<P.Name> = Array[groupIDColName];
   fun makeKey(groupID: String): IndexProjKey {
-    IndexProjKey(
-      Array[(this.getColNbr(groupIDColName), Some(CString(groupID)))],
+    IndexProjKey::create(
+      Array[(this.getColNbr(groupIDColName), P.TEXT(), Some(CString(groupID)))],
     )
   }
 }
@@ -355,10 +359,10 @@ class SKDBGroupPermissions extends PredefinedTable {
   ];
 
   fun makeKey(groupID: String, userID: ?String): IndexProjKey {
-    IndexProjKey(
+    IndexProjKey::create(
       Array[
-        (this.getColNbr(groupIDColName), Some(CString(groupID))),
-        (this.getColNbr(userIDColName), userID.map(x -> CString(x))),
+        (this.getColNbr(groupIDColName), P.TEXT(), Some(CString(groupID))),
+        (this.getColNbr(userIDColName), P.TEXT(), userID.map(x -> CString(x))),
       ],
     )
   }

--- a/sql/src/SqlSelect.sk
+++ b/sql/src/SqlSelect.sk
@@ -41,6 +41,24 @@ extension class ProjKey extends SKStore.Key {
   fun toString(): String {
     this.value.toString()
   }
+
+  // Exclude colNbr from comparison, so that two ProjKeys compare as equal when
+  // their value and left/right shard indices match
+  fun compare(other: SKStore.Key): Order {
+    other match {
+    | otherPK @ ProjKey _ ->
+      this.leftShard.compare(otherPK.leftShard) match {
+      | EQ() ->
+        this.rightShard.compare(otherPK.rightShard) match {
+        | EQ() -> this.value.compare(otherPK.value)
+        | x -> x
+        }
+      | x -> x
+      }
+    | _ ->
+      LT() // not equal to non-ProjKey keys, choose LT over GT here arbitrarily
+    }
+  }
 }
 
 class LeftFile(SKStore.Key, RowValues) extends SKStore.File

--- a/sql/src/SqlSelect.sk
+++ b/sql/src/SqlSelect.sk
@@ -1426,7 +1426,7 @@ fun makeGroupByKey(
   evaluator: ExprEvaluator,
   row: Row,
   groupBy: Array<CGroupByElt>,
-): RowKeyImpl {
+): RowKey {
   rowKey = mutable Vector[];
   kinds = mutable Vector[];
   for (idx => elt in groupBy) {

--- a/sql/src/SqlSelect.sk
+++ b/sql/src/SqlSelect.sk
@@ -352,7 +352,7 @@ class SelectEvaluator{
           };
           evaluator = ExprEvaluator(Array[entry], select.from, up);
           row = static::evalRow(context, evaluator, select.params, repeat);
-          writer.set(RowKey(row, kinds), row)
+          writer.set(RowKey::create(row, kinds), row)
         },
       );
       SelectDir(childName, this.types)
@@ -1426,7 +1426,7 @@ fun makeGroupByKey(
   evaluator: ExprEvaluator,
   row: Row,
   groupBy: Array<CGroupByElt>,
-): RowKey {
+): RowKeyImpl {
   rowKey = mutable Vector[];
   kinds = mutable Vector[];
   for (idx => elt in groupBy) {
@@ -1445,7 +1445,7 @@ fun makeGroupByKey(
       kinds.push((idx, P.IASC(), ty))
     }
   };
-  result = RowKey(RowValues::create(rowKey.toArray()), kinds.toArray());
+  result = RowKey::create(RowValues::create(rowKey.toArray()), kinds.toArray());
   result
 }
 
@@ -1519,7 +1519,7 @@ fun makeJoinReducer(
           left.values.concat(right);
         };
         row = RowValues::create(values, left.repeat);
-        writer.set(RowKey(row, kinds), row);
+        writer.set(RowKey::create(row, kinds), row);
       };
       for (rkv in rightRows) {
         (_, right) = rkv;
@@ -1527,7 +1527,7 @@ fun makeJoinReducer(
           left.values.concat(right.values)
         };
         row = RowValues::create(values, left.repeat * right.repeat);
-        writer.set(RowKey(row, kinds), row);
+        writer.set(RowKey::create(row, kinds), row);
       }
     };
     if (
@@ -1540,7 +1540,7 @@ fun makeJoinReducer(
         left = Array::fill(kinds.size() - right.size(), None<CValue>());
         values = left.concat(right.values);
         row = RowValues::create(values, right.repeat);
-        writer.set(RowKey(row, kinds), row);
+        writer.set(RowKey::create(row, kinds), row);
       }
     }
   }

--- a/sql/src/SqlSelect.sk
+++ b/sql/src/SqlSelect.sk
@@ -37,11 +37,7 @@ class SubTask(
 
 class KVFile(value: (SKStore.Key, Array<SKStore.File>)) extends SKStore.File
 
-class ProjKey(
-  value: ?CValue,
-  leftShard: Int,
-  rightShard: Int,
-) extends SKStore.Key {
+extension class ProjKey extends SKStore.Key {
   fun toString(): String {
     this.value.toString()
   }
@@ -434,7 +430,7 @@ class SelectEvaluator{
         leftShardID = SKStore.genSym(leftShard) % leftShard;
         shardedFile = LeftShardedFile{leftShardID, rightShard, value => row};
         for (i in Range(0, rightShard)) {
-          projKey = ProjKey(key, leftShardID, i);
+          projKey = ProjKey(key, leftColNbr, leftShardID, i);
           writer.set(projKey, LeftFile(fileKey, shardedFile.value))
         }
       };
@@ -450,7 +446,7 @@ class SelectEvaluator{
         rightShardID = SKStore.genSym(rightShard) % rightShard;
         shardedFile = RightShardedFile{leftShard, rightShardID, value => row};
         for (i in Range(0, leftShard)) {
-          projKey = ProjKey(key, i, rightShardID);
+          projKey = ProjKey(key, rightColNbr, i, rightShardID);
           writer.set(projKey, RightFile(fileKey, shardedFile.value))
         }
       };

--- a/sql/src/SqlTables.sk
+++ b/sql/src/SqlTables.sk
@@ -261,7 +261,7 @@ fun dirDescrCopy(
         dirName,
       )).unsafeGetAllDataIterAfter(limit, key)) {
         (_, source, writer, values) = srcValue;
-        entries.push((key, (source.path(), writer.path(), values)));
+        entries.push((key, (source, writer, values)));
       };
       inputDir = context.unsafeGetEagerDir(nextName);
       inputDir.writeArraySourceMany(context, entries.iterator());
@@ -417,9 +417,7 @@ fun getSubsDirs(
           (context, isReset) ~> {
             if (isReset) return alwaysTrue;
             tdir = context.unsafeGetEagerDir(dirDescr.dirName);
-            ignoredSrc = SKStore.Source::create(
-              SKStore.Path(dirDescr.dirName, SKStore.IID(inputSrc)),
-            );
+            ignoredSrc = SKStore.Path(dirDescr.dirName, SKStore.IID(inputSrc));
             (file: SKStore.Key) -> {
               rows = tdir.getAllDataIter(context.mclone(), file).collect(Array);
               !updateIsFromIgnoredSource(ignoredSrc, rows)
@@ -461,13 +459,11 @@ fun getSubsDirs(
 }
 
 fun updateIsFromIgnoredSource(
-  ignoredSrc: SKStore.Source,
-  rows: Array<
-    (SKStore.Tick, SKStore.Source, SKStore.Source, Array<SKStore.File>),
-  >,
+  ignoredSrc: SKStore.Path,
+  rows: Array<(SKStore.Tick, SKStore.Path, SKStore.Path, Array<SKStore.File>)>,
 ): Bool {
   maxTick = SKStore.Tick(0);
-  singleNonTomb: ?(SKStore.Tick, SKStore.Source) = None();
+  singleNonTomb: ?(SKStore.Tick, SKStore.Path) = None();
 
   for ((tick, _origSrc, src, files) in rows) {
     !maxTick = max(maxTick, tick);

--- a/sql/src/SqlTailer.sk
+++ b/sql/src/SqlTailer.sk
@@ -33,7 +33,7 @@ fun buildTailFilter(
       conditionFilter = dirSub.filter(context, isReset);
       baseName -> {
         inputRow = baseName match {
-        | SKDB.RowKey(row, _) -> row
+        | rowKey @ SKDB.RowKey _ -> rowKey.getRowValues()
         | _ ->
           print_error("Unexpected table entry type");
           skipExit(2)
@@ -64,7 +64,8 @@ fun buildTailFilter(
       baseName -> {
         oldFilter(baseName) &&
           baseName match {
-          | SKDB.RowKey(row, _) ->
+          | rowKey @ SKDB.RowKey _ ->
+            row = rowKey.getRowValues();
             SKDB.checkUserCanReadRow(context, user, sqlTable, row) match {
             | SKDB.AROK() -> true
             | _ -> false

--- a/sql/src/SqlValue.sk
+++ b/sql/src/SqlValue.sk
@@ -67,15 +67,25 @@ fun compareRows(
   EQ()
 }
 
-class RowKey(
-  row: RowValues,
-  kinds: Array<(Int, P.IKind, P.Type)>,
-) extends SKStore.Key {
+class RowKey extends RowKeyImpl {
   static fun create(
     row: RowValues,
     kinds: Array<(Int, P.IKind, P.Type)>,
-  ): this {
+  ): RowKeyImpl {
     static(row, kinds)
+  }
+}
+
+base class RowKeyImpl protected (
+  private row: RowValues,
+  private kinds: Array<(Int, P.IKind, P.Type)>,
+) extends SKStore.Key {
+  fun getRowValues(): RowValues {
+    this.row
+  }
+
+  fun getKinds(): Array<(Int, P.IKind, P.Type)> {
+    this.kinds
   }
 
   fun compare(other: SKStore.Key): Order {

--- a/sql/src/SqlValue.sk
+++ b/sql/src/SqlValue.sk
@@ -85,7 +85,11 @@ extension class RowKey {
 
   fun compare(other: SKStore.Key): Order {
     other match {
-    | RowKey(row2, _) -> SKDB.compareRows(this.kinds, this.row, row2)
+    | RowKey(row2, kinds2) ->
+      this.kinds.compare(kinds2) match {
+      | EQ() -> SKDB.compareRows(this.kinds, this.row, row2)
+      | diseq -> diseq
+      }
     | _ -> this.getClassName().compare(other.getClassName())
     }
   }

--- a/sql/src/SqlValue.sk
+++ b/sql/src/SqlValue.sk
@@ -67,19 +67,14 @@ fun compareRows(
   EQ()
 }
 
-class RowKey extends RowKeyImpl {
+extension class RowKey {
   static fun create(
     row: RowValues,
     kinds: Array<(Int, P.IKind, P.Type)>,
-  ): RowKeyImpl {
+  ): RowKey {
     static(row, kinds)
   }
-}
 
-base class RowKeyImpl protected (
-  private row: RowValues,
-  private kinds: Array<(Int, P.IKind, P.Type)>,
-) extends SKStore.Key {
   fun getRowValues(): RowValues {
     this.row
   }
@@ -177,10 +172,7 @@ base class Row extends SKStore.File {
   }
 }
 
-class RowValues private (
-  values: Array<?CValue>,
-  repeat: Int,
-) extends Row uses Orderable {
+extension class RowValues extends Row {
   static fun create(values: Array<?CValue>, repeat: Int = 1): this {
     invariant(repeat >= 0);
     static(values, repeat)

--- a/sqlparser/src/Ast.sk
+++ b/sqlparser/src/Ast.sk
@@ -151,13 +151,6 @@ base class InsertValues uses Equality, Show {
   | IDefault()
 }
 
-base class IKind uses Orderable, Show {
-  children =
-  | INONE()
-  | IASC()
-  | IDESC()
-}
-
 class Select{
   core: SelectCore,
   orderBy: ?Array<(Expr, IKind)>,
@@ -332,15 +325,6 @@ base class InValues uses Equality, Show {
   children =
   | InList(Array<Expr>)
   | InSelect(Select)
-}
-
-base class Type uses Orderable, Show {
-  children =
-  | FLOAT()
-  | INTEGER()
-  | TEXT()
-  | JSON()
-  | SCHEMA()
 }
 
 base class TransactionKind uses Equality, Show {


### PR DESCRIPTION
This PR introduces much more efficient representations of the FixedDir and FixedSingle<Path, MInfo> structures for the special cases produced by SKDB, where a lot of data is shared between different key/val pairs.

The FixedDir stuff should be fairly self-explanatory, but I've written up some details about FixedSourceMap (which is a drop-in replacement for a FixedSingle<Path, MInfo>) in the commit message for sha 6931629.

Putting this up for visibility, but I'm still working on things here.  These more-compact representations look good when I inspect/dump data structures, but the top line size numbers are in fact slightly higher than before these changes.  Digging through some more components of FixedDirs/EagerDirs to see where else there is opportunity for improvement.
