### PR TITLE
Palloc cleanups

### DIFF
--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -329,15 +329,6 @@ void* SKIP_intern_shared(void* obj) {
     }
   }
 
-  {
-    unsigned int i;
-    for (i = 0; i < nbr_pages; i++) {
-      if (large_pages[i]) {
-        pages[i].value = (uint64_t)pages[i].key;
-      }
-    }
-  }
-
   sk_free_size(pages, sizeof(sk_cell_t) * nbr_pages);
   sk_free_size(large_pages, sizeof(int) * nbr_pages);
   sk_stack_free(st);

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -249,14 +249,6 @@ void* SKIP_intern_shared(void* obj) {
   sk_stack3_t* st3 = &st3_holder;
   size_t nbr_pages = sk_get_nbr_pages(NULL);
   sk_cell_t* pages = sk_get_pages(nbr_pages);
-  int* large_pages = sk_malloc(sizeof(int) * nbr_pages);
-
-  {
-    unsigned int i;
-    for (i = 0; i < nbr_pages; i++) {
-      large_pages[i] = 0;
-    }
-  }
 
   sk_stack_init(st, STACK_INIT_CAPACITY);
   sk_stack3_init(st3, STACK_INIT_CAPACITY);
@@ -275,10 +267,6 @@ void* SKIP_intern_shared(void* obj) {
       }
 
       continue;
-    }
-
-    if (sk_is_large_page(pages[obstack_idx].key)) {
-      large_pages[obstack_idx] = 1;
     }
 
     void* interned_ptr;
@@ -330,7 +318,6 @@ void* SKIP_intern_shared(void* obj) {
   }
 
   sk_free_size(pages, sizeof(sk_cell_t) * nbr_pages);
