### PR TITLE
[stdlib] Fix `Time.time()`/`Time.time_ms()`.

### DIFF
--- a/prelude/src/stdlib/other/Time.sk
+++ b/prelude/src/stdlib/other/Time.sk
@@ -1,10 +1,12 @@
 module Time;
 
+@debug
 @cpp_extern("SKIP_time")
 native fun time(): Int;
 
 // Current time expressed as the number of milliseconds since
 // 1970-01-01T00:00:00.000Z, the beginning of the Unix epoch.
+@debug
 @cpp_extern("SKIP_time_ms")
 native fun time_ms(): Int;
 


### PR DESCRIPTION
These runtime functions not being marked `@debug` meant they were eligible to CSE, causing the following code to always return zero:
```
t0 = Time.time_ms();
f();
t1 = Time.time_ms();

t1 - t0
```