### PR TITLE
Make SKDBTable more idiomatic and ergonomic

### DIFF
--- a/sql/ts/src/skdb_util.ts
+++ b/sql/ts/src/skdb_util.ts
@@ -35,14 +35,20 @@ export class ExternalFuns {
 }
 
 /* ***************************************************************************/
-/* Class for query results, extending Array<Object> with some common selectors
-   and utility functions for ease of use. */
+/* Class for query results, extending Array<Record<>> with some common
+   selectors and utility functions for ease of use. */
 /* ***************************************************************************/
 export class SKDBTable extends Array<Record<string, any>> {
-  scalarValue(): any {
-    const row = this.onlyRow();
+  scalarValue(): any | undefined {
+    const row = this.firstRow();
+    if (row === undefined) {
+      return undefined;
+    }
     const cols = Object.keys(row);
-    if (cols.length != 1) {
+    if (cols.length < 1) {
+      return undefined;
+    }
+    if (cols.length > 1) {
       throw new Error(
         `Can't extract scalar: query yielded ${cols.length} columns`,
       );
@@ -57,21 +63,37 @@ export class SKDBTable extends Array<Record<string, any>> {
     return this[0];
   }
 
-  onlyColumn(): Array<any> {
-    let result = [] as Array<any>;
-    for (const row of this) {
-      const cols = Object.keys(row);
-      if (cols.length != 1) {
-        throw new Error(
-          `Can't extract only column: got ${cols.length} columns`,
-        );
-      }
-      result.push(row[cols[0]]);
+  firstRow(): Record<string, any> | undefined {
+    if (this.length < 1) {
+      return undefined;
     }
-    return result;
+    return this[0];
   }
 
-  column(col: string): Array<any> {
+  lastRow(): Record<string, any> | undefined {
+    if (this.length < 1) {
+      return undefined;
+    }
+    return this[this.length - 1];
+  }
+
+  onlyColumn(): any[] {
+    const row = this.firstRow();
+    if (row === undefined) {
+      return [];
+    }
+    const cols = Object.keys(row);
+    if (cols.length < 1) {
+      return []; // unlikely to have rows but no cols
+    }
+    if (cols.length > 1) {
+      throw new Error("Too many columns");
+    }
+    const col = cols[0];
+    return this.column(col);
+  }
+
+  column(col: string): any[] {
     return this.map((row) => {
       if (!row[col]) {
         throw new Error("Missing column: " + col);


### PR DESCRIPTION
We throw less and use undefined more - this makes it more idiomatic
and generally easier to use. E.g. `rows.scalarValue() ?? 0;`.
Typescript does generally do a pretty good job of making you 'unwrap
the optional'.

I also added a couple of methods I kept reaching for to get the first
and last row without throwing.