### PR TITLE
Date tests: force locale

### DIFF
--- a/sql/test_date.sh
+++ b/sql/test_date.sh
@@ -8,8 +8,9 @@ pass() { printf "%-44s OK\n" "$1:"; }
 fail() { printf "%-44s FAILED\n" "$1:"; }
 
 SKDB="skargo run --profile $SKARGO_PROFILE -- "
+LC_TIME=C
 
-export SKDB
+export SKDB LC_TIME
 
 mkdir -p "test/dates"
 rm -f "test/dates/*.diff"


### PR DESCRIPTION
These tests call the `date` command line which would print values in your current locale and would make the tests `formats 1/2/3/4` fail.

`cd sql && ./test_data.sh` now works even if your `LC_TIME` is set to something as weird as `fr_FR.UTF-8` before