### PR TITLE
[cli] Fix parsing of boolean options starting with `--no-`.

### DIFF
--- a/cli/src/parser.sk
+++ b/cli/src/parser.sk
@@ -199,6 +199,12 @@ private fun parse(
 
       // Use arg name as default long flag for convenience.
       longFlag = arg._long.default(arg.name);
+      if (arg is BoolArg _ && longFlag.startsWith("no-")) {
+        positiveFlag = longFlag.stripPrefix("no-");
+        invariant_violation(
+          `Invalid boolean argument name ${longFlag}. Declare a negatable ${positiveFlag} instead.`,
+        )
+      };
       options.add(`--${longFlag}`, arg);
       if (arg._negatable) {
         options.add(`--no-${longFlag}`, arg);

--- a/cli/tests/tests.sk
+++ b/cli/tests/tests.sk
@@ -142,6 +142,13 @@ fun boolArgsNegatable(): void {
 }
 
 @test
+fun boolNegativeArgsRejected(): void {
+  cmd = Cli.Command("foo").arg(Cli.BoolArg("no-bar"));
+
+  T.expectThrow(() -> _ = Cli.parseArgsFrom(cmd, Array["--no-foo"]));
+}
+
+@test
 fun subcommand(): void {
   cmd = Cli.Command("foo")
     .subcommand(Cli.Command("bar"))


### PR DESCRIPTION
Before this change, it was not possible to declare a boolean option whose name started with `--no-` (unless it was generated as the negation of an other option).