### PR TITLE
[sql] Implement create-table-as-select and add parser/AST support for alter-table

### DIFF
--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -476,38 +476,26 @@ class Evaluator{options: Options, user: ?UserFile} {
         this.createTable(context, pos, name, dirDescr, ifNotExists);
       })
     | P.CreateTableAs{pos, name, select, ifNotExists} ->
-      core: P.SelectCoreQuery = select.core match {
-      | P.SelectCoreValues _ ->
-        error(
-          pos,
-          "CREATE TABLE AS requires a SELECT query, not a VALUES literal",
-        )
-      | core @ P.SelectCoreQuery _ -> core
+      compiler = SKDB.Compiler::create(false, this.options, select.pos, params);
+      selectAst = select with {
+        core => select.core match {
+        | vals @ P.SelectCoreValues _ -> compiler.expandValuesClause(vals)
+        | qry @ P.SelectCoreQuery _ -> qry
+        },
       };
 
-      compiler = SKDB.Compiler::create(false, this.options, select.pos, params);
       cselect = compiler.compileSelect(
         context,
-        select,
-        genSelectId(select),
+        selectAst,
+        genSelectId(selectAst),
         true,
       );
 
-      (_, cols) = SKDB.Compiler::getCols(core.params, cselect.from);
-
-      schema = cselect.params.mapWithIndex((idx, param) -> {
-        P.ColumnDefinition{
-          name => cols.maybeGet(idx) match {
-          | None() ->
-            error(
-              pos,
-              "Anonymous columns not allowed in CREATE TABLE AS SELECT",
-            )
-          | Some(x) -> x
-          },
-          ty => param.getType(),
-        }
-      });
+      schema = SKDB.Compiler::getSchema(
+        (selectAst.core as P.SelectCoreQuery _).params,
+        cselect.from,
+        cselect.params,
+      );
 
       dirDescr = computeTableDescr(name, schema);
       dirName = dirDescr.dirName;

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -475,8 +475,52 @@ class Evaluator{options: Options, user: ?UserFile} {
         dirDescr = computeTableDescr(name, schema.columns);
         this.createTable(context, pos, name, dirDescr, ifNotExists);
       })
-    | P.CreateTableAs _ ->
-      invariant_violation("CREATE TABLE AS SELECT not implemented")
+    | P.CreateTableAs{pos, name, select, ifNotExists} ->
+      core: P.SelectCoreQuery = select.core match {
+      | P.SelectCoreValues _ ->
+        error(
+          pos,
+          "CREATE TABLE AS requires a SELECT query, not a VALUES literal",
+        )
+      | core @ P.SelectCoreQuery _ -> core
+      };
+
+      compiler = SKDB.Compiler::create(false, this.options, select.pos, params);
+      cselect = compiler.compileSelect(
+        context,
+        select,
+        genSelectId(select),
+        true,
+      );
+      schema = SKDB.Compiler::getSchema(
+        core.params,
+        cselect.from,
+        cselect.params,
+      );
+
+      dirDescr = computeTableDescr(name, schema);
+      dirName = dirDescr.dirName;
+
+      Some((context, _, _) ~> {
+        if (context.unsafeMaybeGetEagerDir(dirName) is Some _ && ifNotExists) {
+          currentSchema = getTable(context, pos, name).schema;
+          if (currentSchema != dirDescr.schema) {
+            error(pos, "table exists with a different schema")
+          };
+          return void;
+        };
+
+        this.createTable(context, pos, name, dirDescr, false);
+        tableDir = context.unsafeGetEagerDir(dirName);
+
+        selectDir = evalSelect(context, cselect, None());
+        content = context
+          .unsafeGetEagerDir(selectDir.dirName)
+          .getIterator(context)
+          .map(kv -> (kv.i0, kv.i1.collect(Array)));
+
+        tableDir.writeArrayMany(context, content);
+      })
     | P.Insert{pos, onConflict, name, alias, paramsOpt, values} ->
       if (alias is Some _) {
         error(pos, "INSERT INTO table AS not implemented")

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -476,26 +476,38 @@ class Evaluator{options: Options, user: ?UserFile} {
         this.createTable(context, pos, name, dirDescr, ifNotExists);
       })
     | P.CreateTableAs{pos, name, select, ifNotExists} ->
