### PR TITLE
[sql] Evaluate rather than (fail to) compile arg-less VId and VSeqNum

### DIFF
--- a/sql/src/SqlCAst.sk
+++ b/sql/src/SqlCAst.sk
@@ -469,6 +469,9 @@ class CStrftime(
 
 class COn(P.JoinKind, CExpr<Int>) extends CExpr<Int>
 
+class CISeqNum(Bool) extends CExpr<Int>
+class CSId() extends CExpr<String>
+
 /*****************************************************************************/
 /* JSON primitives */
 /*****************************************************************************/

--- a/sql/src/SqlCompile.sk
+++ b/sql/src/SqlCompile.sk
@@ -995,8 +995,7 @@ mutable class Compiler{
         error(this.pos, "Unknown local_sequence_number name " + varName)
       };
       CIExpr(CILiteral(globals[varName]))
-    | P.VSeqNum(_, None()) ->
-      error(this.pos, "local_sequence_number expects a string literal")
+    | P.VSeqNum(isPositive, None()) -> CIExpr(CISeqNum(isPositive))
     | P.VId(Some(varName)) ->
       namedIDs = context.getGlobal(NAMEDIDS) match {
       | None() -> error(this.pos, "Unknown id " + varName)
@@ -1006,7 +1005,7 @@ mutable class Compiler{
         error(this.pos, "Unknown id " + varName)
       };
       CSExpr(CSLiteral(namedIDs[varName]))
-    | P.VId(None()) -> error(this.pos, "id expects a string literal")
+    | P.VId(None()) -> CSExpr(CSId())
     | P.VPermission(arg) ->
       this.compileExpr(context, arg) match {
       | CSExpr(CSLiteral(str)) ->

--- a/sql/src/SqlExpr.sk
+++ b/sql/src/SqlExpr.sk
@@ -291,6 +291,8 @@ class ExprEvaluator(
           "ok"
         })
       })
+
+    | CSId() -> ADef(Ksuid::create().toString())
     }
   }
 
@@ -949,6 +951,13 @@ class ExprEvaluator(
       | AUndef() -> AUndef()
       | ANull() -> ANull()
       | ADef(s) -> ADef(s.length())
+      }
+
+    | CISeqNum(isPositive) ->
+      if (isPositive) {
+        ADef(SKStore.genSym(0))
+      } else {
+        ADef(-SKStore.genSym(0))
       }
     }
   }

--- a/sql/test/unit/insert_select_id.sql
+++ b/sql/test/unit/insert_select_id.sql
@@ -1,0 +1,8 @@
+CREATE TABLE t1(i INTEGER, t TEXT, v INTEGER);
+
+INSERT INTO t1 VALUES (local_sequence_number(), id(), 1);
+INSERT INTO t1 VALUES (local_sequence_number(), id(), 2);
+INSERT INTO t1 VALUES (local_sequence_number(), id(), 3);
+INSERT INTO t1 SELECT local_sequence_number(), id(), v FROM t1;
+SELECT i FROM t1;
+SELECT t FROM t1;

--- a/sql/unit_tests.sh
+++ b/sql/unit_tests.sh
@@ -168,6 +168,12 @@ else
     fail "INSERT ID"
 fi
 
+if cat test/unit/insert_select_id.sql | $SKDB | sort -u | wc -l | grep -q "12"; then
+    pass "INSERT SELECT ID"
+else
+    fail "INSERT SELECT ID"
+fi
+
 
 if cat test/test_string_escaping_json.sql | $SKDB --format=json | grep -q '{"a":"\\"Hello world\\""}'; then
     pass "STRING ESCAPING JSON"


### PR DESCRIPTION
This results in them being evaluated once per row rather than being
compiled once per query. As a result queries such as
```
SELECT local_sequence_number(), id(), v FROM t1;
```
will yield distinct values for each row of t1.

closes #164