### PR TITLE
Get skdb package to work with node, bundler server, and bundler optimised build

### DIFF
--- a/packages/react/src/skdb-react.tsx
+++ b/packages/react/src/skdb-react.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { createContext, useContext } from "react";
 import type { SKDB } from "skdb";
+import { SKDBTable } from "skdb";
 import { Params } from "skdb/dist/skdb_types.js";
 
 export const SKDBContext = createContext<SKDB | undefined>(undefined);
@@ -29,9 +30,9 @@ export function useQuery(
   query: string,
   params: Params = {},
   defaultRows: Array<any> = [],
-): any {
+): SKDBTable {
   const skdb = useSKDB();
-  const [state, setState] = useState(defaultRows);
+  const [state, setState] = useState<SKDBTable>(new SKDBTable(...defaultRows));
 
   const deps = Object.values(params);
   deps.push(skdb);
@@ -41,7 +42,7 @@ export function useQuery(
     let removeQuery = false;
     const closeable = { close: () => {} };
     skdb
-      .watch(query, params, (rows: Array<any>) => {
+      .watch(query, params, (rows) => {
         setState(rows);
       })
       .then((handle) => {

--- a/prelude/ts/src/sk_browser.ts
+++ b/prelude/ts/src/sk_browser.ts
@@ -4,8 +4,12 @@ import { MemFS, MemSys } from "./sk_mem_utils.js";
 class WrkImpl implements Wrk {
   worker: Worker;
 
-  constructor(filename: string | URL, options?: WorkerOptions) {
-    this.worker = new Worker(filename, options);
+  constructor(worker: Worker) {
+    this.worker = worker;
+  }
+
+  static fromPath(filename: string | URL, options?: WorkerOptions) {
+    return new this(new Worker(filename, options))
   }
 
   postMessage = (message: any) => {
@@ -30,6 +34,7 @@ class Env implements Environment {
   base64Decode: (base64: string) => Uint8Array;
   createSocket: (uri: string) => WebSocket;
   createWorker: (filename: string | URL, options?: WorkerOptions) => Wrk;
+  createWorkerWrapper: (worker: Worker) => Wrk;
   crypto: () => Crypto;
   environment: Array<string>;
 
@@ -75,7 +80,8 @@ class Env implements Environment {
     this.onException = () => {};
     this.createSocket = (uri: string) => new WebSocket(uri);
     this.createWorker = (filename: string | URL, options?: WorkerOptions) =>
-      new WrkImpl(filename, options);
+      WrkImpl.fromPath(filename, options);
+    this.createWorkerWrapper = (worker: Worker) => new WrkImpl(worker);
     this.crypto = () => crypto;
   }
 }

--- a/prelude/ts/src/sk_node.ts
+++ b/prelude/ts/src/sk_node.ts
@@ -12,8 +12,15 @@ import { WebSocket } from "ws";
 class WrkImpl implements Wrk {
   worker: Worker;
 
-  constructor(filename: string | URL, options?: WorkerOptions) {
-    this.worker = new Worker(filename, options);
+  constructor(worker: Worker) {
+    this.worker = worker;
+  }
+
+  static fromPath(
+    filename: string | URL,
+    options: WorkerOptions | undefined,
+  ): Wrk {
+    return new this(new Worker(filename, options));
   }
 
   postMessage = (message: any) => {
@@ -41,6 +48,7 @@ class Env implements Environment {
   throwRuntime: (code: int) => void;
   createSocket: (uri: string) => WebSocket;
   createWorker: (filename: string | URL, options?: WorkerOptions) => Wrk;
+  createWorkerWrapper: (worker: any) => Wrk;
   crypto: () => Crypto;
   fs() {
     return this.fileSystem;
@@ -85,7 +93,10 @@ class Env implements Environment {
     };
     this.createSocket = (uri: string) => new WebSocket(uri);
     this.createWorker = (filename: string | URL, options?: WorkerOptions) =>
-      new WrkImpl(filename, options);
+      WrkImpl.fromPath(filename, options);
+    this.createWorkerWrapper = (worker: Worker) => {
+      throw new Error("Not implemented");
+    };
     this.crypto = () => crypto as Crypto;
   }
 }

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -152,6 +152,7 @@ export interface Environment {
   environment: Array<string>;
   createSocket: (uir: string) => WebSocket;
   createWorker: (filename: string | URL, options?: WorkerOptions) => Wrk;
+  createWorkerWrapper: (worker: Worker) => Wrk;
   timestamp: () => float;
   decodeUTF8: (utf8: ArrayBuffer) => string;
   encodeUTF8: (str: string) => Uint8Array;
@@ -775,7 +776,7 @@ export async function loadEnv(
   // don't follow the node dynamic import
   const nodeImport = "./sk_node.mjs";
   const environment = await (isNode()
-    ? import(nodeImport)
+    ? import(/* @vite-ignore */ nodeImport)
     : //@ts-ignore
       import("./sk_browser.mjs"));
   let env = environment.environment(envVals) as Environment;

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -693,7 +693,7 @@ export function trimEndChar(str: string, ch: string) {
   return end < str.length ? str.substring(0, end) : str;
 }
 
-function relativeto(path: string, ref: string) {
+export function relativeto(path: string, ref: string) {
   if (ref.length == 0) {
     return path;
   }
@@ -803,6 +803,24 @@ export async function run(
   } else {
     let path = relativeto(resolve("./" + wasm64 + ".wasm"), env.rootPath());
     buffer = await env.fetch(path);
+  }
+  return await start(modules, buffer, env, main);
+}
+
+export async function runUrl(
+  getUrl: (env: Environment) => Promise<string>,
+  modules: Array<string>,
+  envs: Map<string, Array<string>>,
+  main?: string,
+  getWasmSource?: () => Promise<Uint8Array>,
+) {
+  let env = await loadEnv(envs);
+  let buffer: Uint8Array;
+  if (getWasmSource) {
+    buffer = await getWasmSource();
+  } else {
+    const url = await getUrl(env);
+    buffer = await env.fetch(url);
   }
   return await start(modules, buffer, env, main);
 }

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -746,20 +746,18 @@ export function loadWasm(
 }
 
 async function start(
-  modules: Array<string>,
+  modules: Array<any>,
   buffer: Uint8Array,
   environment: Environment,
   main?: string,
 ) {
-  let promises = modules.map((name) =>
-    import(name).then((module) => {
-      if (module.init) {
-        return module.init(environment);
-      } else {
-        return null;
-      }
-    }),
-  );
+  let promises = modules.map((module) => {
+    if (module.init) {
+      return module.init(environment);
+    } else {
+      return null;
+    }
+  });
   let cs = await Promise.all(promises);
   let ms = cs.filter((c) => c != null);
   return await loadWasm(buffer, ms, environment, main);

--- a/sknpm/src/main.sk
+++ b/sknpm/src/main.sk
@@ -916,9 +916,7 @@ fun copyAndConvertImport(
             elems = imported[1].split("/");
             size = elems.size();
             if (size > 1 && elems[0].startsWith("#")) {
-              !elems = elems.mapWithIndex((idx, v) ->
-                if (idx == 0) "." else v
-              );
+              !elems = elems.mapWithIndex((idx, v) -> if (idx == 0) "." else v);
               !line = `${elements[0]} from "${elems.join("/")}"`
             }
           }
@@ -1004,9 +1002,11 @@ fun copyAndConvertImport(
   };
   invariant(!runtime.isEmpty(), "Runtime must be defined.");
   saved = SKStore.newObstack();
-  strModules = Vector[`"./${runtime}"`].concat(loaderFiles.map(m -> `"./${m}"`))
-    .concat(moduleFiles.map(m -> `"./${m}"`))
-    .join(", ");
+  moduleName = (m) -> m.split(".", 2)[0];
+  import = (m) -> `import * as ${moduleName(m)} from "./${m}";`;
+  files = Vector[runtime].concat(loaderFiles).concat(moduleFiles);
+  imports = files.map(import).join("\n");
+  modulesList = files.map(moduleName).join(", ");
   strExtensions = "";
   extensionsFiles
     .map((_, v) -> "[" + v.map(c -> `"./${c}"`).join(", ") + "]")
@@ -1024,7 +1024,7 @@ fun copyAndConvertImport(
       if (cLine == nameLine) {
         `var wasm64 = "${binary()}";`
       } else if (cLine == modulesLines) {
-        `var modules = [${strModules}];`
+        `${imports}\nvar modules = [${modulesList}];`
       } else if (cLine == base64Line) {
         resources.maybeGet(sf) match {
         | Some(b64File) ->

--- a/sql/ts/src/skdb.ts
+++ b/sql/ts/src/skdb.ts
@@ -1,4 +1,6 @@
 import { run, loadEnv, isNode } from "#std/sk_types.js";
+import { createOnThisThread } from "./skdb_create.js";
+import type { Wrk } from "#std/sk_types.js";
 import type { SKDB, SKDBSync, SKDBShared } from "./skdb_types.js";
 import { SKDBWorker } from "./skdb_wdatabase.js";
 export { SKDBTable as SKDBTable } from "./skdb_util.js";
@@ -26,7 +28,8 @@ export async function createSkdb(
     options.asWorker != undefined ? options.asWorker : !options.getWasmSource;
   const disableWarnings = options.disableWarnings ?? false;
   if (!asWorker) {
-    return createOnMain(disableWarnings, options.dbName, options.getWasmSource);
+    // @ts-ignore
+    return createOnThisThread(disableWarnings, modules, extensions, options.dbName, options.getWasmSource);
   } else {
     if (options.getWasmSource) {
       throw new Error("getWasmSource is not compatible with worker");
@@ -54,35 +57,21 @@ async function createSkdbSync(
   );
 }
 
-async function createOnMain(
-  disableWarnings: boolean,
-  dbName?: string,
-  getWasmSource?: () => Promise<Uint8Array>,
-) {
-  let data = await run(
-    wasm64,
-    // @ts-ignore
-    modules,
-    extensions,
-    "SKDB_factory",
-    getWasmSource,
-  );
-  data.environment.disableWarnings = disableWarnings;
-  return (data.environment.shared.get("SKDB") as SKDBShared).create(dbName);
-}
-
 async function createWorker(disableWarnings: boolean, dbName?: string) {
   let env = await loadEnv(extensions);
   env.disableWarnings = disableWarnings;
-  let path: string;
+  let worker: Wrk;
   if (isNode()) {
-    path = import.meta.url.replace("/skdb.mjs", "/skdb_nodeworker.mjs");
-    // @ts-ignore
+    let path = import.meta.url.replace("/skdb.mjs", "/skdb_nodeworker.mjs");
+    //@ts-ignore
     path = "./" + path.substring(process.cwd().length + 8);
+    worker = env.createWorker(path, { type: "module" });
   } else {
-    path = import.meta.url.replace("/skdb.mjs", "/skdb_worker.mjs");
+    // important that this line looks exactly like this for bundlers to discover the file
+    const wrapped = new Worker(new URL("./skdb_worker.mjs", import.meta.url),
+      {type: 'module'});
+    worker = env.createWorkerWrapper(wrapped);
   }
-  let worker = env.createWorker(path, { type: "module" });
   let skdb = new SKDBWorker(worker);
   await skdb.create(dbName);
   return skdb;

--- a/sql/ts/src/skdb.ts
+++ b/sql/ts/src/skdb.ts
@@ -29,7 +29,13 @@ export async function createSkdb(
   const disableWarnings = options.disableWarnings ?? false;
   if (!asWorker) {
     // @ts-ignore
-    return createOnThisThread(disableWarnings, modules, extensions, options.dbName, options.getWasmSource);
+    return createOnThisThread(
+      disableWarnings,
+      modules,
+      extensions,
+      options.dbName,
+      options.getWasmSource,
+    );
   } else {
     if (options.getWasmSource) {
       throw new Error("getWasmSource is not compatible with worker");
@@ -68,8 +74,9 @@ async function createWorker(disableWarnings: boolean, dbName?: string) {
     worker = env.createWorker(path, { type: "module" });
   } else {
     // important that this line looks exactly like this for bundlers to discover the file
-    const wrapped = new Worker(new URL("./skdb_worker.mjs", import.meta.url),
-      {type: 'module'});
+    const wrapped = new Worker(new URL("./skdb_worker.mjs", import.meta.url), {
+      type: "module",
+    });
     worker = env.createWorkerWrapper(wrapped);
   }
   let skdb = new SKDBWorker(worker);

--- a/sql/ts/src/skdb.ts
+++ b/sql/ts/src/skdb.ts
@@ -1,4 +1,4 @@
-import { run, loadEnv, isNode } from "#std/sk_types.js";
+import { runUrl, loadEnv, isNode } from "#std/sk_types.js";
 import { createOnThisThread } from "./skdb_create.js";
 import type { Wrk } from "#std/sk_types.js";
 import type { SKDB, SKDBSync, SKDBShared } from "./skdb_types.js";
@@ -7,8 +7,8 @@ export { SKDBTable as SKDBTable } from "./skdb_util.js";
 export type { SKDB, RemoteSKDB } from "./skdb_types.js";
 export type { Creds, MuxedSocket } from "./skdb_orchestration.js";
 export type { Environment } from "#std/sk_types.js";
+import { getWasmUrl } from "./skdb_wasm_locator.js";
 
-var wasm64 = "skdb";
 // sknpm searches for the modules line verbatim
 // @ts-ignore
 // prettier-ignore
@@ -44,8 +44,8 @@ async function createSkdbSync(
     getWasmSource?: () => Promise<Uint8Array>;
   } = {},
 ): Promise<SKDBSync> {
-  let data = await run(
-    wasm64,
+  let data = await runUrl(
+    getWasmUrl,
     // @ts-ignore
     modules,
     extensions,

--- a/sql/ts/src/skdb_create.ts
+++ b/sql/ts/src/skdb_create.ts
@@ -1,0 +1,23 @@
+import { run } from "#std/sk_types.js";
+import type { SKDBShared } from "./skdb_types.js";
+
+var wasm64 = "skdb";
+
+export async function createOnThisThread(
+  disableWarnings: boolean,
+  modules: Array<string>,
+  envs: Map<string, Array<string>>,
+  dbName?: string,
+  getWasmSource?: () => Promise<Uint8Array>,
+) {
+  let data = await run(
+    wasm64,
+    // @ts-ignore
+    modules,
+    envs,
+    "SKDB_factory",
+    getWasmSource,
+  );
+  data.environment.disableWarnings = disableWarnings;
+  return (data.environment.shared.get("SKDB") as SKDBShared).create(dbName);
+}

--- a/sql/ts/src/skdb_create.ts
+++ b/sql/ts/src/skdb_create.ts
@@ -1,7 +1,6 @@
-import { run } from "#std/sk_types.js";
+import { runUrl } from "#std/sk_types.js";
 import type { SKDBShared } from "./skdb_types.js";
-
-var wasm64 = "skdb";
+import { getWasmUrl } from "./skdb_wasm_locator.js";
 
 export async function createOnThisThread(
   disableWarnings: boolean,
@@ -10,8 +9,8 @@ export async function createOnThisThread(
   dbName?: string,
   getWasmSource?: () => Promise<Uint8Array>,
 ) {
-  let data = await run(
-    wasm64,
+  let data = await runUrl(
+    getWasmUrl,
     // @ts-ignore
     modules,
     envs,

--- a/sql/ts/src/skdb_wasm_locator.ts
+++ b/sql/ts/src/skdb_wasm_locator.ts
@@ -2,11 +2,12 @@ import { isNode, relativeto, resolve } from "#std/sk_types.js";
 import type { Environment } from "#std/sk_types.js";
 
 export async function getWasmUrl(env: Environment): Promise<string> {
-  if (isNode()) {
-    return relativeto(resolve("./skdb.wasm"), env.rootPath());
-  } else {
+  //@ts-ignore
+  if (import.meta.env || import.meta.webpack) {
     //@ts-ignore
     const url = await import("./skdb.wasm?url");
     return url.default;
   }
+
+  return relativeto(resolve("./skdb.wasm"), env.rootPath());
 }

--- a/sql/ts/src/skdb_wasm_locator.ts
+++ b/sql/ts/src/skdb_wasm_locator.ts
@@ -3,7 +3,7 @@ import type { Environment } from "#std/sk_types.js";
 
 export async function getWasmUrl(env: Environment): Promise<string> {
   if (isNode()) {
-    return relativeto(resolve("./skdb.wasm"), env.rootPath())
+    return relativeto(resolve("./skdb.wasm"), env.rootPath());
   } else {
     //@ts-ignore
     const url = await import("./skdb.wasm?url");

--- a/sql/ts/src/skdb_wasm_locator.ts
+++ b/sql/ts/src/skdb_wasm_locator.ts
@@ -1,0 +1,12 @@
+import { isNode, relativeto, resolve } from "#std/sk_types.js";
+import type { Environment } from "#std/sk_types.js";
+
+export async function getWasmUrl(env: Environment): Promise<string> {
+  if (isNode()) {
+    return relativeto(resolve("./skdb.wasm"), env.rootPath())
+  } else {
+    //@ts-ignore
+    const url = await import("./skdb.wasm?url");
+    return url.default;
+  }
+}

--- a/sql/ts/src/skdb_worker.ts
+++ b/sql/ts/src/skdb_worker.ts
@@ -1,10 +1,36 @@
-import { onDbWorkerMessage } from "./skdb_wmessage.js";
+import { createOnThisThread } from "./skdb_create.js";
+import { onWorkerMessage } from "#std/sk_worker.js";
+import type { Creator } from "#std/sk_worker.js";
+import type { SKDB } from "./skdb.js";
+
+// @ts-ignore
+// prettier-ignore
+var modules = [ /*--MODULES--*/];
+var extensions = new Map();
+/*--EXTENSIONS--*/
+
+class DbCreator implements Creator<SKDB> {
+  getName() {
+    return "create";
+  }
+
+  getType() {
+    return "Database";
+  }
+
+  async create(dbName?: string) {
+    // @ts-ignore
+    return createOnThisThread(false, modules, extensions, dbName);
+  }
+}
+
+const creator = new DbCreator();
 
 var post = (message: any) => {
   postMessage(message);
 };
 
 var onMessage = (message: MessageEvent) =>
-  onDbWorkerMessage(message.data, post);
+  onWorkerMessage(message.data, post, creator);
 
 addEventListener("message", onMessage);


### PR DESCRIPTION
Previously we had the first two, but the optimised build didn't work.

When building for production, the bundler statically analyses the code
to find the dep. tree. It then concatenates, minifies, tree shakes,
etc the js files to produce the smallest set of files possible and
reduce http round trips.

We were being too clever and the bundler couldn't see some of our
module loading so files were not being included. It also broke the
worker and wasm loading.

I've tested the cross product of:

- running skdb on the main thread
- running skdb on a worker thread

- in a node setup
- in a vite dev setup - the clever hot module reloading server thing
- in a vite prod setup - doing a vite build and then serving the files statically

Webpack is another very popular bundler. I looked at it's docs when
considering solutions and it seems to be compatible with this, but I
haven't tested.