-      compiler = SKDB.Compiler::create(false, this.options, select.pos, params);
-      selectAst = select with {
-        core => select.core match {
-        | vals @ P.SelectCoreValues _ -> compiler.expandValuesClause(vals)
-        | qry @ P.SelectCoreQuery _ -> qry
-        },
+      core: P.SelectCoreQuery = select.core match {
+      | P.SelectCoreValues _ ->
+        error(
+          pos,
+          "CREATE TABLE AS requires a SELECT query, not a VALUES literal",
+        )
+      | core @ P.SelectCoreQuery _ -> core
       };
 
+      compiler = SKDB.Compiler::create(false, this.options, select.pos, params);
       cselect = compiler.compileSelect(
         context,
-        selectAst,
-        genSelectId(selectAst),
+        select,
+        genSelectId(select),
         true,
       );
 
-      schema = SKDB.Compiler::getSchema(
-        (selectAst.core as P.SelectCoreQuery _).params,
-        cselect.from,
-        cselect.params,
-      );
+      (_, cols) = SKDB.Compiler::getCols(core.params, cselect.from);
+
+      schema = cselect.params.mapWithIndex((idx, param) -> {
+        P.ColumnDefinition{
+          name => cols.maybeGet(idx) match {
+          | None() ->
+            error(
+              pos,
+              "Anonymous columns not allowed in CREATE TABLE AS SELECT",
+            )
+          | Some(x) -> x
+          },
+          ty => param.getType(),
+        }
+      });
 
       dirDescr = computeTableDescr(name, schema);
       dirName = dirDescr.dirName;

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -492,11 +492,22 @@ class Evaluator{options: Options, user: ?UserFile} {
         genSelectId(select),
         true,
       );
-      schema = SKDB.Compiler::getSchema(
-        core.params,
-        cselect.from,
-        cselect.params,
-      );
+
+      (_, cols) = SKDB.Compiler::getCols(core.params, cselect.from);
+
+      schema = cselect.params.mapWithIndex((idx, param) -> {
+        P.ColumnDefinition{
+          name => cols.maybeGet(idx) match {
+          | None() ->
+            error(
+              pos,
+              "Anonymous columns not allowed in CREATE TABLE AS SELECT",
+            )
+          | Some(x) -> x
+          },
+          ty => param.getType(),
+        }
+      });
 
       dirDescr = computeTableDescr(name, schema);
       dirName = dirDescr.dirName;

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -1141,6 +1141,9 @@ class Evaluator{options: Options, user: ?UserFile} {
         },
       );
       None()
+    | P.AlterTableAddCol _
+    | P.AlterTableDropCol _ ->
+      invariant_violation("ALTER TABLE not yet implemented")
     };
   }
 
@@ -2081,7 +2084,8 @@ fun markIfRead(context: mutable SKStore.Context, stmt: P.Stmt): void {
   | P.DropView _
   | P.DropIndex _
   | P.Delete _
-  | P.Insert _ ->
+  | P.Insert _
+  | P.AlterTable _ ->
     void
   }
 }

