### PR TITLE
Implementation of insertMany in JS

### DIFF
--- a/sql/ts/src/skdb_types.ts
+++ b/sql/ts/src/skdb_types.ts
@@ -39,6 +39,7 @@ export interface SKDBSync {
     update: (added: SKDBTable, removed: SKDBTable) => void,
   ) => { close: () => void };
   insert: (tableName: string, values: Array<any>) => boolean;
+  insertMany: (tableName: string, valuesArray: Array<Array<any>>) => boolean;
 
   tableSchema: (tableName: string) => string;
   viewSchema: (viewName: string) => string;

--- a/sql/ts/src/skdb_types.ts
+++ b/sql/ts/src/skdb_types.ts
@@ -80,6 +80,11 @@ export interface SKDB {
     update: (added: SKDBTable, removed: SKDBTable) => void,
   ) => Promise<{ close: () => Promise<void> }>;
 
+  insertMany: (
+    tableName: string,
+    valuesArray: Array<Array<any>>
+  ) => Promise<boolean>;
+
   connect: (
     db: string,
     accessKey: string,

--- a/sql/ts/src/skdb_types.ts
+++ b/sql/ts/src/skdb_types.ts
@@ -39,7 +39,7 @@ export interface SKDBSync {
     update: (added: SKDBTable, removed: SKDBTable) => void,
   ) => { close: () => void };
   insert: (tableName: string, values: Array<any>) => boolean;
-  insertMany: (tableName: string, valuesArray: Array<Array<any>>) => boolean;
+  insertMany: (tableName: string, valuesArray: Array<Record<string, any>>) => number | Error;
 
   tableSchema: (tableName: string) => string;
   viewSchema: (viewName: string) => string;
@@ -83,7 +83,7 @@ export interface SKDB {
   insertMany: (
     tableName: string,
     valuesArray: Array<Array<any>>
-  ) => Promise<boolean>;
+  ) => Promise<number>;
 
   connect: (
     db: string,

--- a/sql/ts/src/skdb_wdatabase.ts
+++ b/sql/ts/src/skdb_wdatabase.ts
@@ -178,6 +178,12 @@ export class SKDBWorker implements SKDB {
       .send() as Promise<boolean>;
   };
 
+  insertMany = async (tableName: string, valuesArray: Array<Array<any>>) => {
+    return this.worker
+      .post(new Function("insertMany", [tableName, valuesArray]))
+      .send() as Promise<boolean>;
+  };
+
   save = async () => {
     return this.worker
       .post(new Function("save", []))

--- a/sql/ts/src/skdb_wdatabase.ts
+++ b/sql/ts/src/skdb_wdatabase.ts
@@ -178,10 +178,14 @@ export class SKDBWorker implements SKDB {
       .send() as Promise<boolean>;
   };
 
-  insertMany = async (tableName: string, valuesArray: Array<Array<any>>) => {
-    return this.worker
+  insertMany = async (tableName: string, valuesArray: Array<Record<string, any>>) => {
+    let result = await this.worker
       .post(new Function("insertMany", [tableName, valuesArray]))
-      .send() as Promise<boolean>;
+      .send();
+    if(result instanceof Error) {
+      throw result;
+    };
+    return result as Promise<number>;
   };
 
   save = async () => {

--- a/sql/ts/tests/tests.ts
+++ b/sql/ts/tests/tests.ts
@@ -1662,7 +1662,7 @@ export const tests = (asWorker: boolean) => {
       fun: async (skdb: SKDB) => {
         await skdb.exec("create table t1 (a TEXT, b INTEGER);");
         await skdb.insertMany('t1', [{a:'foo', b:0}, {a:'bar', b: 1}]);
-        return skdb.exec("select * from t1");
+        return await skdb.exec("select * from t1");
       },
       check: (res) => {
         let str = JSON.stringify(res);
@@ -1679,7 +1679,7 @@ export const tests = (asWorker: boolean) => {
           values.push({a:'foo', b:i});
         }
         await skdb.insertMany('t1', values);
-        return skdb.exec("select count(*) as c from t1");
+        return await skdb.exec("select count(*) as c from t1");
       },
       check: (res) => {
         expect(res).toEqual([{c: 2100}]);
@@ -1696,7 +1696,7 @@ export const tests = (asWorker: boolean) => {
         }
       },
       check: (res) => {
-        expect(res).toMatch(/mismatch/);
+        expect(res).toMatch(/Missing/);
       },
     },
     {

--- a/sql/ts/tests/tests.ts
+++ b/sql/ts/tests/tests.ts
@@ -1656,6 +1656,17 @@ export const tests = (asWorker: boolean) => {
         expect(all).toMatch(/\u00c3\u00a9al P/);
         expect(all).toMatch(/ \u2022 T/);
       },
+    },
+    {
+      name: n("insertMany", asWorker),
+      fun: async (skdb: SKDB) => {
+        await skdb.exec("create table t1 (a TEXT);");
+        await skdb.insertMany('t1', [['foo'], ['bar']]);
+        return skdb.exec("select count(*) from t1");
+      },
+      check: (res) => {
+        expect(res).toEqual([{"col<0>": 2}]);
+      },
     }
   ];
   return tests


### PR DESCRIPTION
It's the same as insert, but for more than one value. So we had:

skdb.insert([1, 2, 3]);

Now we can also write:

skdb.insertMany([[1, 2, 3], [4, 5, 6]]);