### PR TITLE
[cli] Add option to avoid failing on invalid arg.

### DIFF
--- a/cli/src/parser.sk
+++ b/cli/src/parser.sk
@@ -37,58 +37,96 @@ class ParseResults{
   subcommand: ?String = None(),
   error: ?ArgumentError = None(),
 } {
-  fun getBool(name: String): Bool {
-    this.values[name] match {
-    | BoolValue(v) -> v
+  fun maybeGetBool(name: String, fail_on_undefined_arg: Bool = true): ?Bool {
+    this.getValue(name, fail_on_undefined_arg) match {
+    | BoolValue(v) -> Some(v)
+    | MissingValue() -> None()
     | _ -> invariant_violation(`Argument ${name} is not boolean`)
     }
   }
-
-  fun maybeGetString(name: String): ?String {
-    this.values.maybeGet(name) match {
-    | Some(StringValue(v)) -> Some(v)
-    | Some(MissingValue()) -> None()
-    | Some(_) -> invariant_violation(`Argument ${name} is not a string`)
-    | None() -> invariant_violation(`Argument ${name} is undefined`)
+  fun getBool(name: String, default: ?Bool = None()): Bool {
+    this.maybeGetBool(name, default.isNone()) match {
+    | Some(v) -> v
+    | None() ->
+      default match {
+      | Some(v) -> v
+      | None() -> invariant_violation(`Argument ${name} is missing`)
+      }
     }
   }
 
-  fun getString(name: String): String {
-    this.maybeGetString(name) match {
+  fun maybeGetString(
+    name: String,
+    fail_on_undefined_arg: Bool = true,
+  ): ?String {
+    this.getValue(name, fail_on_undefined_arg) match {
+    | StringValue(v) -> Some(v)
+    | MissingValue() -> None()
+    | _ -> invariant_violation(`Argument ${name} is not a string`)
+    }
+  }
+
+  fun getString(name: String, default: ?String = None()): String {
+    this.maybeGetString(name, default.isNone()) match {
     | Some(s) -> s
-    | None() -> invariant_violation(`Argument ${name} is missing`)
+    | None() ->
+      default match {
+      | Some(s) -> s
+      | None() -> invariant_violation(`Argument ${name} is missing`)
+      }
     }
   }
 
-  fun maybeGetInt(name: String): ?Int {
-    this.values.maybeGet(name) match {
-    | Some(IntValue(v)) -> Some(v)
-    | Some(MissingValue()) -> None()
-    | Some(_) -> invariant_violation(`Argument ${name} is not an int`)
-    | None() -> invariant_violation(`Argument ${name} is undefined`)
+  fun maybeGetInt(name: String, fail_on_undefined_arg: Bool = true): ?Int {
+    this.getValue(name, fail_on_undefined_arg) match {
+    | IntValue(v) -> Some(v)
+    | MissingValue() -> None()
+    | _ -> invariant_violation(`Argument ${name} is not an int`)
     }
   }
 
-  fun getInt(name: String): Int {
-    this.maybeGetInt(name) match {
-    | Some(s) -> s
-    | None() -> invariant_violation(`Argument ${name} is missing`)
+  fun getInt(name: String, default: ?Int = None()): Int {
+    this.maybeGetInt(name, default.isNone()) match {
+    | Some(v) -> v
+    | None() ->
+      default match {
+      | Some(v) -> v
+      | None() -> invariant_violation(`Argument ${name} is missing`)
+      }
     }
   }
 
-  fun maybeGetArray(name: String): ?Array<String> {
-    this.values.maybeGet(name) match {
-    | Some(ArrayValue(v)) -> Some(v)
-    | Some(MissingValue()) -> None()
-    | Some(_) -> invariant_violation(`Argument ${name} is not an array`)
-    | None() -> invariant_violation(`Argument ${name} is undefined`)
+  fun maybeGetArray(
+    name: String,
+    fail_on_undefined_arg: Bool = true,
+  ): ?Array<String> {
+    this.getValue(name, fail_on_undefined_arg) match {
+    | ArrayValue(v) -> Some(v)
+    | MissingValue() -> None()
+    | _ -> invariant_violation(`Argument ${name} is not an array`)
     }
   }
 
-  fun getArray(name: String): Array<String> {
-    this.maybeGetArray(name) match {
+  fun getArray(name: String, default: ?Array<String> = None()): Array<String> {
+    this.maybeGetArray(name, default.isNone()) match {
     | Some(a) -> a
-    | None() -> invariant_violation(`Argument ${name} is missing`)
+    | None() ->
+      default match {
+      | Some(a) -> a
+      | None() -> invariant_violation(`Argument ${name} is missing`)
+      }
+    }
+  }
+
+  private fun getValue(
+    name: String,
+    fail_on_undefined_arg: Bool = true,
+  ): Value {
+    this.values.maybeGet(name) match {
+    | Some(v) -> v
+    | None() if (fail_on_undefined_arg) ->
+      invariant_violation(`Argument ${name} is undefined`)
+    | None() -> MissingValue()
     }
   }
 

--- a/cli/tests/tests.sk
+++ b/cli/tests/tests.sk
@@ -323,4 +323,87 @@ fun intArgsFromEnv(): void {
   T.expectEq(args.getInt("baz"), 42);
 }
 
+@test
+fun undefinedArgs(): void {
+  cmd = Cli.Command("foo")
+    .arg(Cli.BoolArg("bar").negatable())
+    .arg(Cli.StringArg("baz"))
+    .arg(Cli.IntArg("foobar"))
+    .arg(Cli.ArrayArg("foobar2"));
+  args = Cli.parseArgsFrom(
+    cmd,
+    Array[
+      "--no-bar",
+      "--baz",
+      "baz1",
+      "--foobar=1",
+      "--foobar2=abc",
+      "--foobar2",
+      "def",
+    ],
+  );
+
+  // Default is to throw.
+  T.expectThrow(() -> _ = args.maybeGetBool("unknown"));
+  T.expectThrow(() -> _ = args.maybeGetString("unknown"));
+  T.expectThrow(() -> _ = args.maybeGetInt("unknown"));
+  T.expectThrow(() -> _ = args.maybeGetArray("unknown"));
+
+  T.expectThrow(() -> _ = args.maybeGetBool("unknown", true));
+  T.expectThrow(() -> _ = args.maybeGetString("unknown", true));
+  T.expectThrow(() -> _ = args.maybeGetInt("unknown", true));
+  T.expectThrow(() -> _ = args.maybeGetArray("unknown", true));
+
+  T.expectEq(args.maybeGetBool("unknown", false), None());
+  T.expectEq(args.maybeGetString("unknown", false), None());
+  T.expectEq(args.maybeGetInt("unknown", false), None());
+  T.expectEq(args.maybeGetArray("unknown", false), None());
+
+  T.expectThrow(() -> _ = args.getBool("unknown"));
+  T.expectThrow(() -> _ = args.getString("unknown"));
+  T.expectThrow(() -> _ = args.getInt("unknown"));
+  T.expectThrow(() -> _ = args.getArray("unknown"));
+
+  T.expectThrow(() -> _ = args.getBool("unknown", None()));
+  T.expectThrow(() -> _ = args.getString("unknown", None()));
+  T.expectThrow(() -> _ = args.getInt("unknown", None()));
+  T.expectThrow(() -> _ = args.getArray("unknown", None()));
+
+  T.expectEq(args.getBool("unknown", Some(true)), true);
+  T.expectEq(args.getString("unknown", Some("foo")), "foo");
+  T.expectEq(args.getInt("unknown", Some(1337)), 1337);
+  T.expectEq(
+    args.getArray("unknown", Some(Array["1", "2", "3"])),
+    Array["1", "2", "3"],
+  );
+
+  // The default for undefined arg should not override the provided value.
+  T.expectEq(args.getBool("bar", Some(true)), false);
+  T.expectEq(args.getString("baz", Some("foo")), "baz1");
+  T.expectEq(args.getInt("foobar", Some(123)), 1);
+  T.expectEq(
+    args.getArray("foobar2", Some(Array["a", "b", "c"])),
+    Array["abc", "def"],
+  );
+}
+
+@test
+fun argDefaultWithUndefinedDefault(): void {
+  cmd = Cli.Command("foo")
+    .arg(Cli.BoolArg("bar").default(true))
+    .arg(Cli.StringArg("baz").default("foo"))
+    .arg(Cli.IntArg("foobar").default(1337))
+    .arg(Cli.ArrayArg("foobar2").default(Array["a", "b", "c"]));
+  args = Cli.parseArgsFrom(cmd, Array[]);
+
+  // The default for undefined arg should not override the default value.
+  T.expectEq(args.getBool("bar", Some(false)), true);
+  T.expectEq(args.getString("baz", Some("bar")), "foo");
+  T.expectEq(args.getInt("foobar", Some(123)), 1337);
+  T.expectEq(
+    args.getArray("foobar2", Some(Array["d", "e", "f"])),
+    Array["a", "b", "c"],
+  );
+}
+
 module end;


### PR DESCRIPTION
The previous behavior of `ParseResults` is to raise when requesting the value of an argument that was not defined. This is a good thing in general, as inspecting value of an option that was not specified is often a sign of a bug. In certain instances, however, it is desirable not to raise and return `None()` instead for `maybeGetString()` etc. It is the case when a helper function builds an object from `ParseResults` (that may originate from different `Command` definitions) with default values for undefined arguments.