--- a/sql/src/SqlSelect.sk
+++ b/sql/src/SqlSelect.sk
@@ -189,8 +189,7 @@ fun evalSelect(
   select: CSelect,
   up: ?ExprEvaluator,
 ): SelectDir {
-  result = makeSelectEvaluator(context, select, up).evalSelect(context);
-  result
+  makeSelectEvaluator(context, select, up).evalSelect(context)
 }
 
 fun makeSelectEvaluator(

--- a/sql/test/unit/test_create_table_as_select.sql
+++ b/sql/test/unit/test_create_table_as_select.sql
@@ -1,0 +1,8 @@
+create table t (x int, y int);
+
+insert into t values (1, 2), (3, 4);
+
+create table v as select x, x as x1, y, y as y1, 'read-only' as skdb_access from t where x=1;
+
+select x, x1, y, y1, skdb_access from v;
+

--- a/sql/unit_tests.sh
+++ b/sql/unit_tests.sh
@@ -299,3 +299,9 @@ then
 else
     fail "DATETIME"
 fi
+
+if cat test/unit/test_create_table_as_select.sql | $SKDB | grep -q '1|1|2|2|read-only' ; then
+    pass "CREATE TABLE AS SELECT"
+else
+    fail "CREATE TABLE AS SELECT"
+fi

--- a/sqlparser/src/Alter.sk
+++ b/sqlparser/src/Alter.sk
@@ -1,0 +1,26 @@
+module SQLParser;
+
+extension class Parser {
+  mutable fun parseAlter(): Stmt {
+    this.expect_keyword(TAlter());
+    this.expect_keyword(TTable());
+
+    name = Name::create(this.expect_identifier());
+
+    if (this.parse_keyword(TAdd())) {
+      _ = this.parse_keyword(TColumn());
+      colDef = this.parseColumnDefinition();
+      AlterTableAddCol{name, colDef}
+    } else if (this.parse_keyword(TDrop())) {
+      _ = this.parse_keyword(TColumn());
+      col = Name::create(this.expect_identifier());
+      AlterTableDropCol{name, col}
+    } else {
+      this.errorUnexpectedToken(
+        "Only add-column and drop-column ALTER statements are currently supported",
+      )
+    }
+  }
+}
+
+module end;

--- a/sqlparser/src/Ast.sk
+++ b/sqlparser/src/Ast.sk
@@ -74,6 +74,12 @@ base class ViewDefinition uses Equality, Show {
 
 class UpdateSet(columns: Array<(Int, Name)>, value: Expr) uses Equality, Show
 
+base class AlterTable{name: Name} extends Stmt {
+  children =
+  | AlterTableAddCol{colDef: ColumnDefinition}
+  | AlterTableDropCol{col: Name}
+}
+
 base class CreateTable{ifNotExists: Bool, name: Name} extends Stmt {
   children =
   | CreateTableSchema{schema: TableSchema}

--- a/sqlparser/src/AstPp.sk
+++ b/sqlparser/src/AstPp.sk
@@ -111,6 +111,10 @@ extension base class Stmt {
       " (" +
       schema.columns.map(c -> c.toString()).join(", ") +
       ")"
+  | AlterTableAddCol{name, colDef} ->
+    "ALTER TABLE " + name.toString() + " ADD COLUMN " + colDef.toString()
+  | AlterTableDropCol{name, col} ->
+    "ALTER TABLE " + name.toString() + " DROP COLUMN " + col.toString()
 }
 
 extension class ColumnDefinition {
@@ -254,8 +258,8 @@ extension class IndexedColumn {
         ""
       }) +
       this.order match {
-        | INONE() -> ""
-        | ord @ _ -> " " + ord.toString()
+      | INONE() -> ""
+      | ord @ _ -> " " + ord.toString()
       }
   }
 }

--- a/sqlparser/src/Create.sk
+++ b/sqlparser/src/Create.sk
@@ -127,7 +127,8 @@ extension class Parser {
     name = Name::create(this.expect_identifier());
 
     if (this.parse_keyword(TAs())) {
-      this.errorNotImplemented()
+      select = this.parseSelect();
+      CreateTableAs{name, select, ifNotExists}
     } else {
       schema = this.parseCreateTableSchema();
       CreateTableSchema{name, schema, ifNotExists}

--- a/sqlparser/src/Parser.sk
+++ b/sqlparser/src/Parser.sk
@@ -48,7 +48,8 @@ mutable class Parser(tokens: mutable Tokenizer) {
     | TCommit() -> this.parseEndTransaction()
     | TEnd() -> this.parseEndTransaction()
     | TExplain()
-    | TAlter()
+    | TAlter() ->
+      this.parseAlter()
     | TAnalyze()
     | TAttach()
     | TRollback()


### PR DESCRIPTION
This is in preparation for some larger schema migration changes, but mostly stands on its own, adding a full implementation for create-table-as-select SQL statements and syntactic support for alter-table statements.