### PR TITLE
Runtime/compiler cleanups related to gc types

### DIFF
--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -7,7 +7,6 @@ COMMONFLAGS=-Werror -Wall -Wextra -Wno-sign-conversion -Wno-sometimes-uninitiali
 OLEVEL=-O2
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
 CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)
-CXX64FLAGS=$(OLEVEL) $(COMMONFLAGS)
 
 # NB: this MUST be kept in sync with CRELFILES in prelude/build.mk
 # and CRELFILES in prelude/build_wasm32.mk
@@ -62,7 +61,7 @@ libbacktrace: .libs/libbacktrace.a
 	$(MAKE) -C libbacktrace
 
 runtime64_specific.o: runtime64_specific.cpp .libs/libbacktrace.a
-	clang++ -std=c++11 $(CXX64FLAGS) -g3 -o $@ -c -Ilibbacktrace/ $<
+	clang++ -std=c++11 $(CC64FLAGS) -g3 -o $@ -c -Ilibbacktrace/ $<
 
 %.o: %.c
 	clang $(CC64FLAGS) -g3 -o $@ -c $<

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,12 +1,12 @@
 MEMSIZE32=1073741824
 
-COMMONFLAGS=-Werror -Wall -Wextra -Wno-sign-conversion -Wno-sometimes-uninitialized -Wno-c2x-extensions -Wsign-compare -Wextra-semi-stmt
+OLEVEL=-O2
+COMMONFLAGS=$(OLEVEL) -Werror -Wall -Wextra -Wno-sign-conversion -Wno-sometimes-uninitialized -Wno-c2x-extensions -Wsign-compare -Wextra-semi-stmt
 # To add: -Wcast-align -Wcast-qual -Wimplicit-int-conversion -Wmissing-noreturn -Wpadded -Wreserved-identifier -Wshorten-64-to-32 -Wtautological-unsigned-zero-compare
 # -Watomic-implicit-seq-cst ?
 # If using -Weverything, you may want to add -Wno-declaration-after-statement -Wno-missing-prototypes -Wno-missing-variable-declarations -Wno-shadow -Wno-strict-prototypes -Wno-zero-length-array -Wno-unreachable-code-break -Wno-unreachable-code-return
-OLEVEL=-O2
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
-CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)
+CC64FLAGS=-DSKIP64 $(COMMONFLAGS)
 
 # NB: this MUST be kept in sync with CRELFILES in prelude/build.mk
 # and CRELFILES in prelude/build_wasm32.mk
@@ -47,7 +47,7 @@ libskip_runtime32.bc: $(BCFILES32)
 	llvm-link $(BCFILES32) -o $@
 
 %.bc: %.c
-	clang $(OLEVEL) $(CC32FLAGS) -o $@ -c $<
+	clang $(CC32FLAGS) -o $@ -c $<
 
 libskip_runtime64.a: $(OFILES) runtime64_specific.o $(ONATIVE_FILES)
 	$(AR) rcs $@ $^

