### PR TITLE
Change CSV string en/decoding

### DIFF
--- a/sql/src/SqlCAst.sk
+++ b/sql/src/SqlCAst.sk
@@ -221,6 +221,7 @@ base class CValue uses Orderable, Show {
     this match {
     | CInt(n) -> n.toString()
     | CFloat(f) -> floatToString(f)
+    | CString(str) if (format is SKStore.OCSV _) -> SKCSV.escapeString(str)
     | CString(str) if (format.usesDoubleQuotes()) ->
       result = mutable Vector['"'];
       for (c in str) {
@@ -228,9 +229,11 @@ base class CValue uses Orderable, Show {
           format match {
           | SKStore.OJSON _ -> result.push('\\')
           | SKStore.OSQL _ -> void
-          | SKStore.OTable _
+          | SKStore.OTable _ -> result.push(c)
           | SKStore.OCSV _ ->
-            result.push(c)
+            invariant_violation(
+              "CSV handled separately. This branch should not be reached.",
+            )
           | SKStore.OJS _ ->
             invariant_violation(
               "Internal error: JS direct mode should never be pretty-printed",

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -2,50 +2,129 @@ module alias P = SQLParser;
 
 module SKCSV;
 
-base class Token {
-  children =
-  | NewLine()
-  | Comma()
-  | Chars(Array<Char>)
+fun requiresEscape(ch: Char): .Bool {
+  !Chars.isPrintableAscii(ch) || (ch == '"') || (ch == '\\');
 }
 
-fun lexRaw(next: () -> Char): mutable Iterator<Token> {
+// this deviates from 'standard' csv. it actually uses the json
+// escaping algorithm. this is for 2 reasons:
+// 1. this approach is very well battle tested and accounts for more
+//    things than csv usually considers.
+// 2. we have logic that assumes that a row is represented on a single
+//    line (e.g. looking for checkpoint markers). standard csv allows for
+//    line breaks in strings and this wreaks havoc. it'll also hurt
+//    line-based buffering.
+// this is all ok as the csv we produce is not meant to be public
+// facing. and ultimately we plan to replace this with a binary
+// format.
+fun charToString(ch: Char): String {
+  if (!requiresEscape(ch)) {
+    ch.toString()
+  } else {
+    addCode = (chars, code) -> {
+      chars.push('\\');
+      chars.push('u');
+      Chars.intToHexDigits(code, 4).each(chars.push);
+    };
+    ch match {
+    | '\\' -> "\\\\"
+    | '"' -> "\\\""
+    | '\b' -> "\\b"
+    | '\f' -> "\\f"
+    | '\n' -> "\\n"
+    | '\r' -> "\\r"
+    | '\t' -> "\\t"
+    | _ if (Chars.isBasicMultiLingualPlane(ch)) ->
+      chars = mutable Vector<Char>[];
+      addCode(chars, ch.code());
+      String::fromChars(chars.toArray())
+    | _ ->
+      chars = mutable Vector<Char>[];
+      (high, low) = Chars.toUTF16SurrogatePair(ch);
+      addCode(chars, high);
+      addCode(chars, low);
+      String::fromChars(chars.toArray())
+    };
+  }
+}
+
+fun escapeString(s: String): String {
+  s.search(requiresEscape) match {
+  | None() -> "\"" + s + "\""
+  | Some _ ->
+    strings = mutable Vector<String>[];
+    strings.push("\"");
+    s.each(ch -> {
+      strings.push(charToString(ch))
+    });
+    strings.push("\"");
+    strings.join("")
+  };
+}
+
+fun eatHexDigits(iter: () -> Char): Int {
+  result = mutable Vector[];
+  for (_ in Range(0, 4)) result.push(iter());
+  Chars.hexDigitsToInt(result.join(""));
+}
+
+fun decodeString(iter: () -> Char): String {
+  result = mutable Vector[];
+  loop {
+    iter() match {
+    | '"' -> break String::fromChars(result.toArray())
+    | '\\' ->
+      iter() match {
+      | '"' -> result.push('"')
+      | '\\' -> result.push('\\')
+      | '/' -> result.push('/')
+      | 'b' -> result.push('\b')
+      | 'f' -> result.push('\f')
+      | 'n' -> result.push('\n')
+      | 'r' -> result.push('\r')
+      | 't' -> result.push('\t')
+      | 'u' ->
+        leadingCode = eatHexDigits(iter);
+        if (!Chars.isSurrogate(leadingCode)) {
+          result.push(Char::fromCode(leadingCode));
+        } else if (Chars.isLowSurrogate(leadingCode)) {
+          invariant_violation("Trailing surrogate without leading surrogate");
+        } else {
+          trailingCode = eatHexDigits(iter);
+          if (!Chars.isLowSurrogate(trailingCode)) {
+            invariant_violation("Bad low surrogate");
+          };
+          result.push(Chars.fromSurrogatePair(leadingCode, trailingCode));
+        }
+      | _ -> invariant_violation("Invalid escape sequence in CSV string")
+      }
+    | ch if (Chars.isControlC0(ch)) ->
+      invariant_violation("Control C0 character in CSV string: " + ch.code())
+    | x -> result.push(x)
+    }
+  };
+}
+
+fun lex(next: () -> Char): mutable Iterator<(Bool, String)> {
   acc = mutable Vector[];
-  lastIsString = false;
+  processingString = false;
   loop {
     next() match {
     | '\n' ->
-      if (!lastIsString) {
-        str = acc.toArray();
-        acc.clear();
-        yield Chars(str);
+      if (!processingString) {
+        yield (false, String::fromChars(acc.toArray()))
       };
       break void
+    | '"' if (!processingString) ->
+      !processingString = true;
+      yield (true, decodeString(next))
     | ',' ->
-      if (!lastIsString) {
-        str = acc.toArray();
-        acc.clear();
-        yield Chars(str);
+      if (!processingString) {
+        yield (false, String::fromChars(acc.toArray()))
       };
-      !lastIsString = false;
-
-      yield Comma()
-    | '"' ->
-      !lastIsString = true;
-      acc.push('"');
-      loop {
-        c = next();
-        acc.push(c);
-        if (c == '"') {
-          break void;
-        }
-      };
-      str = acc.toArray();
       acc.clear();
-      yield Chars(str)
-    | x ->
-      !lastIsString = false;
-      acc.push(x)
+      !processingString = false
+    | x -> acc.push(x)
     }
   }
 }
@@ -63,46 +142,6 @@ fun trim(chars: Array<Char>): Array<Char> {
   j = chars.size();
   while (j - 1 >= 0 && chars[j - 1] == ' ') !j = j - 1;
   chars.slice(i, j)
-}
-
-fun lex(next: () -> Char): mutable Iterator<(Bool, String)> {
-  stringAcc: ?mutable Vector<Char> = None();
-  isString: Bool = false;
-  for (tok in lexRaw(next)) {
-    (tok, stringAcc) match {
-    | (Chars(chars), Some(acc)) if (chars.size() > 0 && chars[0] == '"') ->
-      !isString = true;
-      !chars = trim(chars);
-      acc.extend(chars.slice(0, chars.size() - 1))
-    | (
-      Chars(chars),
-      None(),
-    ) if (chars.size() > 0 && chars[chars.size() - 1] == '"') ->
-      !isString = true;
-      !chars = trim(chars);
-      !chars = chars.slice(1, chars.size() - 1);
-      !stringAcc = Some(Vector::mcreateFromItems(chars))
-    | _ ->
-      stringAcc match {
-      | None() -> void
-      | Some(acc) ->
-        !stringAcc = None();
-        yield (isString, String::fromChars(acc.toArray()))
-      };
-      !isString = false;
-      tok match {
-      | Chars(chars) -> yield (false, String::fromChars(trim(chars)))
-      | NewLine() -> break void
-      | Comma() -> void
-      }
-    }
-  };
-  stringAcc match {
-  | None() -> void
-  | Some(acc) ->
-    !stringAcc = None();
-    yield (isString, String::fromChars(acc.toArray()))
-  }
 }
 
 fun parseCSVValue(kv: (Bool, String)): P.Value {

--- a/sql/ts/tests/apitests.ts
+++ b/sql/ts/tests/apitests.ts
@@ -368,6 +368,11 @@ async function testClientTail(root: SKDB, user: SKDB) {
       true,
     );
     expect(res).toEqual([{ y: str }]);
+
+    // sanity check that the result we get back in to a json object is
+    // also correctly formed
+    const rows = await user.exec("SELECT y FROM test_pk_string WHERE x = 0");
+    expect(rows).toEqual([{ y: str }]);
   }
 
   // newlines don't break anything, adding...
@@ -385,6 +390,11 @@ async function testClientTail(root: SKDB, user: SKDB) {
       true,
     );
     expect(res).toEqual([{ cnt: 1 }]);
+
+    // sanity check that the result we get back in to a json object is
+    // also correctly formed
+    const rows = await user.exec("SELECT y FROM test_pk_string WHERE x = 1");
+    expect(rows).toEqual([{ y: str }]);
   }
 
   // ...or removing
@@ -415,6 +425,11 @@ async function testClientTail(root: SKDB, user: SKDB) {
       true,
     );
     expect(res).toEqual([{ cnt: 1 }]);
+
+    // sanity check that the result we get back in to a json object is
+    // also correctly formed
+    const rows = await user.exec("SELECT y FROM test_pk_string WHERE x = 1");
+    expect(rows).toEqual([{ y: str }]);
   }
 
   // ...or removing

--- a/sql/ts/tests/apitests.ts
+++ b/sql/ts/tests/apitests.ts
@@ -114,6 +114,11 @@ async function testQueriesAgainstTheServer(skdb: SKDB) {
   );
   expect(tableCreate).toEqual([]);
 
+  await remote.exec(
+    "CREATE TABLE test_pk_string (x INTEGER PRIMARY KEY, y TEXT, skdb_access TEXT);",
+    new Map(),
+  );
+
   const viewCreate = await remote.exec(
     "CREATE REACTIVE VIEW view_pk AS SELECT x, y * 3 AS y, 'read-write' as skdb_access FROM test_pk;",
     {},
@@ -342,6 +347,88 @@ async function testClientTail(root: SKDB, user: SKDB) {
     true,
   );
   expect(resv).toEqual([{ cnt: 1 }]);
+
+  await user.mirror({
+    table: "test_pk_string",
+    expectedColumns: "(x INTEGER PRIMARY KEY, y TEXT, skdb_access TEXT)",
+  });
+
+  // chars outside of ascii replicate and can be queried
+  {
+    const str = "hello, world!\u2122";
+    await user.exec(
+      "insert into test_pk_string values (0,@str,'read-write');",
+      { str },
+    );
+    const res = await waitSynch(
+      root,
+      "select y from test_pk_string where x = 0 and y = @str",
+      (tail) => tail[0].y == str,
+      { str },
+      true,
+    );
+    expect(res).toEqual([{ y: str }]);
+  }
+
+  // newlines don't break anything, adding...
+  {
+    const str = "hello, world!\r\n";
+    await user.exec(
+      "insert into test_pk_string values (1,@str,'read-write');",
+      { str },
+    );
+    const res = await waitSynch(
+      root,
+      "select count(*) as cnt from test_pk_string where x = 1 and y = @str",
+      (tail) => tail[0].cnt == 1,
+      { str },
+      true,
+    );
+    expect(res).toEqual([{ cnt: 1 }]);
+  }
+
+  // ...or removing
+  {
+    await user.exec("delete from test_pk_string where x = 1;", {});
+    const res = await waitSynch(
+      root,
+      "select count(*) as cnt from test_pk_string where x = 1",
+      (tail) => tail[0].cnt == 0,
+      {},
+      true,
+    );
+    expect(res).toEqual([{ cnt: 0 }]);
+  }
+
+  // quotes don't break anything, adding...
+  {
+    const str = "he\"llo\", 'world'!";
+    await user.exec(
+      "insert into test_pk_string values (1,@str,'read-write');",
+      { str },
+    );
+    const res = await waitSynch(
+      root,
+      "select count(*) as cnt from test_pk_string where x = 1 and y = @str",
+      (tail) => tail[0].cnt == 1,
+      { str },
+      true,
+    );
+    expect(res).toEqual([{ cnt: 1 }]);
+  }
+
+  // ...or removing
+  {
+    await user.exec("delete from test_pk_string where x = 1;", {});
+    const res = await waitSynch(
+      root,
+      "select count(*) as cnt from test_pk_string where x = 1",
+      (tail) => tail[0].cnt == 0,
+      {},
+      true,
+    );
+    expect(res).toEqual([{ cnt: 0 }]);
+  }
 }
 
 async function testLargeMirror(root: SKDB, user: SKDB) {


### PR DESCRIPTION
If we insert a string with a newline replication becomes permanently
broken for the client. This is because there is a single w-csv process
per client and the parsing state machine becomes broken. We're looking
for tokens that won't arrive instead of seeing the checkpoint that
indicates end of txn.

The chosen solution is to properly escape and encode strings.

## The encoding itself

The encoding deviates from 'standard' csv -- if there is such a thing.
Instead we use the json escaping algorithm. This is mostly for 2
reasons:

1. this approach is very well battle tested and accounts for more
things than csv usually considers.

2. we have logic that assumes that a row is represented on a single
line (e.g. looking for checkpoint markers, the csv parser itself!).
Standard CSV allows for line breaks in strings and this wreaks havoc.
It'll also hurt line-based buffering. This is all ok as the csv we
produce is not meant to be public facing. And ultimately we plan to
replace this with a binary format.

And it helped that we already have the json en/decoding code written
and tested. I just adapted it a little for the expected interface.