-  sk_free_size(large_pages, sizeof(int) * nbr_pages);
   sk_stack_free(st);
   sk_stack3_free(st3);
 

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -445,7 +445,7 @@ struct file_mapping {
   file_mapping_header_t header;
   pthread_mutexattr_t gmutex_attr;
   pthread_mutex_t gmutex;
-  ginfo_t ginfo_data[2];
+  ginfo_t ginfo_data;
   ginfo_t* ginfo;
   uint64_t gid;
   size_t capacity;
@@ -480,7 +480,7 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
 
   gmutex_attr = &mapping->gmutex_attr;
   gmutex = &mapping->gmutex;
-  ginfo_t* ginfo_data = mapping->ginfo_data;
+  ginfo_t* ginfo_data = &mapping->ginfo_data;
   ginfo = &mapping->ginfo;
   gid = &mapping->gid;
   capacity = &mapping->capacity;

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -448,7 +448,6 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   char* begin =
       mmap(BOTTOM_ADDR, icapacity, prot, MAP_SHARED | MAP_FIXED, fd, 0);
   close(fd);
-  char* end = begin + icapacity;
 
   if (begin == MAP_FAILED) {
     perror("ERROR (MAP FAILED)");
@@ -487,6 +486,8 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   size_t fileName_length = strlen(fileName) + 1;
   char* persistent_fileName = head;
   head += fileName_length;
+
+  char* end = begin + icapacity;
 
   if (head >= end) {
     fprintf(stderr, "Could not initialize memory\n");

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -450,8 +450,8 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
       mmap(BOTTOM_ADDR, icapacity, prot, MAP_SHARED | MAP_FIXED, fd, 0);
   char* end = begin + icapacity;
 
-  if (begin == (void*)-1) {
-    perror("ERROR (MMAP FAILED)");
+  if (begin == MAP_FAILED) {
+    perror("ERROR (MAP FAILED)");
     exit(ERROR_MAPPING_FAILED);
   }
 
@@ -563,8 +563,8 @@ void sk_load_mapping(char* fileName) {
   char* begin = mmap(addr, fsize, prot, MAP_SHARED | MAP_FIXED, fd, 0);
   close(fd);
 
-  if (begin == (void*)-1) {
-    perror("ERROR (MMAP FAILED)");
+  if (begin == MAP_FAILED) {
+    perror("ERROR (MAP FAILED)");
     exit(ERROR_MAPPING_FAILED);
   }
 

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -216,8 +216,7 @@ void SKIP_cond_broadcast(void* c) {
 /* The global information structure. */
 /*****************************************************************************/
 
-typedef struct {
-  void* ginfo_array;
+typedef struct ginfo {
   void* ftable[FTABLE_SIZE];
   void* context;
   char* begin;
@@ -502,7 +501,6 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   memcpy(persistent_fileName, fileName, fileName_length);
 
   *ginfo = ginfo_data;
-  (*ginfo)->ginfo_array = ginfo_data;
 
   int i;
   for (i = 0; i < FTABLE_SIZE; i++) {

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -555,8 +555,7 @@ void sk_load_mapping(char* fileName) {
   }
 
   int prot = PROT_READ | PROT_WRITE;
-  lseek(fd, 0L, SEEK_END);
-  size_t fsize = lseek(fd, 0, SEEK_CUR) - 1;
+  size_t fsize = lseek(fd, 0, SEEK_END) - 1;
   char* begin = mmap(addr, fsize, prot, MAP_SHARED | MAP_FIXED, fd, 0);
   close(fd);
 

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -623,7 +623,7 @@ void* sk_get_ftable(size_t size) {
   if (ptr == NULL) {
     return ptr;
   }
-  (*ginfo)->ftable[slot] = *(void**)(*ginfo)->ftable[slot];
+  (*ginfo)->ftable[slot] = *ptr;
   return ptr;
 }
 

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -636,32 +636,29 @@ void* sk_get_ftable(size_t size) {
 /* No file initialization (the memory is not backed by a file). */
 /*****************************************************************************/
 
+// Handy structure to allocate all those things at once
+typedef struct {
+  ginfo_t* ginfo;
+  ginfo_t ginfo_data;
+  uint64_t gid;
+  void** pconsts;
+} no_file_t;
+
 static void sk_init_no_file(char* static_limit) {
-  ginfo = malloc(sizeof(ginfo_t*));
-  if (ginfo == NULL) {
+  no_file_t* no_file = malloc(sizeof(no_file_t));
+  if (no_file == NULL) {
     perror("malloc");
     exit(1);
   }
-  *ginfo = malloc(sizeof(ginfo_t));
-  if (*ginfo == NULL) {
-    perror("malloc");
-    exit(1);
-  }
+  ginfo = &no_file->ginfo;
+  *ginfo = &no_file->ginfo_data;
   (*ginfo)->break_ptr = static_limit;
   (*ginfo)->total_palloc_size = 0;
   (*ginfo)->fileName = NULL;
   (*ginfo)->context = NULL;
   gmutex = NULL;
-  gid = malloc(sizeof(uint64_t));
-  if (gid == NULL) {
-    perror("malloc");
-    exit(1);
-  }
-  pconsts = malloc(sizeof(void**));
-  if (pconsts == NULL) {
-    perror("malloc");
-    exit(1);
-  }
+  gid = &no_file->gid;
+  pconsts = &no_file->pconsts;
   *gid = 1;
   *pconsts = NULL;
 }

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -488,6 +488,11 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   char* persistent_fileName = head;
   head += fileName_length;
 
+  if (head >= end) {
+    fprintf(stderr, "Could not initialize memory\n");
+    exit(ERROR_MAPPING_MEMORY);
+  }
+
   memcpy(persistent_fileName, fileName, fileName_length);
 
   *ginfo = ginfo_data;
@@ -497,11 +502,6 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   int i;
   for (i = 0; i < FTABLE_SIZE; i++) {
     (*ginfo)->ftable[i] = NULL;
-  }
-
-  if (head >= end) {
-    fprintf(stderr, "Could not initialize memory\n");
-    exit(ERROR_MAPPING_MEMORY);
   }
 
   (*ginfo)->break_ptr = static_limit;

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -446,7 +446,6 @@ struct file_mapping {
   pthread_mutexattr_t gmutex_attr;
   pthread_mutex_t gmutex;
   ginfo_t ginfo_data;
-  ginfo_t* ginfo;
   uint64_t gid;
   size_t capacity;
   void** pconsts;
@@ -480,7 +479,7 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
 
   gmutex_attr = &mapping->gmutex_attr;
   gmutex = &mapping->gmutex;
-  ginfo_t* ginfo_data = &mapping->ginfo_data;
+  ginfo = &mapping->ginfo_data;
   gid = &mapping->gid;
   capacity = &mapping->capacity;
   pconsts = &mapping->pconsts;
@@ -497,8 +496,6 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   }
 
   memcpy(persistent_fileName, fileName, fileName_length);
-
-  mapping->ginfo = ginfo = ginfo_data;
 
   int i;
   for (i = 0; i < FTABLE_SIZE; i++) {
@@ -563,7 +560,7 @@ void sk_load_mapping(char* fileName) {
   }
 
   gmutex = &mapping->gmutex;
-  ginfo = mapping->ginfo;
+  ginfo = &mapping->ginfo_data;
   gid = &mapping->gid;
   capacity = &mapping->capacity;
   pconsts = &mapping->pconsts;

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -554,8 +554,6 @@ void sk_load_mapping(char* fileName) {
     exit(ERROR_MAPPING_MEMORY);
   }
 
-  lseek(fd, 0L, SEEK_SET);
-
   int prot = PROT_READ | PROT_WRITE;
   lseek(fd, 0L, SEEK_END);
   size_t fsize = lseek(fd, 0, SEEK_CUR) - 1;

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -219,7 +219,6 @@ void SKIP_cond_broadcast(void* c) {
 typedef struct ginfo {
   void* ftable[FTABLE_SIZE];
   void* context;
-  char* begin;
   char* head;
   char* end;
   char* fileName;
@@ -513,7 +512,6 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   // The head must be aligned!
   head = (char*)(((uintptr_t)head + (uintptr_t)(15)) & ~((uintptr_t)(15)));
 
-  (*ginfo)->begin = (char*)mapping;
   (*ginfo)->head = head;
   (*ginfo)->end = end;
   (*ginfo)->fileName = persistent_fileName;

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -447,14 +447,13 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   int prot = PROT_READ | PROT_WRITE;
   char* begin =
       mmap(BOTTOM_ADDR, icapacity, prot, MAP_SHARED | MAP_FIXED, fd, 0);
+  close(fd);
   char* end = begin + icapacity;
 
   if (begin == MAP_FAILED) {
     perror("ERROR (MAP FAILED)");
     exit(ERROR_MAPPING_FAILED);
   }
-
-  close(fd);
 
   char* head = begin;
 

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -228,7 +228,6 @@ typedef struct {
   size_t total_palloc_size;
 } ginfo_t;
 
-ginfo_t** ginfo_root = NULL;
 ginfo_t** ginfo = NULL;
 
 /*****************************************************************************/

--- a/compiler/runtime/palloc.c
+++ b/compiler/runtime/palloc.c
@@ -226,7 +226,7 @@ typedef struct ginfo {
   size_t total_palloc_size;
 } ginfo_t;
 
-ginfo_t** ginfo = NULL;
+ginfo_t* ginfo = NULL;
 
 /*****************************************************************************/
 /* Debugging support for contexts. Set CTX_TABLE to 1 to use. */
@@ -295,7 +295,7 @@ void sk_add_ctx(char* context) {
 /*****************************************************************************/
 
 char* SKIP_context_get_unsafe() {
-  char* context = (*ginfo)->context;
+  char* context = ginfo->context;
 
   if (context != NULL) {
     sk_incr_ref_count(context);
@@ -306,14 +306,14 @@ char* SKIP_context_get_unsafe() {
 
 uint32_t SKIP_has_context() {
   sk_global_lock();
-  char* context = (*ginfo)->context;
+  char* context = ginfo->context;
   uint32_t result = context != NULL;
   sk_global_unlock();
   return result;
 }
 
 SkipInt SKIP_context_ref_count() {
-  char* context = (*ginfo)->context;
+  char* context = ginfo->context;
 
   if (context == NULL) {
     return (SkipInt)0;
@@ -331,7 +331,7 @@ char* SKIP_context_get() {
 }
 
 void sk_context_set_unsafe(char* obj) {
-  (*ginfo)->context = obj;
+  ginfo->context = obj;
 #ifdef CTX_TABLE
   sk_add_ctx(obj);
 #endif
@@ -339,7 +339,7 @@ void sk_context_set_unsafe(char* obj) {
 
 void sk_context_set(char* obj) {
   sk_global_lock();
-  (*ginfo)->context = obj;
+  ginfo->context = obj;
   sk_global_unlock();
 }
 
@@ -415,7 +415,7 @@ size_t parse_capacity(int argc, char** argv) {
 /*****************************************************************************/
 
 void sk_commit(char* new_root, uint32_t sync) {
-  if ((*ginfo)->fileName == NULL) {
+  if (ginfo->fileName == NULL) {
     sk_context_set_unsafe(new_root);
     return;
   }
@@ -481,7 +481,6 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   gmutex_attr = &mapping->gmutex_attr;
   gmutex = &mapping->gmutex;
   ginfo_t* ginfo_data = &mapping->ginfo_data;
-  ginfo = &mapping->ginfo;
   gid = &mapping->gid;
   capacity = &mapping->capacity;
   pconsts = &mapping->pconsts;
@@ -499,23 +498,23 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
 
   memcpy(persistent_fileName, fileName, fileName_length);
 
-  *ginfo = ginfo_data;
+  mapping->ginfo = ginfo = ginfo_data;
 
   int i;
   for (i = 0; i < FTABLE_SIZE; i++) {
-    (*ginfo)->ftable[i] = NULL;
+    ginfo->ftable[i] = NULL;
   }
 
-  (*ginfo)->break_ptr = static_limit;
-  (*ginfo)->total_palloc_size = 0;
+  ginfo->break_ptr = static_limit;
+  ginfo->total_palloc_size = 0;
 
   // The head must be aligned!
   head = (char*)(((uintptr_t)head + (uintptr_t)(15)) & ~((uintptr_t)(15)));
 
-  (*ginfo)->head = head;
-  (*ginfo)->end = end;
-  (*ginfo)->fileName = persistent_fileName;
-  (*ginfo)->context = NULL;
+  ginfo->head = head;
+  ginfo->end = end;
+  ginfo->fileName = persistent_fileName;
+  ginfo->context = NULL;
   *gid = 1;
   if (icapacity != DEFAULT_CAPACITY) {
     printf("CAPACITY SET TO: %ld\n", icapacity);
@@ -564,7 +563,7 @@ void sk_load_mapping(char* fileName) {
   }
 
   gmutex = &mapping->gmutex;
-  ginfo = &mapping->ginfo;
+  ginfo = mapping->ginfo;
   gid = &mapping->gid;
   capacity = &mapping->capacity;
   pconsts = &mapping->pconsts;
@@ -575,12 +574,12 @@ void sk_load_mapping(char* fileName) {
 /*****************************************************************************/
 
 int sk_is_static(void* ptr) {
-  return (char*)ptr <= (*ginfo)->break_ptr;
+  return (char*)ptr <= ginfo->break_ptr;
 }
 
 void sk_lower_static(void* ptr) {
-  if ((char*)ptr < (*ginfo)->break_ptr) {
-    (*ginfo)->break_ptr = ptr;
+  if ((char*)ptr < ginfo->break_ptr) {
+    ginfo->break_ptr = ptr;
   }
 }
 
@@ -599,17 +598,17 @@ size_t sk_pow2_size(size_t size) {
 
 void sk_add_ftable(void* ptr, size_t size) {
   int slot = sk_bit_size(size);
-  *(void**)ptr = (*ginfo)->ftable[slot];
-  (*ginfo)->ftable[slot] = ptr;
+  *(void**)ptr = ginfo->ftable[slot];
+  ginfo->ftable[slot] = ptr;
 }
 
 void* sk_get_ftable(size_t size) {
   int slot = sk_bit_size(size);
-  void** ptr = (*ginfo)->ftable[slot];
+  void** ptr = ginfo->ftable[slot];
   if (ptr == NULL) {
     return ptr;
   }
-  (*ginfo)->ftable[slot] = *ptr;
+  ginfo->ftable[slot] = *ptr;
   return ptr;
 }
 
@@ -619,7 +618,6 @@ void* sk_get_ftable(size_t size) {
 
 // Handy structure to allocate all those things at once
 typedef struct {
-  ginfo_t* ginfo;
   ginfo_t ginfo_data;
   uint64_t gid;
   void** pconsts;
@@ -631,12 +629,11 @@ static void sk_init_no_file(char* static_limit) {
     perror("malloc");
     exit(1);
   }
-  ginfo = &no_file->ginfo;
-  *ginfo = &no_file->ginfo_data;
-  (*ginfo)->break_ptr = static_limit;
-  (*ginfo)->total_palloc_size = 0;
-  (*ginfo)->fileName = NULL;
-  (*ginfo)->context = NULL;
+  ginfo = &no_file->ginfo_data;
+  ginfo->break_ptr = static_limit;
+  ginfo->total_palloc_size = 0;
+  ginfo->fileName = NULL;
+  ginfo->context = NULL;
   gmutex = NULL;
   gid = &no_file->gid;
   pconsts = &no_file->pconsts;
@@ -645,7 +642,7 @@ static void sk_init_no_file(char* static_limit) {
 }
 
 int sk_is_nofile_mode() {
-  return ((*ginfo)->fileName == NULL);
+  return (ginfo->fileName == NULL);
 }
 
 /*****************************************************************************/
@@ -691,11 +688,11 @@ void SKIP_memory_init(int argc, char** argv) {
 /*****************************************************************************/
 
 void SKIP_print_persistent_size() {
-  printf("%ld\n", (*ginfo)->total_palloc_size);
+  printf("%ld\n", ginfo->total_palloc_size);
 }
 
 void* sk_palloc(size_t size) {
-  if ((*ginfo)->fileName == NULL) {
+  if (ginfo->fileName == NULL) {
     void* result = malloc(size);
     if (result == NULL) {
       perror("malloc");
@@ -705,27 +702,27 @@ void* sk_palloc(size_t size) {
   }
   sk_check_has_lock();
   size = sk_pow2_size(size);
-  (*ginfo)->total_palloc_size += size;
+  ginfo->total_palloc_size += size;
   sk_cell_t* ptr = sk_get_ftable(size);
   if (ptr != NULL) {
     return ptr;
   }
-  if ((*ginfo)->head + size >= (*ginfo)->end) {
+  if (ginfo->head + size >= ginfo->end) {
     fprintf(stderr, "Error: out of persistent memory.\n");
     exit(ERROR_OUT_OF_MEMORY);
   }
-  void* result = (*ginfo)->head;
-  (*ginfo)->head += size;
+  void* result = ginfo->head;
+  ginfo->head += size;
   return result;
 }
 
 void sk_pfree_size(void* chunk, size_t size) {
-  if ((*ginfo)->fileName == NULL) {
+  if (ginfo->fileName == NULL) {
     free(chunk);
     return;
   }
   sk_check_has_lock();
   size = sk_pow2_size(size);
-  (*ginfo)->total_palloc_size -= size;
+  ginfo->total_palloc_size -= size;
   sk_add_ftable(chunk, size);
 }


### PR DESCRIPTION
A bunch of small cleanups followed by other simplifications changing the file mapping format.

Tested with
```shell
set -a; SKARGO_PROFILE=dev; STAGE=2; PATH=$PWD/compiler/stage$STAGE/bin:$PATH; set +a
make clean && make -C compiler clean test && make test
```