### PR TITLE
Configure and run ktfmt over kotlin sources

### DIFF
--- a/sql/server/build.gradle.kts
+++ b/sql/server/build.gradle.kts
@@ -1,8 +1,3 @@
 plugins {
   id("org.jetbrains.kotlin.jvm") version "1.9.0"
-  id("com.diffplug.spotless") version "6.12.1"
 }
-
-repositories { mavenCentral() }
-
-spotless { kotlin { ktfmt("0.47") } }

--- a/sql/server/build.gradle.kts
+++ b/sql/server/build.gradle.kts
@@ -1,3 +1,8 @@
 plugins {
   id("org.jetbrains.kotlin.jvm") version "1.9.0"
+  id("com.diffplug.spotless") version "6.12.1"
 }
+
+repositories { mavenCentral() }
+
+spotless { kotlin { ktfmt("0.47") } }

--- a/sql/server/core/build.gradle.kts
+++ b/sql/server/core/build.gradle.kts
@@ -8,6 +8,7 @@
 
 plugins {
   id("org.jetbrains.kotlin.jvm")
+  id("com.diffplug.spotless") version "6.12.1"
 
   `java-library`
 }
@@ -32,3 +33,5 @@ tasks.named<Test>("test") {
   // Use JUnit Platform for unit tests.
   useJUnitPlatform()
 }
+
+spotless { kotlin { ktfmt("0.47") } }

--- a/sql/server/core/src/main/kotlin/core/Mux.kt
+++ b/sql/server/core/src/main/kotlin/core/Mux.kt
@@ -47,11 +47,14 @@ data class Credentials(
     val deviceUuid: String? = null,
 ) {
   fun b64privateKey(): String = Base64.getEncoder().encodeToString(privateKey)
+
   fun b64encryptedKey(): String = Base64.getEncoder().encodeToString(encryptedPrivateKey)
+
   fun clear(): Unit {
     privateKey.fill(0)
     encryptedPrivateKey.fill(0)
   }
+
   override fun toString(): String {
     return "Credentials(accessKey=${accessKey}, privateKey=**redacted**, deviceId=${deviceUuid})"
   }
@@ -231,9 +234,13 @@ data class MuxStreamResetMsg(val stream: UInt, val errorCode: UInt, val msg: Str
 
 interface WebSocket {
   fun close()
+
   fun sendData(data: ByteBuffer)
+
   fun sendClose(code: Int, reason: String)
+
   fun suspendReceives()
+
   fun resumeReceives()
 }
 
@@ -318,6 +325,7 @@ class MuxedSocket(
         } finally {
           mutex.readLock().unlock()
         }
+
   private var state: State = State.IDLE
   private var nextStream: UInt = if (isClient) 1u else 2u
   private var otherStreamWatermark: UInt = 0u
@@ -325,6 +333,7 @@ class MuxedSocket(
   private var observers: MutableList<(State) -> Unit> = ArrayList()
 
   data class MuxedSocketEnd(val error: Boolean, val code: UInt?, val msg: String?)
+
   var endState: MuxedSocketEnd? = null
     get() =
         try {
@@ -336,6 +345,7 @@ class MuxedSocket(
 
   private val maxConnectionDuration: Duration = Duration.ofMinutes(10)
   private var timeout: ScheduledFuture<*>? = null
+
   init {
     scheduleSessionTimeout()
   }
@@ -1091,6 +1101,7 @@ class Stream(
   private var observers: Queue<(State) -> Unit> = ConcurrentLinkedQueue()
 
   data class StreamEnd(val error: Boolean, val code: UInt?, val msg: String?)
+
   var endState: AtomicReference<StreamEnd> = AtomicReference(null)
     get() = field
 

--- a/sql/server/core/src/main/kotlin/core/Orchestration.kt
+++ b/sql/server/core/src/main/kotlin/core/Orchestration.kt
@@ -148,7 +148,7 @@ fun decodeProtoMsg(data: ByteBuffer): ProtoMessage {
       val requests = ArrayList<ProtoRequestTail>()
       data.position(data.position() + 1) // skip over reserved
       val n = data.getShort()
-      for (i in 0..<n) {
+      for (i in 0 ..< n) {
         val req = decodeProtoMsg(data)
         if (req is ProtoRequestTail) {
           requests.add(req)
@@ -297,7 +297,9 @@ fun encodeProtoMsg(msg: ProtoMessage): ByteBuffer {
 // adapts the stream interface for this layer in the protocol stack
 interface OrchestrationStream {
   val stream: Stream
+
   fun close()
+
   fun error(errorCode: UInt, msg: String)
   // raises the abstraction of this to messages rather than bytes
   fun send(msg: ProtoMessage)

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -194,7 +194,6 @@ class Skdb(val name: String, private val dbPath: String) {
             user,
             "--read-spec")
 
-
     // TODO: for hacky debug
     tailPb.redirectError(ProcessBuilder.Redirect.INHERIT)
     val proc = tailPb.start()

--- a/sql/server/dev/build.gradle.kts
+++ b/sql/server/dev/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("org.jetbrains.kotlin.jvm")
-
+  id("com.diffplug.spotless") version "6.12.1"
   application
   java
 }
@@ -50,3 +50,5 @@ tasks.jar {
     from(dependencies)
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
+
+spotless { kotlin { ktfmt("0.47") } }

--- a/sql/server/dev/src/main/kotlin/Service.kt
+++ b/sql/server/dev/src/main/kotlin/Service.kt
@@ -89,6 +89,7 @@ fun createDb(dbName: String): Credentials {
 sealed interface StreamHandler {
 
   fun handleMessage(request: ProtoMessage, stream: Stream): StreamHandler
+
   fun handleMessage(message: ByteBuffer, stream: Stream) =
       handleMessage(decodeProtoMsg(message), stream)
 
@@ -196,8 +197,7 @@ class RequestHandler(
                 replicationId,
                 mapOf(
                     request.table to
-                        TailSpec(
-                            request.since.toInt(), request.filterExpr, request.filterParams)),
+                        TailSpec(request.since.toInt(), request.filterExpr, request.filterParams)),
                 { data, shouldFlush -> stream.send(encodeProtoMsg(ProtoData(data, shouldFlush))) },
                 { stream.error(2000u, "Unexpected EOF") },
             )


### PR DESCRIPTION
This adds gradle targets to autoformat kotlin sources under `./sql/server` using `ktfmt` and `spotless`.

I also formatted everything with
```
(cd ./sql/server &&  ./gradlew :spotlessApply :core:spotlessApply :dev:spotlessApply)
```

There's some minor churn as we last ran ktfmt on 0.42 and I used the latest 0.47 here.

@gregsexton, I'm not sure what (if anything) you're using for autoformatting. I'm not picky about what we use as long as it's something -- happy to drop this PR if you've got some other conflicting setup in place that you would rather point me to :)
