### PR TITLE
[cli] Support repeatable bool args.

### DIFF
--- a/cli/src/cli.sk
+++ b/cli/src/cli.sk
@@ -7,6 +7,7 @@ base class Arg(
   _about: ?String = None(),
   _global: Bool = false,
   _env: ?String = None(),
+  _repeatable: Bool = false,
   // NOTE: The following parameters cannot be placed in subclasses, since `name` is required.
   // Other than BoolArgs only
   _default: ?Value = None(),
@@ -37,6 +38,15 @@ base class Arg(
     this with {_global => true}
   }
 
+  fun repeatable(value: Bool = true): this {
+    if (value && this._default is Some _) {
+      invariant_violation(
+        "Cannot call repeatable(true) after default(). Use default_values() instead.",
+      )
+    };
+    this with {_repeatable => value}
+  }
+
   overridable fun env(name: String): this {
     this with {_env => Some(name)}
   }
@@ -54,23 +64,27 @@ base class ValuedArg extends Arg {
 
 class StringArg extends ValuedArg {
   fun default(value: String): this {
+    if (this._repeatable) {
+      invariant_violation(
+        "Cannot call default() if repeatable() was called first. Use default_values() instead.",
+      )
+    };
     this with {_default => Some(StringValue(value))}
+  }
+
+  fun default_values(values: Array<String>): this {
+    if (!this._repeatable) {
+      invariant_violation(
+        "Cannot call default_values() unless repeatable() was called first. Use default() instead.",
+      )
+    };
+    this with {_default => Some(ArrayValue(values))}
   }
 }
 
 class IntArg extends ValuedArg {
   fun default(value: Int): this {
     this with {_default => Some(IntValue(value))}
-  }
-}
-
-class ArrayArg extends ValuedArg {
-  fun default(value: Array<String>): this {
-    this with {_default => Some(ArrayValue(value))}
-  }
-
-  fun env(_name: String): this {
-    invariant_violation("TODO")
   }
 }
 

--- a/cli/src/parser.sk
+++ b/cli/src/parser.sk
@@ -152,34 +152,37 @@ private fun updateValue(
   arg: Arg,
   value: Value,
 ): Result<void, ArgumentError> {
-  arg match {
-  | ArrayArg _ ->
+  if (arg._repeatable) {
     strValue = value match {
     | StringValue(v) -> v
-    | _ -> invariant_violation(`Unexpected value type for ArrayArg`)
+    | BoolValue(true) -> "true"
+    | _ -> invariant_violation(`Unexpected value type for repeatable arg`)
     };
 
     values.maybeGet(arg.name) match {
     | Some(ArrayValue(arr)) ->
       values.set(arg.name, ArrayValue(arr.concat(Array[strValue])))
     | None() -> values.set(arg.name, ArrayValue(Array[strValue]))
-    | Some(v) -> invariant_violation(`Unexpected value type ${v} for ArrayArg`)
+    | Some(v) ->
+      invariant_violation(`Unexpected value type ${v} for repeatable arg`)
     }
-  | _ ->
-    if (!values.containsKey(arg.name)) {
-      values.set(arg.name, value)
-    } else {
-      return Failure(DuplicateValueError(arg.name))
-    }
+  } else if (!values.containsKey(arg.name)) {
+    values.set(arg.name, value)
+  } else {
+    return Failure(DuplicateValueError(arg.name))
   };
 
   Success(void)
 }
 
 private fun defaultValue(arg: Arg): Value {
-  arg match {
-  | ValuedArg _ -> arg._default.default(MissingValue())
-  | BoolArg _ -> arg._default.default(BoolValue(false))
+  if (arg._repeatable) {
+    arg._default.default(ArrayValue(Array[]))
+  } else {
+    arg match {
+    | ValuedArg _ -> arg._default.default(MissingValue())
+    | BoolArg _ -> arg._default.default(BoolValue(false))
+    }
   }
 }
 
@@ -215,11 +218,13 @@ private fun arg_maps(args: Array<Arg>): (Array<Arg>, Map<String, Arg>) {
     if (arg._positional) {
       if (posArgs.size() > 0) {
         prevArg = posArgs[posArgs.size() - 1];
-        if (prevArg is ArrayArg _) {
+        if (prevArg._repeatable) {
           invariant_violation(
             `Positional argument ${
               arg.name
-            } cannot appear after array positional argument ${prevArg.name}`,
+            } cannot appear after repeatable positional argument ${
+              prevArg.name
+            }`,
           )
         }
       };
@@ -338,14 +343,13 @@ mutable class Parser(
             break void
           } else {
             env_var = arg._env.map(v -> Environ.var(v));
-            value = arg match {
-            | StringArg _ -> env_var.map(v -> StringValue(v))
-            | IntArg _ -> env_var.map(v -> IntValue(v.toInt()))
-            | BoolArg _ ->
-              env_var.map(b -> BoolValue(b != "no" && b != "false" && b != "0"))
-            | _ ->
-              env_var.map(_ -> invariant_violation("Unexpected argument type."))
-            };
+            value = env_var.map(v ->
+              arg match {
+              | StringArg _ -> StringValue(v)
+              | IntArg _ -> IntValue(v.toInt())
+              | BoolArg _ -> BoolValue(v != "no" && v != "false" && v != "0")
+              }
+            );
             this.values.set(arg.name, value.default(defaultValue(arg)))
           }
         }
@@ -399,9 +403,8 @@ mutable class Parser(
     | None() if (!str.startsWith("-") && this.posArgId < this.posArgs.size()) ->
       arg = this.posArgs[this.posArgId];
       res = parse_value(arg, str).map(v -> Array[(arg, v)]);
-      arg match {
-      | ArrayArg _ -> void
-      | _ -> this.!posArgId = this.posArgId + 1
+      if (!arg._repeatable) {
+        this.!posArgId = this.posArgId + 1
       };
       res
     | None() ->
@@ -447,9 +450,7 @@ private fun parse_value(
   strValue: String,
 ): Result<Value, ArgumentError> {
   arg match {
-  | StringArg _
-  | ArrayArg _ ->
-    Success(StringValue(strValue))
+  | StringArg _ -> Success(StringValue(strValue))
   | IntArg _ ->
     strValue.toIntOption() match {
     | Some(v) -> Success(IntValue(v))

--- a/cli/src/usage.sk
+++ b/cli/src/usage.sk
@@ -47,7 +47,7 @@ private fun usageUsage(
       } else {
         `[${arg.name}]`
       };
-      if (arg is ArrayArg _) {
+      if (arg._repeatable) {
         !argString = argString + "...";
       };
       !res = res + " " + argString
@@ -84,10 +84,14 @@ private fun usageOptions(options: Sequence<Cli.Arg>): String {
       | (None(), Some(long)) -> `    --${long}`
       | _ -> `    --${arg.name}`
       };
-      arg match {
-      | Cli.ArrayArg _ -> !optFlags = `${optFlags} [<${arg._value_name}>]`
-      | Cli.ValuedArg _ -> !optFlags = `${optFlags} <${arg._value_name}>`
-      | _ -> void
+      if (arg is Cli.ValuedArg _) {
+        !optFlags = if (arg._repeatable) {
+          `${optFlags} [<${arg._value_name}>]`
+        } else {
+          `${optFlags} <${arg._value_name}>`
+        }
+      } else if (arg._repeatable) {
+        !optFlags = `${optFlags}...`
       };
       Array[Some(optFlags), arg._about]
     }),

--- a/cli/tests/tests.sk
+++ b/cli/tests/tests.sk
@@ -4,7 +4,7 @@ module CliTests;
 
 @test
 fun unexpectedExtraArguments(): void {
-  cmd = Cli.Command("foo").arg(Cli.ArrayArg("bar"));
+  cmd = Cli.Command("foo").arg(Cli.StringArg("bar").repeatable());
   args = Cli.parseArgsFrom(cmd, Array["--", "foo2", "--bar", "--foo2"]);
 
   T.expectTrue(args.error is Some(Cli.InvalidArgumentError _));
@@ -12,7 +12,7 @@ fun unexpectedExtraArguments(): void {
 
 @test
 fun extraArguments(): void {
-  cmd = Cli.Command("foo").arg(Cli.ArrayArg("bar")).extra();
+  cmd = Cli.Command("foo").arg(Cli.StringArg("bar").repeatable()).extra();
   args = Cli.parseArgsFrom(cmd, Array["--", "foo2", "--bar", "--foo2"]);
 
   T.expectEq(args.extra, Array["foo2", "--bar", "--foo2"]);
@@ -194,7 +194,7 @@ fun subcommandGlobalOptions(): void {
 
 @test
 fun arrayArgs(): void {
-  cmd = Cli.Command("foo").arg(Cli.ArrayArg("bar"));
+  cmd = Cli.Command("foo").arg(Cli.StringArg("bar").repeatable());
   args = Cli.parseArgsFrom(cmd, Array["--bar", "foo1", "--bar=foo2"]);
 
   T.expectEq(args.getArray("bar"), Array["foo1", "foo2"]);
@@ -203,7 +203,7 @@ fun arrayArgs(): void {
 @test
 fun arrayArgsDefault(): void {
   cmd = Cli.Command("foo").arg(
-    Cli.ArrayArg("bar").default(Array["foo1", "foo2"]),
+    Cli.StringArg("bar").repeatable().default_values(Array["foo1", "foo2"]),
   );
   args = Cli.parseArgsFrom(cmd, Array[]);
 
@@ -212,7 +212,7 @@ fun arrayArgsDefault(): void {
 
 @test
 fun arrayArgsPositional(): void {
-  cmd = Cli.Command("foo").arg(Cli.ArrayArg("bar").positional());
+  cmd = Cli.Command("foo").arg(Cli.StringArg("bar").repeatable().positional());
   args = Cli.parseArgsFrom(cmd, Array["foo1", "foo2"]);
 
   T.expectEq(args.getArray("bar"), Array["foo1", "foo2"]);
@@ -221,7 +221,7 @@ fun arrayArgsPositional(): void {
 @test
 fun arrayArgsPositionalIntertwined(): void {
   cmd = Cli.Command("foo")
-    .arg(Cli.ArrayArg("bar").positional())
+    .arg(Cli.StringArg("bar").repeatable().positional())
     .arg(Cli.StringArg("baz"));
   args = Cli.parseArgsFrom(cmd, Array["foo1", "--baz", "foo", "foo2"]);
 
@@ -231,7 +231,7 @@ fun arrayArgsPositionalIntertwined(): void {
 @test
 fun arrayArgsPositionalAfterArray(): void {
   cmd = Cli.Command("foo")
-    .arg(Cli.ArrayArg("bar").positional())
+    .arg(Cli.StringArg("bar").repeatable().positional())
     .arg(Cli.StringArg("baz").positional());
 
   T.expectThrow(() -> {
@@ -241,10 +241,24 @@ fun arrayArgsPositionalAfterArray(): void {
 
 @test
 fun arrayArgsPositionalWithExtra(): void {
-  cmd = Cli.Command("foo").arg(Cli.ArrayArg("bar").positional());
+  cmd = Cli.Command("foo").arg(Cli.StringArg("bar").repeatable().positional());
   args = Cli.parseArgsFrom(cmd, Array["foo1", "foo2", "--", "baz"]);
 
   T.expectEq(args.getArray("bar"), Array["foo1", "foo2"]);
+}
+
+@test
+fun repeatableBoolArg(): void {
+  cmd = Cli.Command("foo")
+    .arg(Cli.BoolArg("bar").repeatable())
+    .arg(Cli.BoolArg("baz").repeatable())
+    .arg(Cli.BoolArg("verbose").short("v").repeatable());
+
+  args = Cli.parseArgsFrom(cmd, Array["--bar", "--bar", "--bar", "-vv"]);
+
+  T.expectEq(args.getArray("bar").size(), 3);
+  T.expectEq(args.getArray("baz").size(), 0);
+  T.expectEq(args.getArray("verbose").size(), 2)
 }
 
 @test
@@ -355,7 +369,7 @@ fun undefinedArgs(): void {
     .arg(Cli.BoolArg("bar").negatable())
     .arg(Cli.StringArg("baz"))
     .arg(Cli.IntArg("foobar"))
-    .arg(Cli.ArrayArg("foobar2"));
+    .arg(Cli.StringArg("foobar2").repeatable());
   args = Cli.parseArgsFrom(
     cmd,
     Array[
@@ -419,7 +433,11 @@ fun argDefaultWithUndefinedDefault(): void {
     .arg(Cli.BoolArg("bar").default(true))
     .arg(Cli.StringArg("baz").default("foo"))
     .arg(Cli.IntArg("foobar").default(1337))
-    .arg(Cli.ArrayArg("foobar2").default(Array["a", "b", "c"]));
+    .arg(
+      Cli.StringArg("foobar2")
+        .repeatable()
+        .default_values(Array["a", "b", "c"]),
+    );
   args = Cli.parseArgsFrom(cmd, Array[]);
 
   // The default for undefined arg should not override the default value.

--- a/compiler/src/main.sk
+++ b/compiler/src/main.sk
@@ -11,11 +11,11 @@ fun main(): void {
     .help()
     .arg(Cli.BoolArg("disasm-all"))
     .arg(Cli.BoolArg("disasm-annotated"))
-    .arg(Cli.ArrayArg("disasm-file").default(Array[]))
-    .arg(Cli.ArrayArg("disasm-function").default(Array[]))
-    .arg(Cli.ArrayArg("export-function").default(Array[]))
-    .arg(Cli.ArrayArg("export-function-as").default(Array[]))
-    .arg(Cli.ArrayArg("export-module").default(Array[]))
+    .arg(Cli.StringArg("disasm-file").repeatable())
+    .arg(Cli.StringArg("disasm-function").repeatable())
+    .arg(Cli.StringArg("export-function").repeatable())
+    .arg(Cli.StringArg("export-function-as").repeatable())
+    .arg(Cli.StringArg("export-module").repeatable())
     .arg(Cli.StringArg("output").long("output").short("o"))
     // .arg(Cli.StringArg("profile-path").default(""))
     .arg(Cli.StringArg("emit").default("link"))
@@ -47,7 +47,7 @@ fun main(): void {
     .arg(Cli.StringArg("data"))
     .arg(Cli.StringArg("init"))
     .arg(Cli.BoolArg("check"))
-    .arg(Cli.ArrayArg("files").positional().default(Array[]))
+    .arg(Cli.StringArg("files").positional().repeatable())
     .parseArgs();
 
   results.error match {

--- a/compiler/src/skfmt.sk
+++ b/compiler/src/skfmt.sk
@@ -24,9 +24,10 @@ untracked fun main(): void {
   args = Cli.Command("skfmt")
     .about("Format skip code")
     .arg(
-      Cli.ArrayArg("files")
+      Cli.StringArg("files")
         .positional()
-        .default(Array["-"])
+        .repeatable()
+        .default_values(Array["-"])
         .about("Skip file(s) to format"),
     )
     .arg(

--- a/sknpm/src/main.sk
+++ b/sknpm/src/main.sk
@@ -359,14 +359,16 @@ fun test(): (Cli.Command, Cli.ParseResults ~> void) {
       .short("t")
       .about("Run the tests")
       .arg(
-        Cli.ArrayArg("target")
+        Cli.StringArg("target")
+          .repeatable()
           .positional()
           .about(
             "If specified, only run tests for the specified test targets (defined in target.json)",
           ),
       )
       .arg(
-        Cli.ArrayArg("filter")
+        Cli.StringArg("filter")
+          .repeatable()
           .short("f")
           .long("filter")
           .about("If specified, only run tests with names matching the filter"),
@@ -441,9 +443,8 @@ fun execTest(args: Cli.ParseResults, env: Skargo.Env): void {
   };
   services = Array<String>[];
   targets = Array<String>[];
-  args.maybeGetArray("target") match {
-  | Some(a) ->
-    a.each(v ->
+  if (args.getArray("target").size() > 0) {
+    args.getArray("target").each(v ->
       availables.maybeGet(v) match {
       | Some(target) ->
         !services = services.concat(target.services);
@@ -451,11 +452,12 @@ fun execTest(args: Cli.ParseResults, env: Skargo.Env): void {
       | _ -> invariant_violation(`${v} target not defined.`)
       }
     )
-  | _ ->
+  } else {
     availables.each((_, target) -> {
       !services = services.concat(target.services);
     })
   };
+
   processes = mutable Vector<Int>[];
   done = mutable Set<String>[];
   environment = mutable Map<String, String>[];
@@ -477,10 +479,11 @@ fun execTest(args: Cli.ParseResults, env: Skargo.Env): void {
     Environ.set_var("PLAYWRIGHT_JUNIT_OUTPUT_NAME", v);
     "junit"
   });
-  filters = args
-    .maybeGetArray("filter")
-    .map(a -> Array["-g", a.join("|")])
-    .default(Array[]);
+  filters = if (args.getArray("filter").size() > 0) {
+    Array["-g", args.getArray("filter").join("|")]
+  } else {
+    Array[]
+  };
   cmd = Array[
     "npx",
     "playwright",

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -235,7 +235,13 @@ untracked fun main(): void {
     .subcommand(
       Cli.Command("subscribe")
         .about("Subscribe to a directory change")
-        .arg(Cli.ArrayArg("views").positional().required().about("Views"))
+        .arg(
+          Cli.StringArg("views")
+            .repeatable()
+            .positional()
+            .required()
+            .about("Views"),
+        )
         .arg(Cli.BoolArg("connect").about("Send the initial state first"))
         .arg(
           Cli.StringArg("updates").about(


### PR DESCRIPTION
This commit replaces the dubious concept of `ArrayArg` with a
`repeatable` property on scalar args. This enables repeatable bool
args, both in the `-v -v -v` form and in the `-vvv` form.

Based on #170 and #168.