--- a/compiler/runtime/copy.c
+++ b/compiler/runtime/copy.c
@@ -26,7 +26,7 @@ static char* SKIP_copy_class(sk_stack_t* st, char* obj,
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t memsize = ty->m_userByteSize;
-  size_t leftsize = ty->m_uninternedMetadataByteSize;
+  size_t leftsize = uninterned_metadata_byte_size(ty);
   void** result = (void**)shallow_copy(obj, memsize, leftsize, large_page);
 
   if ((ty->m_refsHintMask & 1) != 0) {
@@ -61,7 +61,7 @@ static char* SKIP_copy_array(sk_stack_t* st, char* obj,
 
   size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
   size_t memsize = ty->m_userByteSize * len;
-  size_t leftsize = ty->m_uninternedMetadataByteSize;
+  size_t leftsize = uninterned_metadata_byte_size(ty);
   void** result = (void**)shallow_copy(obj, memsize, leftsize, large_page);
   size_t bitsize = sizeof(void*) * 8;
 

--- a/compiler/runtime/copy.c
+++ b/compiler/runtime/copy.c
@@ -59,7 +59,7 @@ static char* SKIP_copy_array(sk_stack_t* st, char* obj,
                              sk_obstack_t* large_page) {
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
-  size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
+  size_t len = skip_array_len(obj);
   size_t memsize = ty->m_userByteSize * len;
   size_t leftsize = uninterned_metadata_byte_size(ty);
   void** result = (void**)shallow_copy(obj, memsize, leftsize, large_page);

--- a/compiler/runtime/copy.c
+++ b/compiler/runtime/copy.c
@@ -108,14 +108,14 @@ static char* SKIP_copy_obj(sk_stack_t* st, char* obj,
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
   switch (ty->m_kind) {
-    case 0:
+    case kSkipGcKindClass:
       result = SKIP_copy_class(st, obj, large_page);
       break;
-    case 1:
+    case kSkipGcKindArray:
       result = SKIP_copy_array(st, obj, large_page);
       break;
     default:
-      // NOT SUPPORTED
+      // IMPOSSIBLE
       SKIP_exit((SkipInt)-1);
   }
 

--- a/compiler/runtime/copy.c
+++ b/compiler/runtime/copy.c
@@ -31,23 +31,23 @@ static char* SKIP_copy_class(sk_stack_t* st, char* obj,
 
   if ((ty->m_refsHintMask & 1) != 0) {
     size_t size = ty->m_userByteSize / sizeof(void*);
-    size_t bitsize = sizeof(void*) * 8;
+    const size_t refMaskWordBitSize = sizeof(ty->m_refMask[0]) * 8;
     size_t mask_slot = 0;
     unsigned int i;
     while (size > 0) {
-      for (i = 0; i < bitsize && i < size; i++) {
+      for (i = 0; i < refMaskWordBitSize && i < size; i++) {
         if (ty->m_refMask[mask_slot] & (1 << i)) {
-          void** ptr = ((void**)obj) + (mask_slot * bitsize) + i;
-          void** slot = result + (mask_slot * bitsize) + i;
+          void** ptr = ((void**)obj) + (mask_slot * refMaskWordBitSize) + i;
+          void** slot = result + (mask_slot * refMaskWordBitSize) + i;
           if (*ptr != NULL) {
             sk_stack_push(st, ptr, slot);
           }
         }
       }
-      if (size < bitsize) {
+      if (size < refMaskWordBitSize) {
         break;
       }
-      size -= bitsize;
+      size -= refMaskWordBitSize;
       mask_slot++;
     }
   }
@@ -63,9 +63,9 @@ static char* SKIP_copy_array(sk_stack_t* st, char* obj,
   size_t memsize = ty->m_userByteSize * len;
   size_t leftsize = uninterned_metadata_byte_size(ty);
   void** result = (void**)shallow_copy(obj, memsize, leftsize, large_page);
-  size_t bitsize = sizeof(void*) * 8;
 
   if ((ty->m_refsHintMask & 1) != 0) {
+    const size_t refMaskWordBitSize = sizeof(ty->m_refMask[0]) * 8;
     char* rhead = (char*)result;
     char* ohead = obj;
     char* end = obj + memsize;
@@ -75,7 +75,7 @@ static char* SKIP_copy_array(sk_stack_t* st, char* obj,
       size_t mask_slot = 0;
       while (size > 0) {
         unsigned int i;
-        for (i = 0; i < bitsize && size > 0; i++) {
+        for (i = 0; i < refMaskWordBitSize && size > 0; i++) {
           if (ty->m_refMask[mask_slot] & (1 << i)) {
             void** ptr = (void**)ohead;
             void** slot = (void**)rhead;

--- a/compiler/runtime/copy.c
+++ b/compiler/runtime/copy.c
@@ -62,11 +62,11 @@ static char* SKIP_copy_array(sk_stack_t* st, char* obj,
   size_t len = skip_array_len(obj);
   size_t memsize = ty->m_userByteSize * len;
   size_t leftsize = uninterned_metadata_byte_size(ty);
-  void** result = (void**)shallow_copy(obj, memsize, leftsize, large_page);
+  char* result = shallow_copy(obj, memsize, leftsize, large_page);
 
   if ((ty->m_refsHintMask & 1) != 0) {
     const size_t refMaskWordBitSize = sizeof(ty->m_refMask[0]) * 8;
-    char* rhead = (char*)result;
+    char* rhead = result;
     char* ohead = obj;
     char* end = obj + memsize;
 
@@ -78,8 +78,8 @@ static char* SKIP_copy_array(sk_stack_t* st, char* obj,
         for (i = 0; i < refMaskWordBitSize && size > 0; i++) {
           if (ty->m_refMask[mask_slot] & (1 << i)) {
             void** ptr = (void**)ohead;
-            void** slot = (void**)rhead;
             if (*ptr != NULL) {
+              void** slot = (void**)rhead;
               sk_stack_push(st, ptr, slot);
             }
           }
@@ -92,7 +92,7 @@ static char* SKIP_copy_array(sk_stack_t* st, char* obj,
     }
   }
 
-  return (char*)result;
+  return result;
 }
 
 static char* SKIP_copy_string(char* obj, sk_obstack_t* large_page) {

--- a/compiler/runtime/free.c
+++ b/compiler/runtime/free.c
@@ -36,7 +36,7 @@ void sk_free_class(sk_stack_t* st, char* obj) {
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t memsize = ty->m_userByteSize;
-  size_t leftsize = ty->m_uninternedMetadataByteSize;
+  size_t leftsize = uninterned_metadata_byte_size(ty);
 
   if (ty == epointer_ty) {
 #ifdef SKIP64
@@ -86,7 +86,7 @@ void sk_free_array(sk_stack_t* st, char* obj) {
 
   size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
   size_t memsize = ty->m_userByteSize * len;
-  size_t leftsize = ty->m_uninternedMetadataByteSize;
+  size_t leftsize = uninterned_metadata_byte_size(ty);
   size_t bitsize = sizeof(void*) * 8;
 
   if ((ty->m_refsHintMask & 1) != 0) {

--- a/compiler/runtime/free.c
+++ b/compiler/runtime/free.c
@@ -84,7 +84,7 @@ void sk_free_class(sk_stack_t* st, char* obj) {
 void sk_free_array(sk_stack_t* st, char* obj) {
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
-  size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
+  size_t len = skip_array_len(obj);
   size_t memsize = ty->m_userByteSize * len;
   size_t leftsize = uninterned_metadata_byte_size(ty);
 

--- a/compiler/runtime/free.c
+++ b/compiler/runtime/free.c
@@ -132,14 +132,14 @@ void sk_free_obj(sk_stack_t* st, char* obj) {
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
   switch (ty->m_kind) {
-    case 0:
+    case kSkipGcKindClass:
       sk_free_class(st, obj);
       break;
-    case 1:
+    case kSkipGcKindArray:
       sk_free_array(st, obj);
       break;
     default:
-      // NOT SUPPORTED
+      // IMPOSSIBLE
       SKIP_exit((SkipInt)-1);
   }
 

--- a/compiler/runtime/hash.c
+++ b/compiler/runtime/hash.c
@@ -177,7 +177,7 @@ static uint64_t sk_hash_array(sk_stack_t* st, char* obj) {
   size_t memsize = ty->m_userByteSize * len;
 
   if ((ty->m_refsHintMask & 1) == 0) {
-    crc = sk_crc64(crc, obj, len * ty->m_userByteSize);
+    crc = sk_crc64(crc, obj, memsize);
   } else {
     const size_t refMaskWordBitSize = sizeof(ty->m_refMask[0]) * 8;
     char* ohead = obj;

--- a/compiler/runtime/hash.c
+++ b/compiler/runtime/hash.c
@@ -143,13 +143,13 @@ static uint64_t sk_hash_class(sk_stack_t* st, char* obj) {
   uint64_t crc = CRC_INIT;
 
   size_t size = ty->m_userByteSize / sizeof(void*);
-  size_t bitsize = sizeof(void*) * 8;
+  const size_t refMaskWordBitSize = sizeof(ty->m_refMask[0]) * 8;
   size_t mask_slot = 0;
   unsigned int i;
 
   while (size > 0) {
-    for (i = 0; i < bitsize && i < size; i++) {
-      void** ptr = ((void**)obj) + (mask_slot * bitsize) + i;
+    for (i = 0; i < refMaskWordBitSize && i < size; i++) {
+      void** ptr = ((void**)obj) + (mask_slot * refMaskWordBitSize) + i;
       if (((ty->m_refsHintMask & 1) != 0) &&
           ty->m_refMask[mask_slot] & (1 << i)) {
         if (*ptr != NULL) {
@@ -159,10 +159,10 @@ static uint64_t sk_hash_class(sk_stack_t* st, char* obj) {
         crc = sk_crc64_combine(crc, *ptr);
       }
     }
-    if (size < bitsize) {
+    if (size < refMaskWordBitSize) {
       break;
     }
-    size -= bitsize;
+    size -= refMaskWordBitSize;
     mask_slot++;
   }
 
@@ -175,11 +175,11 @@ static uint64_t sk_hash_array(sk_stack_t* st, char* obj) {
 
   size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
   size_t memsize = ty->m_userByteSize * len;
-  size_t bitsize = sizeof(void*) * 8;
 
   if ((ty->m_refsHintMask & 1) == 0) {
     crc = sk_crc64(crc, obj, len * ty->m_userByteSize);
   } else {
+    const size_t refMaskWordBitSize = sizeof(ty->m_refMask[0]) * 8;
     char* ohead = obj;
     char* end = obj + memsize;
 
@@ -188,7 +188,7 @@ static uint64_t sk_hash_array(sk_stack_t* st, char* obj) {
       size_t mask_slot = 0;
       while (size > 0) {
         unsigned int i;
-        for (i = 0; i < bitsize && size > 0; i++) {
+        for (i = 0; i < refMaskWordBitSize && size > 0; i++) {
           if (ty->m_refMask[mask_slot] & (1 << i)) {
             void** ptr = (void**)ohead;
             if (*ptr != NULL) {

--- a/compiler/runtime/hash.c
+++ b/compiler/runtime/hash.c
@@ -228,14 +228,14 @@ static uint64_t sk_hash_obj(sk_stack_t* st, char* obj) {
   uint64_t crc;
 
   switch (ty->m_kind) {
-    case 0:
+    case kSkipGcKindClass:
       crc = sk_hash_class(st, obj);
       break;
-    case 1:
+    case kSkipGcKindArray:
       crc = sk_hash_array(st, obj);
       break;
     default:
-      // NOT SUPPORTED
+      // IMPOSSIBLE
       SKIP_exit((SkipInt)-1);
   }
 

--- a/compiler/runtime/hash.c
+++ b/compiler/runtime/hash.c
@@ -173,7 +173,7 @@ static uint64_t sk_hash_array(sk_stack_t* st, char* obj) {
   uint64_t crc = CRC_INIT;
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
-  size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
+  size_t len = skip_array_len(obj);
   size_t memsize = ty->m_userByteSize * len;
 
   if ((ty->m_refsHintMask & 1) == 0) {

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -141,7 +141,7 @@ static char* SKIP_intern_class(sk_stack_t* st, char* obj) {
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t memsize = ty->m_userByteSize;
-  size_t leftsize = ty->m_uninternedMetadataByteSize;
+  size_t leftsize = uninterned_metadata_byte_size(ty);
   void** result = (void**)shallow_intern(obj, memsize, leftsize);
 
   if (epointer_ty != NULL && ty != epointer_ty &&
@@ -176,7 +176,7 @@ static char* SKIP_intern_array(sk_stack_t* st, char* obj) {
 
   size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
   size_t memsize = ty->m_userByteSize * len;
-  size_t leftsize = ty->m_uninternedMetadataByteSize;
+  size_t leftsize = uninterned_metadata_byte_size(ty);
   void** result = (void**)shallow_intern(obj, memsize, leftsize);
   size_t bitsize = sizeof(void*) * 8;
 

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -112,8 +112,7 @@ static char* SKIP_intern_class(sk_stack_t* st, char* obj) {
   size_t leftsize = uninterned_metadata_byte_size(ty);
   void** result = (void**)shallow_intern(obj, memsize, leftsize);
 
-  if (epointer_ty != NULL && ty != epointer_ty &&
-      (ty->m_refsHintMask & 1) != 0) {
+  if (ty != epointer_ty && (ty->m_refsHintMask & 1) != 0) {
     size_t size = ty->m_userByteSize / sizeof(void*);
     const size_t refMaskWordBitSize = sizeof(ty->m_refMask[0]) * 8;
     size_t mask_slot = 0;

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -144,11 +144,11 @@ static char* SKIP_intern_array(sk_stack_t* st, char* obj) {
   size_t len = skip_array_len(obj);
   size_t memsize = ty->m_userByteSize * len;
   size_t leftsize = uninterned_metadata_byte_size(ty);
-  void** result = (void**)shallow_intern(obj, memsize, leftsize);
+  char* result = shallow_intern(obj, memsize, leftsize);
 
   if ((ty->m_refsHintMask & 1) != 0) {
     const size_t refMaskWordBitSize = sizeof(ty->m_refMask[0]) * 8;
-    char* rhead = (char*)result;
+    char* rhead = result;
     char* ohead = obj;
     char* end = obj + memsize;
 
@@ -160,8 +160,8 @@ static char* SKIP_intern_array(sk_stack_t* st, char* obj) {
         for (i = 0; i < refMaskWordBitSize && size > 0; i++) {
           if (ty->m_refMask[mask_slot] & (1 << i)) {
             void** ptr = (void**)ohead;
-            void** slot = (void**)rhead;
             if (*ptr != NULL) {
+              void** slot = (void**)rhead;
               sk_stack_push(st, ptr, slot);
             }
           }
@@ -174,7 +174,7 @@ static char* SKIP_intern_array(sk_stack_t* st, char* obj) {
     }
   }
 
-  return (char*)result;
+  return result;
 }
 
 static char* SKIP_intern_string(char* obj) {

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -66,36 +66,6 @@ static char* shallow_intern(char* obj, size_t memsize, size_t leftsize) {
   return mem;
 }
 
-void sk_incr_ref_count(void* obj) {
-#ifdef SKIP32
-  sk_persistent_write(obj, 0);
-#endif
-  uintptr_t* count = obj;
-  if (SKIP_is_string(obj)) {
-#ifdef SKIP64
-    count -= 2;
-#endif
-#ifdef SKIP32
-    count -= 3;
-#endif
-  } else {
-    SKIP_gc_type_t* ty = get_gc_type(obj);
-
-    switch (ty->m_kind) {
-      case kSkipGcKindClass:
-        count -= 2;
-        break;
-      case kSkipGcKindArray:
-        count -= 3;
-        break;
-      default:
-        // IMPOSSIBLE
-        SKIP_exit((SkipInt)-1);
-    }
-  }
-  *count = *count + 1;
-}
-
 static uintptr_t* sk_get_ref_count_addr(void* obj) {
   uintptr_t* count = obj;
   if (SKIP_is_string(obj)) {
@@ -121,6 +91,14 @@ static uintptr_t* sk_get_ref_count_addr(void* obj) {
     }
   }
   return count;
+}
+
+void sk_incr_ref_count(void* obj) {
+#ifdef SKIP32
+  sk_persistent_write(obj, 0);
+#endif
+  uintptr_t* count = sk_get_ref_count_addr(obj);
+  *count = *count + 1;
 }
 
 uintptr_t sk_decr_ref_count(void* obj) {

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -78,17 +78,7 @@ static uintptr_t* sk_get_ref_count_addr(void* obj) {
   } else {
     SKIP_gc_type_t* ty = get_gc_type(obj);
 
-    switch (ty->m_kind) {
-      case kSkipGcKindClass:
-        count -= 2;
-        break;
-      case kSkipGcKindArray:
-        count -= 3;
-        break;
-      default:
-        // IMPOSSIBLE
-        SKIP_exit((SkipInt)-1);
-    }
+    count -= 1 + uninterned_metadata_word_size(ty);
   }
   return count;
 }

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -142,7 +142,7 @@ static char* SKIP_intern_class(sk_stack_t* st, char* obj) {
 static char* SKIP_intern_array(sk_stack_t* st, char* obj) {
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
-  size_t len = *(uint32_t*)(obj - sizeof(char*) - sizeof(uint32_t));
+  size_t len = skip_array_len(obj);
   size_t memsize = ty->m_userByteSize * len;
   size_t leftsize = uninterned_metadata_byte_size(ty);
   void** result = (void**)shallow_intern(obj, memsize, leftsize);

--- a/compiler/runtime/intern.c
+++ b/compiler/runtime/intern.c
@@ -82,13 +82,14 @@ void sk_incr_ref_count(void* obj) {
     SKIP_gc_type_t* ty = get_gc_type(obj);
 
     switch (ty->m_kind) {
-      case 0:
+      case kSkipGcKindClass:
         count -= 2;
         break;
-      case 1:
+      case kSkipGcKindArray:
         count -= 3;
         break;
       default:
+        // IMPOSSIBLE
         SKIP_exit((SkipInt)-1);
     }
   }
@@ -108,13 +109,14 @@ static uintptr_t* sk_get_ref_count_addr(void* obj) {
     SKIP_gc_type_t* ty = get_gc_type(obj);
 
     switch (ty->m_kind) {
-      case 0:
+      case kSkipGcKindClass:
         count -= 2;
         break;
-      case 1:
+      case kSkipGcKindArray:
         count -= 3;
         break;
       default:
+        // IMPOSSIBLE
         SKIP_exit((SkipInt)-1);
     }
   }
@@ -224,14 +226,14 @@ static char* SKIP_intern_obj(sk_stack_t* st, char* obj) {
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
   switch (ty->m_kind) {
-    case 0:
+    case kSkipGcKindClass:
       result = SKIP_intern_class(st, obj);
       break;
-    case 1:
+    case kSkipGcKindArray:
       result = SKIP_intern_array(st, obj);
       break;
     default:
-      // NOT SUPPORTED
+      // IMPOSSIBLE
       SKIP_exit((SkipInt)-1);
   }
 

--- a/compiler/runtime/native_eq.c
+++ b/compiler/runtime/native_eq.c
@@ -41,13 +41,13 @@ SkipInt SKIP_native_eq_class(sk_stack_t* st, char* obj1, char* obj2) {
   }
 
   size_t size = ty1->m_userByteSize / sizeof(void*);
-  size_t bitsize = sizeof(void*) * 8;
+  const size_t refMaskWordBitSize = sizeof(ty1->m_refMask[0]) * 8;
   size_t mask_slot = 0;
   unsigned int i;
   while (size > 0) {
-    for (i = 0; i < bitsize && i < size; i++) {
-      void* ptr1 = *(((void**)obj1) + (mask_slot * bitsize) + i);
-      void* ptr2 = *(((void**)obj2) + (mask_slot * bitsize) + i);
+    for (i = 0; i < refMaskWordBitSize && i < size; i++) {
+      void* ptr1 = *(((void**)obj1) + (mask_slot * refMaskWordBitSize) + i);
+      void* ptr2 = *(((void**)obj2) + (mask_slot * refMaskWordBitSize) + i);
 
       if (ty1->m_refMask[mask_slot] & (1 << i) && ptr1 != ptr2) {
         sk_stack_push(st, ptr1, ptr2);
@@ -57,10 +57,10 @@ SkipInt SKIP_native_eq_class(sk_stack_t* st, char* obj1, char* obj2) {
         }
       }
     }
-    if (size < bitsize) {
+    if (size < refMaskWordBitSize) {
       break;
     }
-    size -= bitsize;
+    size -= refMaskWordBitSize;
     mask_slot++;
   }
 
@@ -84,11 +84,11 @@ SkipInt SKIP_native_eq_array(sk_stack_t* st, char* obj1, char* obj2) {
 
   size_t memsize = ty1->m_userByteSize * len1;
 
-  size_t bitsize = sizeof(void*) * 8;
-
   if ((ty1->m_refsHintMask & 1) == 0) {
     return (SkipInt)memcmp(obj1, obj2, memsize);
   }
+
+  const size_t refMaskWordBitSize = sizeof(ty1->m_refMask[0]) * 8;
 
   char* ohead1 = obj1;
   char* ohead2 = obj2;
@@ -99,7 +99,7 @@ SkipInt SKIP_native_eq_array(sk_stack_t* st, char* obj1, char* obj2) {
     size_t mask_slot = 0;
     while (size > 0) {
       unsigned int i;
-      for (i = 0; i < bitsize && size > 0; i++) {
+      for (i = 0; i < refMaskWordBitSize && size > 0; i++) {
         void* ptr1 = *((void**)ohead1);
         void* ptr2 = *((void**)ohead2);
 

--- a/compiler/runtime/native_eq.c
+++ b/compiler/runtime/native_eq.c
@@ -150,14 +150,14 @@ SkipInt SKIP_native_eq_helper(sk_stack_t* st, char* obj1, char* obj2) {
   }
 
   switch (ty1->m_kind) {
-    case 0:
+    case kSkipGcKindClass:
       return SKIP_native_eq_class(st, obj1, obj2);
       break;
-    case 1:
+    case kSkipGcKindArray:
       return SKIP_native_eq_array(st, obj1, obj2);
       break;
     default:
-      // NOT SUPPORTED
+      // IMPOSSIBLE
       SKIP_exit((SkipInt)-1);
   }
 

--- a/compiler/runtime/native_eq.c
+++ b/compiler/runtime/native_eq.c
@@ -103,10 +103,10 @@ SkipInt SKIP_native_eq_array(sk_stack_t* st, char* obj1, char* obj2) {
         void* ptr1 = *((void**)ohead1);
         void* ptr2 = *((void**)ohead2);
 
-        if (ty1->m_refMask[mask_slot] & (1 << i) && ptr1 != ptr2) {
-          sk_stack_push(st, ptr1, ptr2);
-        } else {
-          if (ptr1 != ptr2) {
+        if (ptr1 != ptr2) {
+          if (ty1->m_refMask[mask_slot] & (1 << i)) {
+            sk_stack_push(st, ptr1, ptr2);
+          } else {
             return 1;
           }
         }

--- a/compiler/runtime/native_eq.c
+++ b/compiler/runtime/native_eq.c
@@ -26,7 +26,7 @@
  */
 /*****************************************************************************/
 
-SkipInt SKIP_native_eq_class(sk_stack_t* st, char* obj1, char* obj2) {
+SkipInt SKIP_native_eq_obj(sk_stack_t* st, char* obj1, char* obj2) {
   if (obj1 == obj2) return 0;
 
   SKIP_gc_type_t* ty1 = get_gc_type(obj1);
@@ -36,47 +36,8 @@ SkipInt SKIP_native_eq_class(sk_stack_t* st, char* obj1, char* obj2) {
     return 1;
   }
 
-  if ((ty1->m_refsHintMask & 1) == 0) {
-    return (SkipInt)memcmp(obj1, obj2, ty1->m_userByteSize);
-  }
-
-  size_t size = ty1->m_userByteSize / sizeof(void*);
-  const size_t refMaskWordBitSize = sizeof(ty1->m_refMask[0]) * 8;
-  size_t mask_slot = 0;
-  unsigned int i;
-  while (size > 0) {
-    for (i = 0; i < refMaskWordBitSize && i < size; i++) {
-      void* ptr1 = *(((void**)obj1) + (mask_slot * refMaskWordBitSize) + i);
-      void* ptr2 = *(((void**)obj2) + (mask_slot * refMaskWordBitSize) + i);
-
-      if (ty1->m_refMask[mask_slot] & (1 << i) && ptr1 != ptr2) {
-        sk_stack_push(st, ptr1, ptr2);
-      } else {
-        if (ptr1 != ptr2) {
-          return 1;
-        }
-      }
-    }
-    if (size < refMaskWordBitSize) {
-      break;
-    }
-    size -= refMaskWordBitSize;
-    mask_slot++;
-  }
-
-  return 0;
-}
-
-SkipInt SKIP_native_eq_array(sk_stack_t* st, char* obj1, char* obj2) {
-  SKIP_gc_type_t* ty1 = get_gc_type(obj1);
-  SKIP_gc_type_t* ty2 = get_gc_type(obj2);
-
-  if (ty1 != ty2) {
-    return 1;
-  }
-
-  size_t len1 = skip_array_len(obj1);
-  size_t len2 = skip_array_len(obj2);
+  size_t len1 = skip_object_len(ty1, obj1);
+  size_t len2 = skip_object_len(ty1, obj2);
 
   if (len1 != len2) {
     return 1;
@@ -142,26 +103,7 @@ SkipInt SKIP_native_eq_helper(sk_stack_t* st, char* obj1, char* obj2) {
     return 1;
   }
 
-  SKIP_gc_type_t* ty1 = get_gc_type(obj1);
-  SKIP_gc_type_t* ty2 = get_gc_type(obj2);
-
-  if (ty1 != ty2) {
-    return 1;
-  }
-
-  switch (ty1->m_kind) {
-    case kSkipGcKindClass:
-      return SKIP_native_eq_class(st, obj1, obj2);
-      break;
-    case kSkipGcKindArray:
-      return SKIP_native_eq_array(st, obj1, obj2);
-      break;
-    default:
-      // IMPOSSIBLE
-      SKIP_exit((SkipInt)-1);
-  }
-
-  return 0;
+  return SKIP_native_eq_obj(st, obj1, obj2);
 }
 
 SkipInt SKIP_isEq(char* obj1, char* obj2) {

--- a/compiler/runtime/native_eq.c
+++ b/compiler/runtime/native_eq.c
@@ -75,8 +75,8 @@ SkipInt SKIP_native_eq_array(sk_stack_t* st, char* obj1, char* obj2) {
     return 1;
   }
 
-  size_t len1 = *(uint32_t*)(obj1 - sizeof(char*) - sizeof(uint32_t));
-  size_t len2 = *(uint32_t*)(obj2 - sizeof(char*) - sizeof(uint32_t));
+  size_t len1 = skip_array_len(obj1);
+  size_t len2 = skip_array_len(obj2);
 
   if (len1 != len2) {
     return 1;

--- a/compiler/runtime/obstack.c
+++ b/compiler/runtime/obstack.c
@@ -150,7 +150,7 @@ char* SKIP_Obstack_shallowClone(size_t /* size */, char* obj) {
   SKIP_gc_type_t* ty = get_gc_type(obj);
 
   size_t memsize = ty->m_userByteSize;
-  size_t leftsize = ty->m_uninternedMetadataByteSize;
+  size_t leftsize = uninterned_metadata_byte_size(ty);
   size_t size = memsize + leftsize;
 
   char* mem = SKIP_Obstack_alloc(size);

--- a/compiler/runtime/posix.c
+++ b/compiler/runtime/posix.c
@@ -178,8 +178,7 @@ int64_t SKIP_posix_wstopsig(int64_t stat_loc) {
 }
 
 int64_t SKIP_posix_poll(char *pollfds) {
-  unsigned int nfds =
-      *(uint32_t *)(pollfds - sizeof(char *) - sizeof(uint32_t));
+  unsigned int nfds = skip_array_len(pollfds);
 
   for (;;) {
     int rv = poll((struct pollfd *)pollfds, nfds, -1);
@@ -276,7 +275,7 @@ int64_t SKIP_posix_spawnp(char *skargv, char *skenvp, char *file_actionsp) {
 }
 
 void SKIP_posix_execvp(char *args_obj) {
-  size_t num_args = *(uint32_t *)(args_obj - sizeof(char *) - sizeof(uint32_t));
+  size_t num_args = skip_array_len(args_obj);
   char **args = (char **)malloc(sizeof(char *) * (num_args + 1));
   if (args == NULL) {
     perror("malloc");

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -155,10 +155,7 @@ typedef struct {
   uint16_t m_uninternedMetadataByteSize;
   uint16_t m_unused_internedMetadataByteSize;
   SkipInt m_userByteSize;
-#ifdef SKIP32
-  void* unused1;
-#endif
-  void* unused;
+  SkipInt m_unused_padding;
   size_t m_refMask[0];
   // a 0-terminated name follows if m_hasName is true
 } SKIP_gc_type_t;

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -146,10 +146,13 @@ sk_value3_t sk_stack3_pop(sk_stack3_t* st);
 /* The type information exposed by the Skip compiler for each object. */
 /*****************************************************************************/
 
+#define kSkipGcKindClass 0
+#define kSkipGcKindArray 1
+
 // vtable entries created by createGCType in vtable.sk
 typedef struct {
   uint8_t m_refsHintMask;
-  uint8_t m_kind;
+  uint8_t m_kind;  // either kSkipGcKindClass or kSkipGcKindArray
   uint8_t m_unused_tilesPerMask;
   uint8_t m_hasName;
   uint16_t m_uninternedMetadataByteSize;

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -159,7 +159,7 @@ typedef struct {
   uint16_t m_unused_internedMetadataByteSize;
   SkipInt m_userByteSize;
   SkipInt m_unused_padding;
-  size_t m_refMask[0];
+  SkipInt m_refMask[0];
   // a 0-terminated name follows if m_hasName is true
 } SKIP_gc_type_t;
 

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -154,10 +154,9 @@ typedef struct {
   uint8_t m_hasName;
   uint16_t m_uninternedMetadataByteSize;
   uint16_t m_unused_internedMetadataByteSize;
-  size_t m_userByteSize;
+  SkipInt m_userByteSize;
 #ifdef SKIP32
   void* unused1;
-  void* unused2;
 #endif
   void* unused;
   size_t m_refMask[0];

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -163,6 +163,16 @@ typedef struct {
   // a 0-terminated name follows if m_hasName is true
 } SKIP_gc_type_t;
 
+/* The uninterned_metadata_byte_size is the size preceding the pointer to a
+   non-string GC value. It is:
+   - 1 word for kSkipGcKindClass, its vtable pointer
+   - 2 words for kSkipGcKindArray, its vtable pointer preceded by its size on
+       32 bits, itself preceded by an unused padding of 32 bits on 64-bits arch.
+*/
+#define uninterned_metadata_word_size(ty) ((ty)->m_kind + 1)
+#define uninterned_metadata_byte_size(ty) \
+  (uninterned_metadata_word_size(ty) * sizeof(void*))
+
 SKIP_gc_type_t* get_gc_type(char* skip_object);
 
 /*****************************************************************************/

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -153,7 +153,7 @@ typedef struct {
   uint8_t m_unused_tilesPerMask;
   uint8_t m_hasName;
   uint16_t m_uninternedMetadataByteSize;
-  uint16_t m_internedMetadataByteSize;
+  uint16_t m_unused_internedMetadataByteSize;
   size_t m_userByteSize;
 #ifdef SKIP32
   void* unused1;

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -41,6 +41,16 @@ void sk_print_ctx_table();
 #endif
 
 /*****************************************************************************/
+/* Handy macros. */
+/*****************************************************************************/
+
+#define ptr_is_a_type_member_array(ptr, type, member) \
+  (1 ? (ptr) : &((type*)0)->member[0])
+#define container_of_type_member_array(ptr, type, member)         \
+  ((type*)((char*)ptr_is_a_type_member_array(ptr, type, member) - \
+           offsetof(type, member)))
+
+/*****************************************************************************/
 /* The error code thrown by the runtime. */
 /*****************************************************************************/
 
@@ -167,13 +177,30 @@ typedef struct {
    non-string GC value. It is:
    - 1 word for kSkipGcKindClass, its vtable pointer
    - 2 words for kSkipGcKindArray, its vtable pointer preceded by its size on
-       32 bits, itself preceded by an unused padding of 32 bits on 64-bits arch.
+       32 bits, itself preceded by an unused padding of 32 bits on 64-bits arch
+       (see sk_array_t).
 */
 #define uninterned_metadata_word_size(ty) ((ty)->m_kind + 1)
 #define uninterned_metadata_byte_size(ty) \
   (uninterned_metadata_word_size(ty) * sizeof(void*))
 
 SKIP_gc_type_t* get_gc_type(char* skip_object);
+
+/*****************************************************************************/
+/* SKIP Array representation: */
+/*****************************************************************************/
+
+typedef struct {
+#ifdef SKIP64
+  uint32_t unused_padding;
+#endif
+  uint32_t length;
+  void** vtable;
+  char data[0];
+} sk_array_t;
+
+#define skip_array_len(obj) \
+  (container_of_type_member_array(obj, sk_array_t, data)->length)
 
 /*****************************************************************************/
 /* SKIP String representation. */

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -150,7 +150,7 @@ sk_value3_t sk_stack3_pop(sk_stack3_t* st);
 typedef struct {
   uint8_t m_refsHintMask;
   uint8_t m_kind;
-  uint8_t m_tilesPerMask;
+  uint8_t m_unused_tilesPerMask;
   uint8_t m_hasName;
   uint16_t m_uninternedMetadataByteSize;
   uint16_t m_internedMetadataByteSize;

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -188,6 +188,8 @@ typedef struct {
 
 #define ty_is_array(ty) ((ty)->m_kind == kSkipGcKindArray)
 
+#define ty_is_array(ty) ((ty)->m_kind == kSkipGcKindArray)
+
 SKIP_gc_type_t* get_gc_type(char* skip_object);
 
 /*****************************************************************************/
@@ -214,6 +216,12 @@ typedef struct {
 
 #define skip_array_len(obj) \
   (container_of_type_member_array(obj, sk_array_t, data)->length)
+
+/*****************************************************************************/
+/* SKIP objects: arrays and class instances. */
+/*****************************************************************************/
+
+#define skip_object_len(ty, obj) (ty_is_array(ty) ? skip_array_len(obj) : 1)
 
 /*****************************************************************************/
 /* SKIP String representation. */

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -175,16 +175,29 @@ typedef struct {
 
 /* The uninterned_metadata_byte_size is the size preceding the pointer to a
    non-string GC value. It is:
-   - 1 word for kSkipGcKindClass, its vtable pointer
+   - 1 word for kSkipGcKindClass, its vtable pointer (see sk_class_inst_t)
    - 2 words for kSkipGcKindArray, its vtable pointer preceded by its size on
        32 bits, itself preceded by an unused padding of 32 bits on 64-bits arch
        (see sk_array_t).
 */
-#define uninterned_metadata_word_size(ty) ((ty)->m_kind + 1)
-#define uninterned_metadata_byte_size(ty) \
-  (uninterned_metadata_word_size(ty) * sizeof(void*))
+#define uninterned_metadata_byte_size(ty)       \
+  (ty_is_array(ty) ? offsetof(sk_array_t, data) \
+                   : offsetof(sk_class_inst_t, data))
+#define uninterned_metadata_word_size(ty) \
+  (uninterned_metadata_byte_size(ty) / sizeof(void*))
+
+#define ty_is_array(ty) ((ty)->m_kind == kSkipGcKindArray)
 
 SKIP_gc_type_t* get_gc_type(char* skip_object);
+
+/*****************************************************************************/
+/* SKIP Class instance representation: */
+/*****************************************************************************/
+
+typedef struct {
+  void** vtable;
+  char data[0];
+} sk_class_inst_t;
 
 /*****************************************************************************/
 /* SKIP Array representation: */

--- a/compiler/runtime/runtime.h
+++ b/compiler/runtime/runtime.h
@@ -161,6 +161,7 @@ typedef struct {
 #endif
   void* unused;
   size_t m_refMask[0];
+  // a 0-terminated name follows if m_hasName is true
 } SKIP_gc_type_t;
 
 SKIP_gc_type_t* get_gc_type(char* skip_object);

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -1,3 +1,7 @@
+#ifndef SKIP64
+#error "This file requires -DSKIP64"
+#endif
+
 extern "C" {
 #include "runtime.h"
 }

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -177,7 +177,7 @@ char* sk2c_string(char* skstr) {
 }
 
 char** sk2c_string_array(char* skarr) {
-  size_t sz = *(uint32_t*)(skarr - sizeof(char*) - sizeof(uint32_t));
+  size_t sz = skip_array_len(skarr);
   char** arr = (char**)malloc(sizeof(char*) * (sz + 1));
   if (arr == NULL) {
     perror("malloc");

--- a/compiler/src/IR.sk
+++ b/compiler/src/IR.sk
@@ -241,11 +241,6 @@ class SClass{
   private scalarType: ?ScalarType = None(),
   // If a Vector, the layout describing its elements.
   arraySlot: ?ArraySlotInfo = None(),
-  // True if this type can refer to aliased mutable types (and thus needs
-  // special handling during freeze).  False if any reference can only appear
-  // once in an object of this type.  Note that 'this' needs to be included in
-  // that set.
-  canAliasMutableTypes: Bool = true,
 } extends HasFileRange uses Show {
   fun isArray(): Bool {
     this.arraySlot.isSome()

--- a/compiler/src/specialize.sk
+++ b/compiler/src/specialize.sk
@@ -1032,7 +1032,6 @@ mutable class Specializer{
       !info.sclass = sclass with {
         fields => buf.toArray(),
         arraySlot,
-        canAliasMutableTypes => true,
       };
       this.untrackedSClassSet(info.sclass.id, info);
     }

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -592,7 +592,7 @@ private fun createGCType(
     !fieldBitOffset = fieldBitOffset + f.typ.getScalarType(env).bitSize
   };
 
-  // m_refsHint
+  // m_refsHintMask
   pushField(kByteConstants[refsHint]);
 
   // m_kind

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -473,13 +473,7 @@ private fun createGCType(
   env: GlobalEnv,
   config: Config.Config,
 ): ConstantStruct {
-  (
-    userByteSize,
-    hasGCPointers,
-    uninternedMetaSize,
-    kind,
-    isAllDeepFrozen,
-  ) = sc.arraySlot match {
+  (userByteSize, hasGCPointers, uninternedMetaSize, kind) = sc.arraySlot match {
   | None() ->
     // This is a non-Vector type.
 
@@ -495,14 +489,11 @@ private fun createGCType(
 
     hasGCPointers = layout.any(x -> x.typ.isGCPointer());
 
-    isAllDeepFrozen = sc.fields.all(x -> x.typ.isDeepFrozen());
-
     (
       userSize, // userByteSize
       hasGCPointers,
       config.ptrByteSize, // sizeof(RObjMetadata)
       0, // kSkipGcKindClass
-      isAllDeepFrozen, // kSkipGcRefsHintFrozenRefs
     )
   | Some(slotInfo) ->
     // This is a Vector type.
@@ -513,17 +504,11 @@ private fun createGCType(
 
     userSize = slotInfo.bitSize / 8;
 
-    // Set the GC bits. All pointers are at the beginning of each slot,
-    // but we tile it out as many times as will fit in a 64-bit word
-    // so the inner loop of the GC can be tighter.
-    isAllDeepFrozen = slotInfo.types.all(x -> x.isDeepFrozen());
-
     (
       userSize, // userByteSize
       hasGCPointers,
       2 * config.ptrByteSize, // uninternedMetaSize
       1, // kSkipGcKindArray
-      isAllDeepFrozen,
     ) // kSkipGcRefsHintFrozenRefs
   };
 
@@ -536,10 +521,6 @@ private fun createGCType(
   } else {
     0
   };
-
-  !numMaskWords =
-    numMaskWords * 2 -
-    (if (isAllDeepFrozen && (numMaskWords > 0)) 1 else 0);
 
   refsHint = 0;
   if (numMaskWords != 0) {
@@ -601,14 +582,11 @@ private fun createGCType(
     // Create a memory image of the flag words array.
     flags = Array::mfill(numMaskWords, 0);
 
-    setBit = (bitOffset, isMutable) -> {
+    setBit = (bitOffset) -> {
       bitIndex = bitOffset / config.ptrBitSize;
-      wordIndex = 2 * (bitIndex / 64);
+      wordIndex = bitIndex / 64;
       bit = 1.shl(bitIndex % 64);
       flags.set(wordIndex, flags[wordIndex].or(bit));
-      if (isMutable) {
-        flags.set(wordIndex + 1, flags[wordIndex + 1].or(bit));
-      };
     };
 
     sc.arraySlot match {
@@ -616,7 +594,7 @@ private fun createGCType(
       for (x in sc.fields) {
         if (x.typ.getScalarType(env).isGCPointer()) {
           bitOffset = sc.getLayoutSlot(x.name, sc.pos).bitOffset;
-          setBit(bitOffset, !isAllDeepFrozen && !x.typ.isDeepFrozen())
+          setBit(bitOffset)
         }
       }
     | Some(slotInfo) ->
@@ -625,7 +603,7 @@ private fun createGCType(
         scalarType = x.getScalarType(env);
         if (scalarType.isGCPointer()) {
           bitOffset = slotInfo.bitOffsets[idx];
-          setBit(bitOffset, !isAllDeepFrozen && !x.isDeepFrozen())
+          setBit(bitOffset)
         }
       })
     };

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -515,21 +515,13 @@ private fun createGCType(
   | Some(slotInfo) ->
     // This is a Vector type.
 
-    // Count how many pointers are in each array slot.
+    // Check whether there are pointers in array slots.
     // They go at the beginning of each slot (in the case of a tuple etc.)
-    numPointers = slotInfo.types.foldl(
-      (acc, t) ->
-        if (t.getScalarType(env).isGCPointer()) {
-          acc + 1
-        } else {
-          acc
-        },
-      0,
-    );
+    hasGCPointers = slotInfo.types.any(t -> t.getScalarType(env).isGCPointer());
 
     userSize = slotInfo.bitSize / 8;
 
-    words = if (numPointers == 0) {
+    words = if (!hasGCPointers) {
       0
     } else {
       (userSize / config.ptrByteSize + (config.ptrBitSize - 1)) /

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -552,9 +552,7 @@ private fun createGCType(
     !refsHint = refsHint.or(2) // kSkipGcRefsHintAllFrozenRefs
   };
 
-  if (!sc.canAliasMutableTypes) {
-    !refsHint = refsHint.or(4) // kSkipGcRefsHintNoDuplicateMutables
-  };
+  !refsHint = refsHint.or(4); // kSkipGcRefsHintNoDuplicateMutables
 
   // Inserting names into GC info prevents SkipGcTypes from being shared
   // between different classes, which prevents their vtables from being

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -552,8 +552,6 @@ private fun createGCType(
     !refsHint = refsHint.or(2) // kSkipGcRefsHintAllFrozenRefs
   };
 
-  !refsHint = refsHint.or(4); // kSkipGcRefsHintNoDuplicateMutables
-
   // Inserting names into GC info prevents SkipGcTypes from being shared
   // between different classes, which prevents their vtables from being
   // shared, which can bloat the binary. So we only include detailed

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -598,8 +598,8 @@ private fun createGCType(
   // m_kind
   pushField(kByteConstants[kind]);
 
-  // m_tilesPerMask
-  pushField(kByteConstants[tilesPerMask]);
+  // m_unused_tilesPerMask
+  pushField(kByteConstants[0]);
 
   // m_hasName
   pushField(kByteConstants[if (provideName) 1 else 0]);

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -589,14 +589,8 @@ private fun createGCType(
     ConstantInt{id => InstrID::none, typ => tInt, value => userByteSize},
   );
 
-  // unused padding
-  pushField(ConstantInt{id => InstrID::none, typ => tNonGCPointer, value => 0});
-
-  if (config.ptrBitSize == 32) {
-    // Emit alignment padding before the mask words.
-    // TODO: Maybe use 32-bit mask words in this case.
-    pushField(ConstantInt{id => InstrID::none, typ => tInt32, value => 0})
-  };
+  // m_unused_padding
+  pushField(ConstantInt{id => InstrID::none, typ => tInt, value => 0});
 
   if (fieldBitOffset % 64 != 0) {
     sc.die("bad vtable entry alignment")

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -514,10 +514,9 @@ private fun createGCType(
 
   // Create the string declaring a SkipGcType.
 
-  // We need this many words for our bit mask.
+  // We need this many tInt words for our bit mask.
   numMaskWords = if (hasGCPointers) {
-    (userByteSize / config.ptrByteSize + (config.ptrBitSize - 1)) /
-      config.ptrBitSize
+    (userByteSize / config.ptrByteSize + 63) / 64
   } else {
     0
   };

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -548,9 +548,6 @@ private fun createGCType(
   if (numMaskWords != 0) {
     !refsHint = refsHint.or(1) // kSkipGcRefsHintMixedRefs
   };
-  if (isAllDeepFrozen) {
-    !refsHint = refsHint.or(2) // kSkipGcRefsHintAllFrozenRefs
-  };
 
   // Inserting names into GC info prevents SkipGcTypes from being shared
   // between different classes, which prevents their vtables from being

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -475,7 +475,7 @@ private fun createGCType(
 ): ConstantStruct {
   (
     userByteSize,
-    numMaskWords,
+    hasGCPointers,
     uninternedMetaSize,
     internedMetaSize,
     kind,
@@ -494,19 +494,13 @@ private fun createGCType(
       roundUp(last.bitOffset + last.typ.bitSize, 64) / 8
     };
 
-    // We need this many words for our bit mask.
-    words = if (layout.any(x -> x.typ.isGCPointer())) {
-      (userSize / config.ptrByteSize + (config.ptrBitSize - 1)) /
-        config.ptrBitSize
-    } else {
-      0
-    };
+    hasGCPointers = layout.any(x -> x.typ.isGCPointer());
 
     isAllDeepFrozen = sc.fields.all(x -> x.typ.isDeepFrozen());
 
     (
       userSize, // userByteSize
-      words, // numMaskWords
+      hasGCPointers,
       config.ptrByteSize, // sizeof(RObjMetadata)
       3 * config.ptrByteSize, // sizeof(IObjMetadata)
       0, // kSkipGcKindClass
@@ -521,13 +515,6 @@ private fun createGCType(
 
     userSize = slotInfo.bitSize / 8;
 
-    words = if (!hasGCPointers) {
-      0
-    } else {
-      (userSize / config.ptrByteSize + (config.ptrBitSize - 1)) /
-        config.ptrBitSize
-    };
-
     // Set the GC bits. All pointers are at the beginning of each slot,
     // but we tile it out as many times as will fit in a 64-bit word
     // so the inner loop of the GC can be tighter.
@@ -535,7 +522,7 @@ private fun createGCType(
 
     (
       userSize, // userByteSize
-      words, // numMaskWords
+      hasGCPointers,
       2 * config.ptrByteSize, // uninternedMetaSize
       3 * config.ptrByteSize, // internedMetaSize
       1, // kSkipGcKindArray
@@ -544,6 +531,14 @@ private fun createGCType(
   };
 
   // Create the string declaring a SkipGcType.
+
+  // We need this many words for our bit mask.
+  numMaskWords = if (hasGCPointers) {
+    (userByteSize / config.ptrByteSize + (config.ptrBitSize - 1)) /
+      config.ptrBitSize
+  } else {
+    0
+  };
 
   !numMaskWords =
     numMaskWords * 2 -

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -476,7 +476,6 @@ private fun createGCType(
   (
     userByteSize,
     numMaskWords,
-    tilesPerMask,
     uninternedMetaSize,
     internedMetaSize,
     kind,
@@ -508,7 +507,6 @@ private fun createGCType(
     (
       userSize, // userByteSize
       words, // numMaskWords
-      1, // tilesPerMask
       config.ptrByteSize, // sizeof(RObjMetadata)
       3 * config.ptrByteSize, // sizeof(IObjMetadata)
       0, // kSkipGcKindClass
@@ -538,12 +536,6 @@ private fun createGCType(
         config.ptrBitSize
     };
 
-    tiles = if (words == 0) {
-      1
-    } else {
-      max(1, 64 / (userSize / config.ptrByteSize))
-    };
-
     // Set the GC bits. All pointers are at the beginning of each slot,
     // but we tile it out as many times as will fit in a 64-bit word
     // so the inner loop of the GC can be tighter.
@@ -552,7 +544,6 @@ private fun createGCType(
     (
       userSize, // userByteSize
       words, // numMaskWords
-      tiles, // tilesPerMask
       2 * config.ptrByteSize, // uninternedMetaSize
       3 * config.ptrByteSize, // internedMetaSize
       1, // kSkipGcKindArray
@@ -660,21 +651,14 @@ private fun createGCType(
         }
       }
     | Some(slotInfo) ->
-      // Set the GC bits. All pointers are at the beginning of each slot,
-      // but we tile it out as many times as will fit in a 64-bit word
-      // so the inner loop of the GC can be tighter.
-      for (i in Range(0, tilesPerMask)) {
-        slotInfo.types.eachWithIndex((idx, x) -> {
-          scalarType = x.getScalarType(env);
-          if (scalarType.isGCPointer()) {
-            bitOffset = slotInfo.bitOffsets[idx];
-            setBit(
-              (slotInfo.bitSize * i) + bitOffset,
-              !isAllDeepFrozen && !x.isDeepFrozen(),
-            )
-          }
-        });
-      }
+      // Possible optimization: tile the mask so the inner loop of the GC is tighter.
+      slotInfo.types.eachWithIndex((idx, x) -> {
+        scalarType = x.getScalarType(env);
+        if (scalarType.isGCPointer()) {
+          bitOffset = slotInfo.bitOffsets[idx];
+          setBit(bitOffset, !isAllDeepFrozen && !x.isDeepFrozen())
+        }
+      })
     };
 
     for (f in flags) {

--- a/compiler/src/vtable.sk
+++ b/compiler/src/vtable.sk
@@ -477,7 +477,6 @@ private fun createGCType(
     userByteSize,
     hasGCPointers,
     uninternedMetaSize,
-    internedMetaSize,
     kind,
     isAllDeepFrozen,
   ) = sc.arraySlot match {
@@ -502,7 +501,6 @@ private fun createGCType(
       userSize, // userByteSize
       hasGCPointers,
       config.ptrByteSize, // sizeof(RObjMetadata)
-      3 * config.ptrByteSize, // sizeof(IObjMetadata)
       0, // kSkipGcKindClass
       isAllDeepFrozen, // kSkipGcRefsHintFrozenRefs
     )
@@ -524,7 +522,6 @@ private fun createGCType(
       userSize, // userByteSize
       hasGCPointers,
       2 * config.ptrByteSize, // uninternedMetaSize
-      3 * config.ptrByteSize, // internedMetaSize
       1, // kSkipGcKindArray
       isAllDeepFrozen,
     ) // kSkipGcRefsHintFrozenRefs
@@ -584,10 +581,8 @@ private fun createGCType(
     },
   );
 
-  // m_internedMetadataByteSize
-  pushField(
-    ConstantInt{id => InstrID::none, typ => tInt16, value => internedMetaSize},
-  );
+  // m_unused_internedMetadataByteSize
+  pushField(ConstantInt{id => InstrID::none, typ => tInt16, value => 0});
 
   // m_userByteSize
   pushField(

--- a/prelude/build.mk
+++ b/prelude/build.mk
@@ -90,7 +90,7 @@ endif
 
 $(BUILD_DIR)runtime/runtime64_specific.o: $(COMP_DIR)/runtime/runtime64_specific.cpp
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@)
-	@clang++ $(OLEVEL) -g3 -o $@ -c -I$(COMP_DIR)/runtime/libbacktrace/ $<
+	@clang++ $(CC64FLAGS) -g3 -o $@ -c -I$(COMP_DIR)/runtime/libbacktrace/ $<
 
 $(BUILD_DIR)%.o: $(COMP_DIR)/%.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@)

--- a/prelude/build.mk
+++ b/prelude/build.mk
@@ -21,7 +21,8 @@ OLEVEL=-O2 -g3
 endif # ifdef PROFILE
 
 LBT_EXISTS=$(shell [ -e $(LIB_DIR)/libbacktrace.a ] && echo 1 || echo 0 )
-CC64FLAGS=$(OLEVEL) -DSKIP64
+COMMONFLAGS=$(OLEVEL) -Werror -Wall -Wextra -Wno-sign-conversion -Wno-sometimes-uninitialized -Wno-c2x-extensions -Wsign-compare -Wextra-semi-stmt
+CC64FLAGS=-DSKIP64 $(COMMONFLAGS)
 
 # NB: this MUST be kept in sync with CFILES in compiler/runtime/Makefile
 # and CRELFILES in prelude/build_wasm32.mk

--- a/prelude/build_wasm32.mk
+++ b/prelude/build_wasm32.mk
@@ -18,7 +18,8 @@ DEFINITIONS=
 OLEVEL=-O2 -g3
 endif # ifdef PROFILE
 
-CC32FLAGS=$(OLEVEL) -DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc
+COMMONFLAGS=$(OLEVEL) -Werror -Wall -Wextra -Wno-sign-conversion -Wno-sometimes-uninitialized -Wno-c2x-extensions -Wsign-compare -Wextra-semi-stmt
+CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
 
 # NB: this MUST be kept in sync with CFILES in compiler/runtime/Makefile
 # and CRELFILES in prelude/build.mk

--- a/prelude/build_wasm32.mk
+++ b/prelude/build_wasm32.mk
@@ -18,7 +18,7 @@ DEFINITIONS=
 OLEVEL=-O2 -g3
 endif # ifdef PROFILE
 
-CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc
+CC32FLAGS=$(OLEVEL) -DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc
 
 # NB: this MUST be kept in sync with CFILES in compiler/runtime/Makefile
 # and CRELFILES in prelude/build.mk
@@ -60,7 +60,7 @@ $(BUILD_DIR)magic.c:
 
 $(BUILD_DIR)magic.bc: $(BUILD_DIR)magic.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@)
-	@clang $(OLEVEL) $(CC32FLAGS) -o $@ -c $<
+	@clang $(CC32FLAGS) -o $@ -c $<
 
 $(BUILD_DIR)libskip_runtime32.bc: $(BCFILES32)
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@)
@@ -68,5 +68,5 @@ $(BUILD_DIR)libskip_runtime32.bc: $(BCFILES32)
 
 $(BUILD_DIR)%.bc: $(COMP_DIR)/%.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@)
-	@clang $(OLEVEL) $(CC32FLAGS) -o $@ -c $<
+	@clang $(CC32FLAGS) -o $@ -c $<
 


### PR DESCRIPTION
Here are a few cleanups pertaining to `SKIP_gc_type_t`, its creation and its usage.

Follows simplifications and code sharing between the only two kinds of non-string skip objects: class instances and arrays.

Test with `STAGE=C make clean && make -C compiler clean test && make test`