### PR TITLE
[runtime] -Werror

### DIFF
--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -1,6 +1,6 @@
 MEMSIZE32=1073741824
 
-COMMONFLAGS=-Wall -Wextra -Wno-sign-conversion -Wno-sometimes-uninitialized -Wno-c2x-extensions -Wsign-compare -Wextra-semi-stmt
+COMMONFLAGS=-Werror -Wall -Wextra -Wno-sign-conversion -Wno-sometimes-uninitialized -Wno-c2x-extensions -Wsign-compare -Wextra-semi-stmt
 # To add: -Wcast-align -Wcast-qual -Wimplicit-int-conversion -Wmissing-noreturn -Wpadded -Wreserved-identifier -Wshorten-64-to-32 -Wtautological-unsigned-zero-compare
 # -Watomic-implicit-seq-cst ?
 # If using -Weverything, you may want to add -Wno-declaration-after-statement -Wno-missing-prototypes -Wno-missing-variable-declarations -Wno-shadow -Wno-strict-prototypes -Wno-zero-length-array -Wno-unreachable-code-break -Wno-unreachable-code-return

--- a/compiler/runtime/Makefile
+++ b/compiler/runtime/Makefile
@@ -7,6 +7,7 @@ COMMONFLAGS=-Wall -Wextra -Wno-sign-conversion -Wno-sometimes-uninitialized -Wno
 OLEVEL=-O2
 CC32FLAGS=-DSKIP32 --target=wasm32 -emit-llvm -nostdlibinc $(COMMONFLAGS)
 CC64FLAGS=$(OLEVEL) -DSKIP64 $(COMMONFLAGS)
+CXX64FLAGS=$(OLEVEL) $(COMMONFLAGS)
 
 # NB: this MUST be kept in sync with CRELFILES in prelude/build.mk
 # and CRELFILES in prelude/build_wasm32.mk
@@ -61,7 +62,7 @@ libbacktrace: .libs/libbacktrace.a
 	$(MAKE) -C libbacktrace
 
 runtime64_specific.o: runtime64_specific.cpp .libs/libbacktrace.a
-	clang++ -std=c++11 $(OLEVEL) -g3 -o $@ -c -Ilibbacktrace/ $<
+	clang++ -std=c++11 $(CXX64FLAGS) -g3 -o $@ -c -Ilibbacktrace/ $<
 
 %.o: %.c
 	clang $(CC64FLAGS) -g3 -o $@ -c $<

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -430,6 +430,7 @@ int64_t SKIP_notify(char* filename_obj, uint64_t tick) {
   while (size > 0) {
     ssize_t written = write(fd, buf, size);
     if (written == -1) {
+      close(fd);
       return -1;
     }
     buf += written;

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -363,22 +363,19 @@ char* SKIP_open_file(char* filename_obj) {
   size_t size = s.st_size;
 
   char* result = sk_string_alloc(size);
-  if (size == 0) {
-    sk_string_set_hash(result);
-    return result;
+  if (size != 0) {
+    void* f = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (f == MAP_FAILED) {
+      perror("ERROR (MAP FAILED)");
+      fprintf(stderr, "Could not open file: %s\n", filename);
+      exit(ERROR_FILE_IO);
+    }
+    memcpy(result, f, size);
+    munmap(f, size);
   }
-
-  void* f = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
-  if (f == MAP_FAILED) {
-    perror("ERROR (MAP FAILED)");
-    fprintf(stderr, "Could not open file: %s\n", filename);
-    exit(ERROR_FILE_IO);
-  }
-  memcpy(result, f, size);
   sk_string_set_hash(result);
   if (filename != filename_obj) free(filename);
   close(fd);
-  munmap(f, size);
   return result;
 }
 

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -369,8 +369,8 @@ char* SKIP_open_file(char* filename_obj) {
     return result;
   }
 
-  char* f = (char*)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
-  if (f == (void*)MAP_FAILED) {
+  void* f = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+  if (f == MAP_FAILED) {
     perror("ERROR (MAP FAILED)");
     fprintf(stderr, "Could not open file: %s\n", filename);
     exit(ERROR_FILE_IO);

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -428,7 +428,7 @@ int64_t SKIP_notify(char* filename_obj, uint64_t tick) {
   size_t size = strlen(buf);
 
   while (size > 0) {
-    size_t written = write(fd, buf, size);
+    ssize_t written = write(fd, buf, size);
     if (written == -1) {
       return -1;
     }

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -59,7 +59,7 @@ struct backtrace_data {
   bool before_throw;
 };
 
-static int print_callback(void* data, uintptr_t pc, const char* filename,
+static int print_callback(void* data, uintptr_t /* pc */, const char* filename,
                           int lineno, const char* function) {
   auto ctx = static_cast<backtrace_data*>(data);
 

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -349,7 +349,17 @@ char* SKIP_open_file(char* filename_obj) {
   char* filename = sk2c_string(filename_obj);
 
   int fd = open(filename, O_RDONLY);
+  if (fd == -1) {
+    perror("ERROR (open failed)");
+    fprintf(stderr, "Could not open file: %s\n", filename);
+    exit(ERROR_FILE_IO);
+  }
   int status = fstat(fd, &s);
+  if (status == -1) {
+    perror("ERROR (fstat failed)");
+    fprintf(stderr, "Could not open file: %s\n", filename);
+    exit(ERROR_FILE_IO);
+  }
   size_t size = s.st_size;
 
   char* result = nullptr;
@@ -361,7 +371,7 @@ char* SKIP_open_file(char* filename_obj) {
 
   char* f = (char*)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
   if (f == (void*)MAP_FAILED) {
-    perror("ERROR (MMap FAILED)");
+    perror("ERROR (MAP FAILED)");
     fprintf(stderr, "Could not open file: %s\n", filename);
     exit(ERROR_FILE_IO);
   }

--- a/compiler/runtime/runtime64_specific.cpp
+++ b/compiler/runtime/runtime64_specific.cpp
@@ -362,9 +362,8 @@ char* SKIP_open_file(char* filename_obj) {
   }
   size_t size = s.st_size;
 
-  char* result = nullptr;
+  char* result = sk_string_alloc(size);
   if (size == 0) {
-    result = sk_string_alloc(0);
     sk_string_set_hash(result);
     return result;
   }
@@ -375,12 +374,11 @@ char* SKIP_open_file(char* filename_obj) {
     fprintf(stderr, "Could not open file: %s\n", filename);
     exit(ERROR_FILE_IO);
   }
-  result = sk_string_alloc(size);
   memcpy(result, f, size);
   sk_string_set_hash(result);
   if (filename != filename_obj) free(filename);
-  munmap(f, size);
   close(fd);
+  munmap(f, size);
   return result;
 }
 


### PR DESCRIPTION
Follow-up of #138:
- adds warnings to `runtime64_specific.cpp` that I forgot in #138 
- minor fixes in `SKIP_open_file` and `SKIP_notify`
- `-Werror`