### PR TITLE
[runtime] Fix warnings

### DIFF
--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,6 +1,6 @@
 MEMSIZE32=1073741824
 
-COMMONFLAGS=-Wpointer-arith
+COMMONFLAGS=-Wpointer-arith -Wunused-variable
 OLEVEL=-O2
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
 CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,6 +1,6 @@
 MEMSIZE32=1073741824
 
-COMMONFLAGS=-Wall -Wno-sometimes-uninitialized -Wunused-parameter -Wno-c2x-extensions
+COMMONFLAGS=-Wall -Wno-sometimes-uninitialized -Wunused-parameter -Wno-c2x-extensions -Wsign-compare
 OLEVEL=-O2
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
 CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,6 +1,6 @@
 MEMSIZE32=1073741824
 
-COMMONFLAGS=-Wpointer-arith -Wunused-variable
+COMMONFLAGS=-Wpointer-arith -Wunused-variable -Wsometimes-uninitialized
 OLEVEL=-O2
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
 CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,6 +1,6 @@
 MEMSIZE32=1073741824
 
-COMMONFLAGS=-Wall -Wno-sometimes-uninitialized
+COMMONFLAGS=-Wall -Wno-sometimes-uninitialized -Wunused-parameter -Wno-c2x-extensions
 OLEVEL=-O2
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
 CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,6 +1,6 @@
 MEMSIZE32=1073741824
 
-COMMONFLAGS=-Wpointer-arith -Wunused-variable -Wsometimes-uninitialized
+COMMONFLAGS=-Wall -Wno-sometimes-uninitialized
 OLEVEL=-O2
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
 CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,6 +1,9 @@
 MEMSIZE32=1073741824
 
-COMMONFLAGS=-Wall -Wno-sometimes-uninitialized -Wunused-parameter -Wno-c2x-extensions -Wsign-compare -Wextra-semi-stmt
+COMMONFLAGS=-Wall -Wextra -Wno-sign-conversion -Wno-sometimes-uninitialized -Wno-c2x-extensions -Wsign-compare -Wextra-semi-stmt
+# To add: -Wcast-align -Wcast-qual -Wimplicit-int-conversion -Wmissing-noreturn -Wpadded -Wreserved-identifier -Wshorten-64-to-32 -Wtautological-unsigned-zero-compare
+# -Watomic-implicit-seq-cst ?
+# If using -Weverything, you may want to add -Wno-declaration-after-statement -Wno-missing-prototypes -Wno-missing-variable-declarations -Wno-shadow -Wno-strict-prototypes -Wno-zero-length-array -Wno-unreachable-code-break -Wno-unreachable-code-return
 OLEVEL=-O2
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
 CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,6 +1,6 @@
 MEMSIZE32=1073741824
 
-COMMONFLAGS=-Wall -Wno-sometimes-uninitialized -Wunused-parameter -Wno-c2x-extensions -Wsign-compare
+COMMONFLAGS=-Wall -Wno-sometimes-uninitialized -Wunused-parameter -Wno-c2x-extensions -Wsign-compare -Wextra-semi-stmt
 OLEVEL=-O2
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
 CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,8 +1,9 @@
 MEMSIZE32=1073741824
 
+COMMONFLAGS=-Wpointer-arith
 OLEVEL=-O2
-CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc
-CC64FLAGS=$(OLEVEL) -DSKIP64
+CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
+CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)
 
 # NB: this MUST be kept in sync with CRELFILES in prelude/build.mk
 # and CRELFILES in prelude/build_wasm32.mk

--- a/compiler/runtime/copy.c
+++ b/compiler/runtime/copy.c
@@ -113,7 +113,7 @@ static char* SKIP_copy_obj(sk_stack_t* st, char* obj, char* large_page) {
       break;
     default:
       // NOT SUPPORTED
-      SKIP_exit(-1);
+      SKIP_exit((SkipInt)-1);
   }
 
   return (char*)result;

--- a/compiler/runtime/copy.c
+++ b/compiler/runtime/copy.c
@@ -31,7 +31,6 @@ static char* SKIP_copy_class(sk_stack_t* st, char* obj, char* large_page) {
   if ((ty->m_refsHintMask & 1) != 0) {
     size_t size = ty->m_userByteSize / sizeof(void*);
     size_t bitsize = sizeof(void*) * 8;
-    size_t slot = 0;
     size_t mask_slot = 0;
     int i;
     while (size > 0) {
@@ -71,7 +70,6 @@ static char* SKIP_copy_array(sk_stack_t* st, char* obj, char* large_page) {
 
     while (ohead < end) {
       size_t size = ty->m_userByteSize;
-      size_t slot = 0;
       size_t mask_slot = 0;
       while (size > 0) {
         int i;

--- a/compiler/runtime/copy.c
+++ b/compiler/runtime/copy.c
@@ -42,7 +42,7 @@ static char* SKIP_copy_class(sk_stack_t* st, char* obj, char* large_page) {
             sk_stack_push(st, ptr, slot);
           }
         }
-      };
+      }
       if (size < bitsize) {
         break;
       }
@@ -84,7 +84,7 @@ static char* SKIP_copy_array(sk_stack_t* st, char* obj, char* large_page) {
           ohead += sizeof(void*);
           rhead += sizeof(void*);
           size -= sizeof(void*);
-        };
+        }
         mask_slot++;
       }
     }

--- a/compiler/runtime/copy.c
+++ b/compiler/runtime/copy.c
@@ -32,7 +32,7 @@ static char* SKIP_copy_class(sk_stack_t* st, char* obj, char* large_page) {
     size_t size = ty->m_userByteSize / sizeof(void*);
     size_t bitsize = sizeof(void*) * 8;
     size_t mask_slot = 0;
-    int i;
+    unsigned int i;
     while (size > 0) {
       for (i = 0; i < bitsize && i < size; i++) {
         if (ty->m_refMask[mask_slot] & (1 << i)) {
@@ -72,7 +72,7 @@ static char* SKIP_copy_array(sk_stack_t* st, char* obj, char* large_page) {
       size_t size = ty->m_userByteSize;
       size_t mask_slot = 0;
       while (size > 0) {
-        int i;
+        unsigned int i;
         for (i = 0; i < bitsize && size > 0; i++) {
           if (ty->m_refMask[mask_slot] & (1 << i)) {
             void** ptr = (void**)ohead;
@@ -139,7 +139,7 @@ void* SKIP_copy_with_pages(void* obj, size_t nbr_pages, sk_cell_t* pages) {
     sk_value_t delayed = sk_stack_pop(st);
     void* toCopy = *delayed.value;
 
-    int obstack_idx = sk_get_obstack_idx(toCopy, pages, nbr_pages);
+    size_t obstack_idx = sk_get_obstack_idx(toCopy, pages, nbr_pages);
 
     if (obstack_idx >= nbr_pages) {
       continue;
@@ -156,7 +156,7 @@ void* SKIP_copy_with_pages(void* obj, size_t nbr_pages, sk_cell_t* pages) {
 
     if (SKIP_is_string(toCopy)) {
       sk_string_t* str = (sk_string_t*)((char*)toCopy - sizeof(uint32_t) * 2);
-      if (str->size != -1 && str->size < sizeof(void*)) {
+      if (str->size != (uint32_t)-1 && str->size < sizeof(void*)) {
         void* copied_ptr = SKIP_copy_string(toCopy, large_page);
         *delayed.slot = copied_ptr;
         continue;

--- a/compiler/runtime/free.c
+++ b/compiler/runtime/free.c
@@ -140,7 +140,7 @@ void sk_free_obj(sk_stack_t* st, char* obj) {
       break;
     default:
       // NOT SUPPORTED
-      SKIP_exit(-1);
+      SKIP_exit((SkipInt)-1);
   }
 
   return;

--- a/compiler/runtime/free.c
+++ b/compiler/runtime/free.c
@@ -14,7 +14,7 @@ extern sk_list_t* sk_external_pointers;
 
 static SkipInt test_counter = 0;
 
-void SKIP_test_free_external_pointer(SkipInt n) {
+void SKIP_test_free_external_pointer(SkipInt /* n */) {
   test_counter++;
 }
 

--- a/compiler/runtime/free.c
+++ b/compiler/runtime/free.c
@@ -60,7 +60,7 @@ void sk_free_class(sk_stack_t* st, char* obj) {
     size_t size = ty->m_userByteSize / sizeof(void*);
     size_t bitsize = sizeof(void*) * 8;
     size_t mask_slot = 0;
-    int i;
+    unsigned int i;
     while (size > 0) {
       for (i = 0; i < bitsize && i < size; i++) {
         if (ty->m_refMask[mask_slot] & (1 << i)) {
@@ -97,7 +97,7 @@ void sk_free_array(sk_stack_t* st, char* obj) {
       size_t size = ty->m_userByteSize;
       size_t mask_slot = 0;
       while (size > 0) {
-        int i;
+        unsigned int i;
         for (i = 0; i < bitsize && size > 0; i++) {
           if (ty->m_refMask[mask_slot] & (1 << i)) {
             void* ptr = *((void**)ohead);

--- a/compiler/runtime/free.c
+++ b/compiler/runtime/free.c
@@ -59,7 +59,6 @@ void sk_free_class(sk_stack_t* st, char* obj) {
   } else if ((ty->m_refsHintMask & 1) != 0) {
     size_t size = ty->m_userByteSize / sizeof(void*);
     size_t bitsize = sizeof(void*) * 8;
-    size_t slot = 0;
     size_t mask_slot = 0;
     int i;
     while (size > 0) {
@@ -96,7 +95,6 @@ void sk_free_array(sk_stack_t* st, char* obj) {
 
     while (ohead < end) {
       size_t size = ty->m_userByteSize;
-      size_t slot = 0;
       size_t mask_slot = 0;
       while (size > 0) {
         int i;

--- a/compiler/runtime/free.c
+++ b/compiler/runtime/free.c
@@ -67,7 +67,7 @@ void sk_free_class(sk_stack_t* st, char* obj) {
           void* ptr = *(((void**)obj) + (mask_slot * bitsize) + i);
           sk_stack_push(st, ptr, ptr);
         }
-      };
+      }
       if (size < bitsize) {
         break;
       }
@@ -105,7 +105,7 @@ void sk_free_array(sk_stack_t* st, char* obj) {
           }
           ohead += sizeof(void*);
           size -= sizeof(void*);
-        };
+        }
         mask_slot++;
       }
     }

--- a/compiler/runtime/hash.c
+++ b/compiler/runtime/hash.c
@@ -236,7 +236,7 @@ static uint64_t sk_hash_obj(sk_stack_t* st, char* obj) {
       break;
     default:
       // NOT SUPPORTED
-      SKIP_exit(-1);
+      SKIP_exit((SkipInt)-1);
   }
 
   crc = sk_crc64_combine(crc, ty);

--- a/compiler/runtime/hash.c
+++ b/compiler/runtime/hash.c
@@ -101,7 +101,7 @@ const uint64_t crc64table[256] = {
 
 static uint64_t sk_crc64(uint64_t crc, const void* p, size_t len) {
   const unsigned char* _p = p;
-  const unsigned char* end = p + len;
+  const unsigned char* end = _p + len;
 
   while (_p < end) {
     unsigned int t = ((unsigned int)(crc >> 56) ^ (*_p++)) & 0xFF;

--- a/compiler/runtime/hash.c
+++ b/compiler/runtime/hash.c
@@ -158,7 +158,7 @@ static uint64_t sk_hash_class(sk_stack_t* st, char* obj) {
       } else {
         crc = sk_crc64_combine(crc, *ptr);
       }
-    };
+    }
     if (size < bitsize) {
       break;
     }
@@ -199,7 +199,7 @@ static uint64_t sk_hash_array(sk_stack_t* st, char* obj) {
           }
           ohead += sizeof(void*);
           size -= sizeof(void*);
-        };
+        }
         mask_slot++;
       }
     }

--- a/compiler/runtime/hash.c
+++ b/compiler/runtime/hash.c
@@ -140,13 +140,10 @@ SkipInt SKIP_hash_combine(SkipInt crc1, SkipInt crc2) {
 static uint64_t sk_hash_class(sk_stack_t* st, char* obj) {
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
-  size_t memsize = ty->m_userByteSize;
-  size_t leftsize = ty->m_uninternedMetadataByteSize;
   uint64_t crc = CRC_INIT;
 
   size_t size = ty->m_userByteSize / sizeof(void*);
   size_t bitsize = sizeof(void*) * 8;
-  size_t slot = 0;
   size_t mask_slot = 0;
   int i;
 
@@ -178,11 +175,7 @@ static uint64_t sk_hash_array(sk_stack_t* st, char* obj) {
 
   size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
   size_t memsize = ty->m_userByteSize * len;
-  size_t leftsize = ty->m_uninternedMetadataByteSize;
   size_t bitsize = sizeof(void*) * 8;
-
-  char* ohead = obj;
-  char* end = obj + memsize;
 
   if ((ty->m_refsHintMask & 1) == 0) {
     crc = sk_crc64(crc, obj, len * ty->m_userByteSize);
@@ -192,7 +185,6 @@ static uint64_t sk_hash_array(sk_stack_t* st, char* obj) {
 
     while (ohead < end) {
       size_t size = ty->m_userByteSize;
-      size_t slot = 0;
       size_t mask_slot = 0;
       while (size > 0) {
         int i;

--- a/compiler/runtime/hash.c
+++ b/compiler/runtime/hash.c
@@ -145,7 +145,7 @@ static uint64_t sk_hash_class(sk_stack_t* st, char* obj) {
   size_t size = ty->m_userByteSize / sizeof(void*);
   size_t bitsize = sizeof(void*) * 8;
   size_t mask_slot = 0;
-  int i;
+  unsigned int i;
 
   while (size > 0) {
     for (i = 0; i < bitsize && i < size; i++) {
@@ -187,7 +187,7 @@ static uint64_t sk_hash_array(sk_stack_t* st, char* obj) {
       size_t size = ty->m_userByteSize;
       size_t mask_slot = 0;
       while (size > 0) {
-        int i;
+        unsigned int i;
         for (i = 0; i < bitsize && size > 0; i++) {
           if (ty->m_refMask[mask_slot] & (1 << i)) {
             void** ptr = (void**)ohead;

--- a/compiler/runtime/hashtable.c
+++ b/compiler/runtime/hashtable.c
@@ -129,7 +129,7 @@ int sk_test_table() {
     if ((uintptr_t)cell->value != i) {
       return 3;
     }
-  };
+  }
 
   return 0;
 }

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -147,7 +147,7 @@ static char* SKIP_intern_class(sk_stack_t* st, char* obj) {
     size_t size = ty->m_userByteSize / sizeof(void*);
     size_t bitsize = sizeof(void*) * 8;
     size_t mask_slot = 0;
-    int i;
+    unsigned int i;
     while (size > 0) {
       for (i = 0; i < bitsize && i < size; i++) {
         if (ty->m_refMask[mask_slot] & (1 << i)) {
@@ -187,7 +187,7 @@ static char* SKIP_intern_array(sk_stack_t* st, char* obj) {
       size_t size = ty->m_userByteSize;
       size_t mask_slot = 0;
       while (size > 0) {
-        int i;
+        unsigned int i;
         for (i = 0; i < bitsize && size > 0; i++) {
           if (ty->m_refMask[mask_slot] & (1 << i)) {
             void** ptr = (void**)ohead;
@@ -252,7 +252,7 @@ void* SKIP_intern_shared(void* obj) {
   int* large_pages = sk_malloc(sizeof(int) * nbr_pages);
 
   {
-    int i;
+    unsigned int i;
     for (i = 0; i < nbr_pages; i++) {
       large_pages[i] = 0;
     }
@@ -285,7 +285,7 @@ void* SKIP_intern_shared(void* obj) {
 
     if (SKIP_is_string(toCopy)) {
       sk_string_t* str = (sk_string_t*)((char*)toCopy - sizeof(uint32_t) * 2);
-      if (str->size != -1 && str->size < sizeof(void*)) {
+      if (str->size != (uint32_t)-1 && str->size < sizeof(void*)) {
         void* interned_ptr = SKIP_intern_string(toCopy);
         *delayed.slot = interned_ptr;
         continue;
@@ -330,7 +330,7 @@ void* SKIP_intern_shared(void* obj) {
   }
 
   {
-    int i;
+    unsigned int i;
     for (i = 0; i < nbr_pages; i++) {
       if (large_pages[i]) {
         pages[i].value = (uint64_t)pages[i].key;

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -146,7 +146,6 @@ static char* SKIP_intern_class(sk_stack_t* st, char* obj) {
       (ty->m_refsHintMask & 1) != 0) {
     size_t size = ty->m_userByteSize / sizeof(void*);
     size_t bitsize = sizeof(void*) * 8;
-    size_t slot = 0;
     size_t mask_slot = 0;
     int i;
     while (size > 0) {
@@ -186,7 +185,6 @@ static char* SKIP_intern_array(sk_stack_t* st, char* obj) {
 
     while (ohead < end) {
       size_t size = ty->m_userByteSize;
-      size_t slot = 0;
       size_t mask_slot = 0;
       while (size > 0) {
         int i;

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -157,7 +157,7 @@ static char* SKIP_intern_class(sk_stack_t* st, char* obj) {
             sk_stack_push(st, ptr, slot);
           }
         }
-      };
+      }
       if (size < bitsize) {
         break;
       }
@@ -199,7 +199,7 @@ static char* SKIP_intern_array(sk_stack_t* st, char* obj) {
           ohead += sizeof(void*);
           rhead += sizeof(void*);
           size -= sizeof(void*);
-        };
+        }
         mask_slot++;
       }
     }

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -89,7 +89,7 @@ void sk_incr_ref_count(void* obj) {
         count -= 3;
         break;
       default:
-        SKIP_exit(-1);
+        SKIP_exit((SkipInt)-1);
     }
   }
   *count = *count + 1;
@@ -115,7 +115,7 @@ static uintptr_t* sk_get_ref_count_addr(void* obj) {
         count -= 3;
         break;
       default:
-        SKIP_exit(-1);
+        SKIP_exit((SkipInt)-1);
     }
   }
   return count;
@@ -232,7 +232,7 @@ static char* SKIP_intern_obj(sk_stack_t* st, char* obj) {
       break;
     default:
       // NOT SUPPORTED
-      SKIP_exit(-1);
+      SKIP_exit((SkipInt)-1);
   }
 
   return (char*)result;

--- a/compiler/runtime/memory.c
+++ b/compiler/runtime/memory.c
@@ -185,7 +185,7 @@ void* sk_malloc(size_t size) {
   return result;
 }
 
-void sk_free_size(void* ptr, size_t size) {
+void sk_free_size(void* ptr, size_t /* size */) {
 #ifdef MEMORY_CHECK
   sk_htbl_remove(sk_malloc_table, ptr);
 #endif

--- a/compiler/runtime/memory.c
+++ b/compiler/runtime/memory.c
@@ -29,13 +29,13 @@ size_t sk_pow2_size(size_t size) {
 }
 
 void sk_add_ftable(void* ptr, size_t size) {
-  int slot = sk_bit_size(size);
+  size_t slot = sk_bit_size(size);
   *(void**)ptr = sk_ftable[slot];
   sk_ftable[slot] = ptr;
 }
 
 void* sk_get_ftable(size_t size) {
-  int slot = sk_bit_size(size);
+  size_t slot = sk_bit_size(size);
   void** ptr = sk_ftable[slot];
   if (ptr == NULL) {
     return ptr;
@@ -137,7 +137,7 @@ int memcmp(const void* ptr1, const void* ptr2, size_t num) {
     }
     char c1 = *str1;
     char c2 = *str2;
-    SkipInt diff = c1 - c2;
+    int diff = c1 - c2;
     if (diff != 0) return diff;
     str1++;
     str2++;

--- a/compiler/runtime/native_eq.c
+++ b/compiler/runtime/native_eq.c
@@ -43,7 +43,7 @@ SkipInt SKIP_native_eq_class(sk_stack_t* st, char* obj1, char* obj2) {
   size_t size = ty1->m_userByteSize / sizeof(void*);
   size_t bitsize = sizeof(void*) * 8;
   size_t mask_slot = 0;
-  int i;
+  unsigned int i;
   while (size > 0) {
     for (i = 0; i < bitsize && i < size; i++) {
       void* ptr1 = *(((void**)obj1) + (mask_slot * bitsize) + i);
@@ -98,7 +98,7 @@ SkipInt SKIP_native_eq_array(sk_stack_t* st, char* obj1, char* obj2) {
     size_t size = ty1->m_userByteSize;
     size_t mask_slot = 0;
     while (size > 0) {
-      int i;
+      unsigned int i;
       for (i = 0; i < bitsize && size > 0; i++) {
         void* ptr1 = *((void**)ohead1);
         void* ptr2 = *((void**)ohead2);

--- a/compiler/runtime/native_eq.c
+++ b/compiler/runtime/native_eq.c
@@ -37,7 +37,7 @@ SkipInt SKIP_native_eq_class(sk_stack_t* st, char* obj1, char* obj2) {
   }
 
   if ((ty1->m_refsHintMask & 1) == 0) {
-    return memcmp(obj1, obj2, ty1->m_userByteSize);
+    return (SkipInt)memcmp(obj1, obj2, ty1->m_userByteSize);
   }
 
   size_t size = ty1->m_userByteSize / sizeof(void*);
@@ -87,7 +87,7 @@ SkipInt SKIP_native_eq_array(sk_stack_t* st, char* obj1, char* obj2) {
   size_t bitsize = sizeof(void*) * 8;
 
   if ((ty1->m_refsHintMask & 1) == 0) {
-    return memcmp(obj1, obj2, memsize);
+    return (SkipInt)memcmp(obj1, obj2, memsize);
   }
 
   char* ohead1 = obj1;
@@ -131,8 +131,8 @@ SkipInt SKIP_native_eq_helper(sk_stack_t* st, char* obj1, char* obj2) {
     return 1;
   }
 
-  int isString1 = SKIP_is_string(obj1);
-  int isString2 = SKIP_is_string(obj2);
+  uint32_t isString1 = SKIP_is_string(obj1);
+  uint32_t isString2 = SKIP_is_string(obj2);
 
   if (isString1 && isString2) {
     return SKIP_String_cmp((unsigned char*)obj1, (unsigned char*)obj2);
@@ -158,7 +158,7 @@ SkipInt SKIP_native_eq_helper(sk_stack_t* st, char* obj1, char* obj2) {
       break;
     default:
       // NOT SUPPORTED
-      SKIP_exit(-1);
+      SKIP_exit((SkipInt)-1);
   }
 
   return 0;

--- a/compiler/runtime/native_eq.c
+++ b/compiler/runtime/native_eq.c
@@ -56,7 +56,7 @@ SkipInt SKIP_native_eq_class(sk_stack_t* st, char* obj1, char* obj2) {
           return 1;
         }
       }
-    };
+    }
     if (size < bitsize) {
       break;
     }
@@ -114,7 +114,7 @@ SkipInt SKIP_native_eq_array(sk_stack_t* st, char* obj1, char* obj2) {
         ohead1 += sizeof(void*);
         ohead2 += sizeof(void*);
         size -= sizeof(void*);
-      };
+      }
       mask_slot++;
     }
   }

--- a/compiler/runtime/native_eq.c
+++ b/compiler/runtime/native_eq.c
@@ -42,7 +42,6 @@ SkipInt SKIP_native_eq_class(sk_stack_t* st, char* obj1, char* obj2) {
 
   size_t size = ty1->m_userByteSize / sizeof(void*);
   size_t bitsize = sizeof(void*) * 8;
-  size_t slot = 0;
   size_t mask_slot = 0;
   int i;
   while (size > 0) {
@@ -97,7 +96,6 @@ SkipInt SKIP_native_eq_array(sk_stack_t* st, char* obj1, char* obj2) {
 
   while (ohead1 < end) {
     size_t size = ty1->m_userByteSize;
-    size_t slot = 0;
     size_t mask_slot = 0;
     while (size > 0) {
       int i;

--- a/compiler/runtime/obstack.c
+++ b/compiler/runtime/obstack.c
@@ -147,7 +147,7 @@ void* SKIP_Obstack_calloc(size_t size) {
   return result;
 }
 
-char* SKIP_Obstack_shallowClone(size_t _size, char* obj) {
+char* SKIP_Obstack_shallowClone(size_t /* size */, char* obj) {
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t memsize = ty->m_userByteSize;
@@ -280,7 +280,7 @@ uint32_t SKIP_should_GC(sk_saved_obstack_t* saved) {
 
 void SKIP_Obstack_auto_collect() {}
 
-void* SKIP_Obstack_collect1(void* note, void* obj) {
+void* SKIP_Obstack_collect1(void* /* note */, void* obj) {
   return obj;
 }
 

--- a/compiler/runtime/obstack.c
+++ b/compiler/runtime/obstack.c
@@ -340,10 +340,10 @@ size_t sk_get_nbr_pages(void* saved_page) {
 sk_cell_t* sk_get_pages(size_t size) {
   sk_cell_t* result = (sk_cell_t*)sk_malloc(sizeof(sk_cell_t) * size);
   int i = 0;
-  void* cursor = page;
+  char* cursor = page;
   for (i = 0; i < size; i++) {
     result[i].key = cursor;
-    result[i].value = (uint64_t)(cursor + *(size_t*)(cursor + sizeof(char*)));
+    result[i].value = (uint64_t)cursor + *(size_t*)(cursor + sizeof(char*));
     cursor = *(char**)cursor;
   }
   sk_heap_sort(result, size);

--- a/compiler/runtime/obstack.c
+++ b/compiler/runtime/obstack.c
@@ -263,7 +263,6 @@ void SKIP_enable_GC() {
 uint32_t SKIP_should_GC(sk_saved_obstack_t* saved) {
   if (!sk_gc_enabled) return 0;
   size_t nbr_page = 0;
-  size_t size = 0;
   void* cursor = page;
   while (cursor != NULL && cursor != saved->page) {
     cursor = *(char**)cursor;

--- a/compiler/runtime/obstack.c
+++ b/compiler/runtime/obstack.c
@@ -236,7 +236,7 @@ void* SKIP_destroy_Obstack_with_value(sk_saved_obstack_t* saved, void* toCopy) {
 
   void* result = SKIP_copy_with_pages(toCopy, nbr_pages, pages);
 
-  int i;
+  unsigned int i;
   for (i = 0; i < nbr_pages; i++) {
     if ((uint64_t)pages[i].key != pages[i].value) {
       char* fpage = (char*)(pages[i].key);
@@ -338,7 +338,7 @@ size_t sk_get_nbr_pages(void* saved_page) {
 
 sk_cell_t* sk_get_pages(size_t size) {
   sk_cell_t* result = (sk_cell_t*)sk_malloc(sizeof(sk_cell_t) * size);
-  int i = 0;
+  unsigned int i = 0;
   char* cursor = page;
   for (i = 0; i < size; i++) {
     result[i].key = cursor;

--- a/compiler/runtime/obstack.c
+++ b/compiler/runtime/obstack.c
@@ -288,10 +288,10 @@ void* SKIP_Obstack_collect1(void* /* note */, void* obj) {
 /* Sort used to sort the pages. */
 /*****************************************************************************/
 
-static void heapify(sk_cell_t* arr, int n, int i) {
-  int largest = i;
-  int l = 2 * i + 1;
-  int r = 2 * i + 2;
+static void heapify(sk_cell_t* arr, size_t n, size_t i) {
+  size_t largest = i;
+  size_t l = 2 * i + 1;
+  size_t r = 2 * i + 2;
 
   if (l < n && arr[l].key > arr[largest].key) {
     largest = l;
@@ -309,12 +309,14 @@ static void heapify(sk_cell_t* arr, int n, int i) {
   }
 }
 
-void sk_heap_sort(sk_cell_t* arr, int n) {
+void sk_heap_sort(sk_cell_t* arr, size_t n) {
+  if (n <= 1) return;
+
   for (int i = n / 2 - 1; i >= 0; i--) {
     heapify(arr, n, i);
   }
 
-  for (int i = n - 1; i > 0; i--) {
+  for (size_t i = n - 1; i > 0; i--) {
     sk_cell_t tmp = arr[0];
     arr[0] = arr[i];
     arr[i] = tmp;
@@ -349,19 +351,24 @@ sk_cell_t* sk_get_pages(size_t size) {
   return result;
 }
 
-size_t binarySearch(sk_cell_t* arr, int l, int r, char* x) {
+size_t binarySearch(sk_cell_t* arr, size_t l, size_t r, char* x) {
   if (l >= r) {
     if (((char*)arr[l].key <= x && x < (char*)(arr[l].value))) {
       return l;
     } else {
-      return -1;
+      return (size_t)-1;
     }
   }
 
-  int mid = l + (r - l) / 2;
+  size_t mid = l + (r - l) / 2;
 
   if (x < (char*)arr[mid].key) {
-    return binarySearch(arr, l, mid - 1, x);
+    if (mid <= l) {
+      // this happens when r = l + 1
+      return (size_t)-1;
+    } else {
+      return binarySearch(arr, l, mid - 1, x);
+    }
   } else if (x >= (char*)(arr[mid].value)) {
     return binarySearch(arr, mid + 1, r, x);
   } else {
@@ -371,8 +378,8 @@ size_t binarySearch(sk_cell_t* arr, int l, int r, char* x) {
 
 size_t sk_get_obstack_idx(char* ptr, sk_cell_t* pages, size_t size) {
   if (size == 0 || pages == NULL) {
-    return -1;
+    return (size_t)-1;
   }
-  int result = binarySearch(pages, 0, size - 1, ptr);
+  size_t result = binarySearch(pages, 0, size - 1, ptr);
   return result;
 }

--- a/compiler/runtime/obstack.c
+++ b/compiler/runtime/obstack.c
@@ -79,14 +79,15 @@ void sk_obstack_attach_page(char* lpage) {
 }
 
 char* sk_large_page(size_t size) {
-  size_t block_size = size + sizeof(char*) + sizeof(size_t) + sizeof(sk_saved_obstack_t);
+  size_t block_size =
+      size + sizeof(char*) + sizeof(size_t) + sizeof(sk_saved_obstack_t);
   block_size += 64;
   char* lpage = (char*)sk_malloc(block_size);
   sk_obstack_attach_page(lpage);
   lpage += sizeof(char*);
   *(size_t*)lpage = block_size;
   lpage += sizeof(size_t);
-  sk_saved_obstack_t * saved = (sk_saved_obstack_t*)lpage;
+  sk_saved_obstack_t* saved = (sk_saved_obstack_t*)lpage;
   saved->head = NULL;
   saved->end = NULL;
   saved->page = NULL;
@@ -110,7 +111,7 @@ void sk_new_page() {
   head += sizeof(char*);
   *(size_t*)head = block_size;
   head += sizeof(size_t);
-  sk_saved_obstack_t * saved = (sk_saved_obstack_t*)head;
+  sk_saved_obstack_t* saved = (sk_saved_obstack_t*)head;
   saved->head = NULL;
   saved->end = NULL;
   saved->page = NULL;
@@ -123,7 +124,8 @@ char* SKIP_Obstack_alloc(size_t size) {
   size = (size + 7) & ~7;
 
   if (head + size >= end) {
-    if (size + sizeof(char*) + sizeof(size_t) + sizeof(sk_saved_obstack_t) > PAGE_SIZE) {
+    if (size + sizeof(char*) + sizeof(size_t) + sizeof(sk_saved_obstack_t) >
+        PAGE_SIZE) {
       result = sk_large_page(size);
       result += 8;
       return result;
@@ -161,8 +163,7 @@ char* SKIP_Obstack_shallowClone(size_t _size, char* obj) {
 /* Obstack creation/destruction. */
 /*****************************************************************************/
 
-
-sk_saved_obstack_t * sk_saved_obstack(char* page) {
+sk_saved_obstack_t* sk_saved_obstack(char* page) {
   return (sk_saved_obstack_t*)(page + sizeof(char*) + sizeof(size_t));
 }
 

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -241,8 +241,8 @@ size_t ctx_table_size = 0;
 
 int sk_find_ctx(char* context) {
   int i;
-  for(i = 0; i < ctx_table_size; i++) {
-    if(context == ctx_table[i]) {
+  for (i = 0; i < ctx_table_size; i++) {
+    if (context == ctx_table[i]) {
       return i;
     }
   }
@@ -252,16 +252,16 @@ int sk_find_ctx(char* context) {
 void sk_clean_ctx_table() {
   int i = 0;
   int j = 0;
-  for(; j < ctx_table_size; j++) {
+  for (; j < ctx_table_size; j++) {
     int rcount = sk_get_ref_count(ctx_table[j]);
-    if(rcount < 0) {
+    if (rcount < 0) {
       fprintf(stderr, "Error: CTX_TABLE found negative ref count");
       exit(ERROR_CONTEXT_CHECK);
     }
-    if(rcount == 0) {
+    if (rcount == 0) {
       continue;
     }
-    if(i != j) {
+    if (i != j) {
       ctx_table[i] = ctx_table[j];
     }
     i++;
@@ -272,16 +272,17 @@ void sk_clean_ctx_table() {
 void sk_print_ctx_table() {
   int i = 0;
   fprintf(stderr, "---- CTX TABLE BEGIN -----\n");
-  for(; i < ctx_table_size; i++) {
-    fprintf(stderr, "%p, REF_COUNT: %lu\n", ctx_table[i], sk_get_ref_count(ctx_table[i]));
+  for (; i < ctx_table_size; i++) {
+    fprintf(stderr, "%p, REF_COUNT: %lu\n", ctx_table[i],
+            sk_get_ref_count(ctx_table[i]));
   }
   fprintf(stderr, "---- CTX TABLE END -------\n");
 }
 
 void sk_add_ctx(char* context) {
   int i = sk_find_ctx(context);
-  if(i < 0) {
-    if(ctx_table_size >= CTX_TABLE_CAPACITY) {
+  if (i < 0) {
+    if (ctx_table_size >= CTX_TABLE_CAPACITY) {
       fprintf(stderr, "Error: CTX_TABLE reached maximum capacity");
       exit(ERROR_CONTEXT_CHECK);
     }
@@ -291,7 +292,6 @@ void sk_add_ctx(char* context) {
 }
 
 #endif
-
 
 /*****************************************************************************/
 /* Global context access primitives. */
@@ -353,7 +353,7 @@ void sk_context_set(char* obj) {
 
 static char* parse_args(int argc, char** argv, int* is_init) {
   // FIXME
-  if (argc > 0 && strcmp(argv[0], "skargo") == 0 ) {
+  if (argc > 0 && strcmp(argv[0], "skargo") == 0) {
     return NULL;
   }
 

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -459,8 +459,8 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
 
   char* head = begin;
 
-  *(uint64_t*)head = SKIP_get_version();
-  head += sizeof(uint64_t);
+  *(int64_t*)head = SKIP_get_version();
+  head += sizeof(int64_t);
 
   *(void**)head = begin;
   head += sizeof(void*);

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -540,11 +540,11 @@ void sk_load_mapping(char* fileName) {
   }
 
   void* addr;
-  uint64_t magic;
+  int64_t magic;
   lseek(fd, 0L, SEEK_SET);
-  int magic_size = read(fd, &magic, sizeof(uint64_t));
+  int magic_size = read(fd, &magic, sizeof(int64_t));
 
-  if (magic_size != sizeof(uint64_t) || magic != SKIP_get_version()) {
+  if (magic_size != sizeof(int64_t) || magic != SKIP_get_version()) {
     fprintf(stderr, "Error: wrong file format: %s\n", fileName);
     exit(ERROR_MAPPING_VERSION);
   }

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -334,7 +334,6 @@ char* SKIP_context_get() {
 }
 
 void sk_context_set_unsafe(char* obj) {
-  void* vobj = (void*)obj;
   (*ginfo)->context = obj;
 #ifdef CTX_TABLE
   sk_add_ctx(obj);
@@ -386,7 +385,6 @@ static char* parse_args(int argc, char** argv, int* is_init) {
 
 size_t parse_capacity(int argc, char** argv) {
   int i;
-  int idx = -1;
 
   for (i = 1; i < argc; i++) {
     if (strcmp(argv[i], "--capacity") == 0) {

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -51,7 +51,7 @@ uint64_t SKIP_genSym(uint64_t largerThan) {
 
   if (largerThan > gid_value) {
     n += largerThan - gid_value;
-  };
+  }
 
   return __atomic_fetch_add(gid, n, __ATOMIC_RELAXED);
 }
@@ -396,7 +396,7 @@ size_t parse_capacity(int argc, char** argv) {
             if (argv[i + 1][j] >= '0' && argv[i + 1][j] <= '9') {
               j++;
               continue;
-            };
+            }
             fprintf(stderr, "--capacity expects an integer\n");
             exit(2);
           }

--- a/compiler/runtime/posix.c
+++ b/compiler/runtime/posix.c
@@ -296,7 +296,7 @@ void SKIP_posix_execvp(char *args_obj) {
 int64_t SKIP_posix_isatty(int64_t fd) {
   int rv = isatty((int)fd);
   if (rv == 0 && errno != ENOTTY) {
-    return 0;     /* treat this call as best effort and assume not a tty */
+    return 0; /* treat this call as best effort and assume not a tty */
   }
   return (char)rv;
 }

--- a/compiler/runtime/posix.c
+++ b/compiler/runtime/posix.c
@@ -79,7 +79,7 @@ char *SKIP_posix_read(int64_t fd, int64_t len) {
     perror("malloc");
     exit(EXIT_FAILURE);
   }
-  int rv = read((int)fd, buf, len);
+  ssize_t rv = read((int)fd, buf, len);
   if (rv == -1) {
     perror("read");
     exit(EXIT_FAILURE);
@@ -178,7 +178,8 @@ int64_t SKIP_posix_wstopsig(int64_t stat_loc) {
 }
 
 int64_t SKIP_posix_poll(char *pollfds) {
-  int nfds = *(uint32_t *)(pollfds - sizeof(char *) - sizeof(uint32_t));
+  unsigned int nfds =
+      *(uint32_t *)(pollfds - sizeof(char *) - sizeof(uint32_t));
 
   for (;;) {
     int rv = poll((struct pollfd *)pollfds, nfds, -1);

--- a/compiler/runtime/runtime.c
+++ b/compiler/runtime/runtime.c
@@ -18,41 +18,6 @@ SKIP_gc_type_t* get_gc_type(char* skip_object) {
 }
 
 /*****************************************************************************/
-/* Saving/restoring context to thread locals.
- *
- * These primitives are very dangerous to use unless you really know what you
- * are doing. The GC does not keep track of the local context, so saving a
- * local context without a good understanding of how the memory model works
- * will probably lead to memory corruption.
- *
- * You have been warned ...
- */
-/*****************************************************************************/
-
-#ifdef SKIP32
-char* lcontext = NULL;
-#endif
-#ifdef SKIP64
-__thread char* lcontext = NULL;
-#endif
-
-int32_t SKIP_has_local_context() {
-  return (int32_t)(lcontext != NULL);
-}
-
-void SKIP_set_local_context(char* context) {
-  lcontext = context;
-}
-
-void SKIP_remove_local_context() {
-  lcontext = NULL;
-}
-
-char* SKIP_get_local_context() {
-  return lcontext;
-}
-
-/*****************************************************************************/
 /* Primitives that are not used in embedded mode. */
 /*****************************************************************************/
 

--- a/compiler/runtime/runtime.c
+++ b/compiler/runtime/runtime.c
@@ -17,7 +17,6 @@ SKIP_gc_type_t* get_gc_type(char* skip_object) {
   return *slot1;
 }
 
-
 /*****************************************************************************/
 /* Saving/restoring context to thread locals.
  *
@@ -82,32 +81,6 @@ void* SKIP_llvm_memcpy(char* dest, char* val, SkipInt len) {
 /*****************************************************************************/
 /* Global context synchronization. */
 /*****************************************************************************/
-
-#ifdef SKIP32
-static char* local_ctx = NULL;
-#endif
-
-#ifdef SKIP64
-static __thread char* local_ctx = NULL;
-#endif
-
-void SKIP_unsafe_set_local_context(char* obj) {
-  local_ctx = obj;
-}
-
-void SKIP_unsafe_remove_local_context(char* obj) {
-  local_ctx = NULL;
-}
-
-char* SKIP_unsafe_get_local_context() {
-  if (local_ctx == NULL) {
-#ifdef SKIP64
-    fprintf(stderr, "Error: local context is not set");
-#endif
-    SKIP_throw_cruntime(ERROR_LOCAL_CONTEXT_NULL);
-  }
-  return local_ctx;
-}
 
 void SKIP_context_init(char* obj) {
   sk_global_lock();

--- a/compiler/runtime/runtime.c
+++ b/compiler/runtime/runtime.c
@@ -72,7 +72,7 @@ void SKIP_Obstack_vectorUnsafeSet(char** arr, char* x) {
   *arr = x;
 }
 
-void SKIP_Obstack_collect(char* dumb1, char** dumb2, SkipInt dumb3) {}
+void SKIP_Obstack_collect(char*, char**, SkipInt) {}
 
 void* SKIP_llvm_memcpy(char* dest, char* val, SkipInt len) {
   return memcpy(dest, val, (size_t)len);

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -269,7 +269,7 @@ uintptr_t sk_get_ref_count(void* obj);
 void SKIP_throwInvalidSynchronization();
 void SKIP_call_finalize(char*, char*);
 void SKIP_exit(SkipInt);
-void sk_heap_sort(sk_cell_t* arr, int n);
+void sk_heap_sort(sk_cell_t* arr, size_t n);
 int SKIP_get_version();
 
 #endif

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -222,7 +222,7 @@ char* SKIP_resolve_context(uint64_t, char* context, char* obj,
 void SKIP_call_after_unlock(char*, char*);
 
 void SKIP_throw(void*);
-void SKIP_throw_cruntime(int32_t);
+__attribute__((noreturn)) void SKIP_throw_cruntime(int32_t);
 
 void sk_add_ftable(void* ptr, size_t size);
 void sk_commit(char*, uint32_t);

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -66,7 +66,6 @@ void sk_print_ctx_table();
 #define ERROR_CONTEXT_CHECK 102
 #define ERROR_ARG_PARSE 103
 
-
 /*****************************************************************************/
 /* Types used for the Obstack pages info. */
 /*****************************************************************************/
@@ -198,9 +197,9 @@ typedef struct {
 /*****************************************************************************/
 
 #ifndef __cplusplus
-int (memcmp)(const void* ptr1, const void* ptr2, size_t num);
-void* (memcpy)(void *restrict dst, const void *restrict src, size_t n);
-void* (memset)(void* b, int c, size_t len);
+int(memcmp)(const void* ptr1, const void* ptr2, size_t num);
+void*(memcpy)(void* restrict dst, const void* restrict src, size_t n);
+void*(memset)(void* b, int c, size_t len);
 #endif
 
 char* SKIP_Obstack_alloc(size_t size);

--- a/compiler/runtime/runtime32_specific.c
+++ b/compiler/runtime/runtime32_specific.c
@@ -169,7 +169,7 @@ uint64_t SKIP_random_next() {
   return xoroshiro128plus_next();
 }
 
-void SKIP_exit(uint64_t code) {
+__attribute__((noreturn)) void SKIP_exit(uint64_t code) {
   SKIP_throw_cruntime((int32_t)code);
 }
 

--- a/compiler/runtime/runtime32_specific.c
+++ b/compiler/runtime/runtime32_specific.c
@@ -1,5 +1,6 @@
-#include "runtime.h"
 #include <stdbool.h>
+
+#include "runtime.h"
 #include "xoroshiro128plus.h"
 
 void js_throw(void*, uint32_t);
@@ -208,16 +209,14 @@ int SKIP_stdin_has_data() {
 
 void SKIP_unix_die_on_EOF() {}
 
-int32_t SKIP_js_open_flags(
-  bool read, bool write, bool append,
-                              bool truncate, bool create,
-                              bool create_new
-);
+int32_t SKIP_js_open_flags(bool read, bool write, bool append, bool truncate,
+                           bool create, bool create_new);
 
 int64_t SKIP_posix_open_flags(int64_t read, int64_t write, int64_t append,
                               int64_t truncate, int64_t create,
                               int64_t create_new) {
-  return SKIP_js_open_flags((bool)read, (bool)write, (bool)append, (bool)truncate, (bool)create, (bool)create_new);
+  return SKIP_js_open_flags((bool)read, (bool)write, (bool)append,
+                            (bool)truncate, (bool)create, (bool)create_new);
 }
 
 int32_t SKIP_js_open(char* path, int32_t oflag, int32_t mode);
@@ -238,10 +237,9 @@ int64_t SKIP_posix_write(int64_t fd, char* buf) {
   return (int64_t)SKIP_js_write((uint32_t)fd, buf);
 }
 
+char* SKIP_js_read(uint32_t fd, uint32_t len);
 
-char *SKIP_js_read(uint32_t fd, uint32_t len);
-
-char *SKIP_posix_read(int64_t fd, int64_t len) {
+char* SKIP_posix_read(int64_t fd, int64_t len) {
   return SKIP_js_read((uint32_t)fd, (uint32_t)len);
 }
 
@@ -257,24 +255,21 @@ char* SKIP_getArgN(int64_t n) {
   return SKIP_js_get_argn((int32_t)n);
 }
 
-
 uint32_t SKIP_js_get_envc();
 
 int64_t SKIP_get_envc() {
   return (int64_t)SKIP_js_get_envc();
 }
 
+char* SKIP_js_get_envn(uint32_t n);
 
-char *SKIP_js_get_envn(uint32_t n);
-
-
-char *SKIP_get_envN(int64_t n) {
+char* SKIP_get_envN(int64_t n) {
   return SKIP_js_get_envn((uint32_t)n);
 }
 
-char *SKIP_js_pipe();
+char* SKIP_js_pipe();
 
-char *SKIP_posix_pipe() {
+char* SKIP_posix_pipe() {
   return SKIP_js_pipe();
 }
 
@@ -290,8 +285,8 @@ void SKIP_posix_dup2(int64_t oldfd, int64_t newfd) {
   SKIP_js_dup2((uint32_t)oldfd, (uint32_t)newfd);
 }
 
-void SKIP_js_execvp(char *args_obj);
+void SKIP_js_execvp(char* args_obj);
 
-void SKIP_posix_execvp(char *args_obj) {
+void SKIP_posix_execvp(char* args_obj) {
   SKIP_js_execvp(args_obj);
 }

--- a/compiler/runtime/runtime32_specific.c
+++ b/compiler/runtime/runtime32_specific.c
@@ -55,11 +55,11 @@ int sk_is_static(void* ptr) {
 
 void sk_staging() {}
 
-void sk_commit(char* new_root, uint32_t sync) {
+void sk_commit(char* new_root, uint32_t /* sync */) {
   sk_context_set_unsafe(new_root);
 }
 
-char* SKIP_read_file(char* filename_obj) {
+char* SKIP_read_file(char* /* filename_obj */) {
   SKIP_throw_cruntime(ERROR_NOT_IMPLEMENTED);
   return (void*)0;
 }
@@ -93,7 +93,7 @@ void sk_context_set_unsafe(char* obj) {
   context = obj;
 }
 
-SkipInt SKIP_genSym(SkipInt n) {
+SkipInt SKIP_genSym(SkipInt /* n */) {
   static SkipInt x = 1;
   x++;
   return x;
@@ -105,20 +105,20 @@ char* sk_new_const(char* cst) {
 
 void SKIP_throw_EndOfFile();
 
-int64_t SKIP_posix_isatty(int64_t fd) {
+int64_t SKIP_posix_isatty(int64_t /* fd */) {
   return 0;
 }
 
-void* SKIP_exec(char* cmd) {
+void* SKIP_exec(char* /* cmd */) {
   // Not implemented
   return NULL;
 }
 
-void SKIP_write_to_proc(void* proc, char* str) {
+void SKIP_write_to_proc(void* /* proc */, char* /* str */) {
   // Not implemented.
 }
 
-void SKIP_wait_for_proc(void* proc) {
+void SKIP_wait_for_proc(void* /* proc */) {
   // Not implemented
 }
 
@@ -151,7 +151,7 @@ void SKIP_flush_stdout() {
   // Not implemented
 }
 
-uint64_t SKIP_notify(char* filename_obj, uint64_t tick) {
+uint64_t SKIP_notify(char* /* filename_obj */, uint64_t /* tick */) {
   // Not implemented
   return 0;
 }
@@ -189,19 +189,19 @@ void* SKIP_unfreeze_cond(void* x) {
   return x;
 }
 
-void SKIP_mutex_init(void* lock) {}
+void SKIP_mutex_init(void* /* lock */) {}
 
-void SKIP_mutex_lock(void* lock) {}
+void SKIP_mutex_lock(void* /* lock */) {}
 
-void SKIP_mutex_unlock(void* lock) {}
+void SKIP_mutex_unlock(void* /* lock */) {}
 
-void SKIP_cond_init(void* cond) {}
+void SKIP_cond_init(void* /* cond */) {}
 
-void SKIP_cond_wait(void* x, void* y) {}
+void SKIP_cond_wait(void* /* x */, void* /* y */) {}
 
-void SKIP_cond_timedwait(void* x, void* y, uint32_t secs) {}
+void SKIP_cond_timedwait(void* /* x */, void* /* y */, uint32_t /* secs */) {}
 
-void SKIP_cond_broadcast(void* c) {}
+void SKIP_cond_broadcast(void* /* c */) {}
 
 int SKIP_stdin_has_data() {
   return 1;

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -43,8 +43,6 @@ typedef struct {
   char* end;
 } sk_saved_obstack_t;
 
-
-
 extern "C" {
 char* sk2c_string(char* skStr);
 void* sk_get_exception_type(void* skExn);
@@ -87,7 +85,7 @@ static void error_callback(void* /* data */, const char* msg, int errnum) {
 }
 }  // namespace
 
-#endif // RELEASE
+#endif  // RELEASE
 
 namespace skip {
 struct SkipException : std::exception {
@@ -119,7 +117,7 @@ void printStackTrace() {
 }
 
 #endif
-}
+}  // namespace skip
 
 #ifndef RELEASE
 namespace {
@@ -139,7 +137,7 @@ void terminate() {
   std::cerr << "*** Stack trace:" << std::endl;
   skip::printStackTrace();
 }
-} // namespace
+}  // namespace
 #endif
 
 extern "C" {
@@ -463,9 +461,7 @@ int64_t SKIP_time() {
 uint64_t SKIP_time_ms() {
   using namespace std::chrono;
 
-  return
-    duration_cast<milliseconds>
-      (steady_clock::now().time_since_epoch())
+  return duration_cast<milliseconds>(steady_clock::now().time_since_epoch())
       .count();
 }
 
@@ -646,5 +642,4 @@ void SKIP_push_object() {
 void SKIP_js_delete_fun() {
   // Not implemented
 }
-
 }

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -591,7 +591,7 @@ char* SKIP_realpath(char* path_obj) {
   return sk_string_create(res, strlen(res));
 }
 
-void SKIP_exit(uint64_t code) {
+__attribute__((noreturn)) void SKIP_exit(uint64_t code) {
   exit(code);
 }
 

--- a/compiler/runtime/stdlib.c
+++ b/compiler/runtime/stdlib.c
@@ -127,7 +127,7 @@ char* SKIP_read_line() {
     return NULL;
   }
 
-  uint32_t i;
+  int32_t i;
   char* result = SKIP_Obstack_alloc(size);
 
   for (i = 0; i < size; i++) {
@@ -141,7 +141,7 @@ char* SKIP_read_line() {
 char* SKIP_read_to_end() {
   int32_t size = SKIP_read_to_end_fill();
 
-  uint32_t i;
+  int32_t i;
   char* result = SKIP_Obstack_alloc(size);
 
   for (i = 0; i < size; i++) {

--- a/compiler/runtime/stdlib.c
+++ b/compiler/runtime/stdlib.c
@@ -42,47 +42,48 @@ uint32_t SKIP_wait_for_proc(FILE* f) {
 
 #ifdef SKIP32
 
-void* memset(void* ptr, int value, size_t size) {
-  void* result = ptr;
+void* memset(void* orig_ptr, int value, size_t size) {
+  char* ptr = (char*)orig_ptr;
 
   if (value != 0) {
     // memset only implemented for zero
     SKIP_throw_cruntime(ERROR_NOT_IMPLEMENTED);
   }
 
-  const char* end = (char*)ptr + size;
-  const char* lend = (char*)ptr + (size / sizeof(long) * sizeof(long));
+  const char* end = ptr + size;
+  const char* lend = ptr + (size / sizeof(long) * sizeof(long));
 
-  while (ptr < (void*)lend) {
+  while (ptr < lend) {
     *(long*)ptr = 0;
     ptr += sizeof(long);
   }
 
-  while (ptr < (void*)end) {
-    *(char*)ptr = 0;
+  while (ptr < end) {
+    *ptr = 0;
     ptr++;
   }
 
-  return result;
+  return orig_ptr;
 }
 
-void* memcpy(void* dest, const void* src, size_t size) {
-  void* result = dest;
-  const char* end = (char*)src + size;
-  const char* lend = (char*)src + (size / sizeof(long) * sizeof(long));
+void* memcpy(void* orig_dest, const void* orig_src, size_t size) {
+  char* dest = (char*)orig_dest;
+  const char* src = (const char*)orig_src;
+  const char* end = src + size;
+  const char* lend = src + (size / sizeof(long) * sizeof(long));
 
-  while (src < (void*)lend) {
+  while (src < lend) {
     *(long*)dest = *(long*)src;
     dest += sizeof(long);
     src += sizeof(long);
   }
 
-  while (src < (void*)end) {
-    *(char*)dest = *(char*)src;
+  while (src < end) {
+    *dest = *src;
     dest++;
     src++;
   }
-  return result;
+  return orig_dest;
 }
 
 #endif

--- a/compiler/runtime/stdlib.c
+++ b/compiler/runtime/stdlib.c
@@ -30,7 +30,7 @@ uint32_t SKIP_write_to_proc(FILE* f, char* str) {
   size_t n = fwrite(str, 1, size, f);
   if (n != size) {
     return 1;
-  };
+  }
   return 0;
 }
 
@@ -109,10 +109,10 @@ void sk_print_int(uint64_t x) {
     if (x % 10 == 9) str[i] = '9';
     i--;
     x = x / 10;
-  };
+  }
   for (i++; i < 256; i++) {
     SKIP_print_char(str[i]);
-  };
+  }
   SKIP_print_char('\n');
 }
 

--- a/compiler/runtime/string.c
+++ b/compiler/runtime/string.c
@@ -88,7 +88,7 @@ unsigned char* SKIP_String__fromChars(const unsigned char* /* dumb */,
     } else {
       SKIP_invalid_utf8();
     }
-  };
+  }
   uint32_t* iresult =
       (uint32_t*)SKIP_Obstack_alloc(result_size + 2 * sizeof(uint32_t));
   uint32_t* bsize = iresult;
@@ -127,7 +127,7 @@ unsigned char* SKIP_String__fromChars(const unsigned char* /* dumb */,
     } else {
       SKIP_invalid_utf8();
     }
-  };
+  }
   *bsize = (uint32_t)j;
   sk_string_set_hash((char*)result);
   return result;

--- a/compiler/runtime/string.c
+++ b/compiler/runtime/string.c
@@ -146,7 +146,7 @@ char* SKIP_String_concat2(char* str1, char* str2) {
 char* SKIP_String_concatN(char** arr) {
   uint32_t arr_size = SKIP_getArraySize((char*)arr);
   SkipInt byte_size = 0;
-  int i;
+  unsigned int i;
 
   for (i = 0; i < arr_size; i++) {
     byte_size += SKIP_String_byteSize(arr[i]);
@@ -359,7 +359,7 @@ static unsigned char
     string_utf8_buffer[sizeof(test_utf8_data) / sizeof(int) + 1];
 
 char* SKIP_utf8_test_string() {
-  int i;
+  unsigned int i;
   for (i = 0; i < sizeof(string_utf8_buffer); i++) {
     string_utf8_buffer[i] = (unsigned char)test_utf8_data[i];
   }

--- a/compiler/runtime/string.c
+++ b/compiler/runtime/string.c
@@ -198,7 +198,6 @@ uint32_t SKIP_String_unsafe_get(unsigned char* str, SkipInt n) {
 }
 
 void SKIP_String_unsafe_set(unsigned char* str, SkipInt n, SkipInt v) {
-  unsigned char c = (unsigned char)v;
   str[n] = v;
 }
 

--- a/compiler/runtime/string.c
+++ b/compiler/runtime/string.c
@@ -49,7 +49,7 @@ char* SKIP_getBuildVersion() {
   return sk_string_create("1", 1);
 }
 
-char* SKIP_String__fromUtf8(char* class, char* array) {
+char* SKIP_String__fromUtf8(char* /* class */, char* array) {
   uint32_t size = SKIP_getArraySize(array);
   return sk_string_create(array, size);
 }
@@ -67,7 +67,7 @@ char* SKIP_String_StringIterator__substring(char* argStart, char* argEnd) {
   return result;
 }
 
-unsigned char* SKIP_String__fromChars(const unsigned char* dumb,
+unsigned char* SKIP_String__fromChars(const unsigned char* /* dumb */,
                                       unsigned char* src_) {
   uint32_t* src = (uint32_t*)src_;
   uint32_t size = SKIP_getArraySize((char*)src_);

--- a/compiler/runtime/string.c
+++ b/compiler/runtime/string.c
@@ -175,7 +175,7 @@ SkipInt SKIP_String_cmp(unsigned char* str1, unsigned char* str2) {
       return 0;
     }
     if (str1 == end1) {
-      return -1;
+      return (SkipInt)-1;
     }
     if (str2 == end2) {
       return 1;

--- a/compiler/runtime/xoroshiro128plus.c
+++ b/compiler/runtime/xoroshiro128plus.c
@@ -7,6 +7,7 @@ worldwide. This software is distributed without any warranty.
 See <http://creativecommons.org/publicdomain/zero/1.0/>. */
 
 #include <stdint.h>
+
 #include "splitmix64.h"
 
 /* This is xoroshiro128+ 1.0, our best and fastest small-state generator
@@ -27,62 +28,61 @@ See <http://creativecommons.org/publicdomain/zero/1.0/>. */
 
    The state must be seeded so that it is not everywhere zero. If you have
    a 64-bit seed, we suggest to seed a splitmix64 generator and use its
-   output to fill s. 
+   output to fill s.
 
    NOTE: the parameters (a=24, b=16, b=37) of this version give slightly
    better results in our test than the 2016 version (a=55, b=14, c=36).
 */
 
 static inline uint64_t rotl(const uint64_t x, int k) {
-	return (x << k) | (x >> (64 - k));
+  return (x << k) | (x >> (64 - k));
 }
-
 
 static uint64_t s[2];
 
-
 void xoroshiro128plus_init(uint64_t seed) {
-	splitmix64_init(seed);
-	do { s[0] = splitmix64_next(); } while (s[0] == 0);
-	do { s[1] = splitmix64_next(); } while (s[1] == 0);
+  splitmix64_init(seed);
+  do {
+    s[0] = splitmix64_next();
+  } while (s[0] == 0);
+  do {
+    s[1] = splitmix64_next();
+  } while (s[1] == 0);
 }
-
 
 uint64_t xoroshiro128plus_next(void) {
-	const uint64_t s0 = s[0];
-	uint64_t s1 = s[1];
-	const uint64_t result = s0 + s1;
+  const uint64_t s0 = s[0];
+  uint64_t s1 = s[1];
+  const uint64_t result = s0 + s1;
 
-	s1 ^= s0;
-	s[0] = rotl(s0, 24) ^ s1 ^ (s1 << 16); // a, b
-	s[1] = rotl(s1, 37); // c
+  s1 ^= s0;
+  s[0] = rotl(s0, 24) ^ s1 ^ (s1 << 16);  // a, b
+  s[1] = rotl(s1, 37);                    // c
 
-	return result;
+  return result;
 }
-
 
 /* This is the jump function for the generator. It is equivalent
    to 2^64 calls to next(); it can be used to generate 2^64
    non-overlapping subsequences for parallel computations. */
 
 void xoroshiro128plus_jump(void) {
-	static const uint64_t JUMP[] = { 0xdf900294d8f554a5, 0x170865df4b3201fc };
+  static const uint64_t JUMP[] = {0xdf900294d8f554a5, 0x170865df4b3201fc};
 
-	uint64_t s0 = 0;
-	uint64_t s1 = 0;
-	for(int i = 0; i < sizeof JUMP / sizeof *JUMP; i++)
-		for(int b = 0; b < 64; b++) {
-			if (JUMP[i] & UINT64_C(1) << b) {
-				s0 ^= s[0];
-				s1 ^= s[1];
-			}
-			xoroshiro128plus_next();
-		}
+  uint64_t s0 = 0;
+  uint64_t s1 = 0;
+  for (int i = 0; i < sizeof JUMP / sizeof *JUMP; i++)
+    for (int b = 0; b < 64; b++) {
+      if (JUMP[i] & UINT64_C(1) << b) {
+        s0 ^= s[0];
+        s1 ^= s[1];
+      }
+      xoroshiro128plus_next();
+    }
 
-	s[0] = s0;
-	s[1] = s1;
+  s[0] = s0;
+  s[1] = s1;
 }
-
 
 /* This is the long-jump function for the generator. It is equivalent to
    2^96 calls to next(); it can be used to generate 2^32 starting points,
@@ -90,19 +90,19 @@ void xoroshiro128plus_jump(void) {
    subsequences for parallel distributed computations. */
 
 void xoroshiro128plus_long_jump(void) {
-	static const uint64_t LONG_JUMP[] = { 0xd2a98b26625eee7b, 0xdddf9b1090aa7ac1 };
+  static const uint64_t LONG_JUMP[] = {0xd2a98b26625eee7b, 0xdddf9b1090aa7ac1};
 
-	uint64_t s0 = 0;
-	uint64_t s1 = 0;
-	for(int i = 0; i < sizeof LONG_JUMP / sizeof *LONG_JUMP; i++)
-		for(int b = 0; b < 64; b++) {
-			if (LONG_JUMP[i] & UINT64_C(1) << b) {
-				s0 ^= s[0];
-				s1 ^= s[1];
-			}
-			xoroshiro128plus_next();
-		}
+  uint64_t s0 = 0;
+  uint64_t s1 = 0;
+  for (int i = 0; i < sizeof LONG_JUMP / sizeof *LONG_JUMP; i++)
+    for (int b = 0; b < 64; b++) {
+      if (LONG_JUMP[i] & UINT64_C(1) << b) {
+        s0 ^= s[0];
+        s1 ^= s[1];
+      }
+      xoroshiro128plus_next();
+    }
 
-	s[0] = s0;
-	s[1] = s1;
+  s[0] = s0;
+  s[1] = s1;
 }

--- a/compiler/runtime/xoroshiro128plus.c
+++ b/compiler/runtime/xoroshiro128plus.c
@@ -71,7 +71,7 @@ void xoroshiro128plus_jump(void) {
 
   uint64_t s0 = 0;
   uint64_t s1 = 0;
-  for (int i = 0; i < sizeof JUMP / sizeof *JUMP; i++)
+  for (unsigned int i = 0; i < sizeof JUMP / sizeof *JUMP; i++)
     for (int b = 0; b < 64; b++) {
       if (JUMP[i] & UINT64_C(1) << b) {
         s0 ^= s[0];
@@ -94,7 +94,7 @@ void xoroshiro128plus_long_jump(void) {
 
   uint64_t s0 = 0;
   uint64_t s1 = 0;
-  for (int i = 0; i < sizeof LONG_JUMP / sizeof *LONG_JUMP; i++)
+  for (unsigned int i = 0; i < sizeof LONG_JUMP / sizeof *LONG_JUMP; i++)
     for (int b = 0; b < 64; b++) {
       if (LONG_JUMP[i] & UINT64_C(1) << b) {
         s0 ^= s[0];


### PR DESCRIPTION
In #135, @jberdine found that we used pointer arithmetic on `void`. This could have been avoided by enabling compiler warnings. So let's do it and fix a few more oddities.

I've run
```shell
set -a; SKARGO_PROFILE=dev; STAGE=2; PATH=$PWD/compiler/stage$STAGE/bin:$PATH; set +a; make clean && make -C compiler clean test && make test
```
as suggested by @jberdine 