### PR TITLE
[skip] Question mark operator.

### DIFF
--- a/compiler/src/SkipParseTree.sk
+++ b/compiler/src/SkipParseTree.sk
@@ -4564,6 +4564,43 @@ class TypeParametersTree{
   }
 }
 
+class EnsureExpressionTree{
+  operand: ParseTree.ParseTree,
+  operator: ParseTree.ParseTree,
+} extends ParseTree.ParseTree {
+  fun getNamedFields(): List<(String, ParseTree.ParseTree)> {
+    List<(String, ParseTree.ParseTree)>[
+      ("operand", this.operand),
+      ("operator", this.operator),
+    ];
+  }
+
+  fun getKind(): String {
+    "EnsureExpression";
+  }
+
+  fun getChildren(): mutable Iterator<ParseTree.ParseTree> {
+    yield this.operand;
+    yield this.operator;
+    yield break;
+  }
+
+  fun transform(
+    codemod: mutable CodeMod,
+  ): (ParseTree.ParseTree, Vector<Subst>) {
+    tx_operand = codemod.transform(this.operand);
+    tx_operator = codemod.transform(this.operator);
+    (
+      EnsureExpressionTree{
+        range => this.range,
+        operand => tx_operand.i0,
+        operator => tx_operator.i0,
+      },
+      Vector[tx_operand.i1, tx_operator.i1].flatten(),
+    );
+  }
+}
+
 class UnaryExpressionTree{
   operator: ParseTree.ParseTree,
   operand: ParseTree.ParseTree,

--- a/compiler/src/SkipParser.sk
+++ b/compiler/src/SkipParser.sk
@@ -3874,6 +3874,15 @@ mutable class SkipParser{
       this.parsePostfixSuffix(this.parseMemberSelection(value))
     | TokenKind.COLON_COLON() ->
       this.parsePostfixSuffix(this.parseMemberSelection(value))
+    | TokenKind.QUESTION() ->
+      operator = this.tokenResult();
+      this.parsePostfixSuffix(
+        ParseTree.EnsureExpressionTree{
+          range => Parser.createRangeOfTrees(value, operator),
+          operator,
+          operand => value,
+        },
+      )
     | _ -> value
     }
   }
@@ -4925,6 +4934,7 @@ mutable class SkipParser{
     | ParseTree.TemplateLiteralExpressionTree _
     | ParseTree.ErrorTree _
     | ParseTree.EmptyTree _
+    | ParseTree.EnsureExpressionTree _
     | ParseTree.InfiniteLoopExpressionTree _
     | ParseTree.DoLoopExpressionTree _
     | ParseTree.WhileLoopExpressionTree _

--- a/compiler/src/convertTree.sk
+++ b/compiler/src/convertTree.sk
@@ -586,6 +586,8 @@ class Converter{filename: String} {
         operator,
         member,
       )
+    | ParseTree.EnsureExpressionTree{range, operand} ->
+      this.convertEnsureExpression(this.convertRange(range), operand)
     | ParseTree.UnaryExpressionTree{range, operator, operand} ->
       this.convertUnaryExpression(this.convertRange(range), operator, operand)
     | ParseTree.WithExpressionTree{range, value, arguments} ->
@@ -1345,6 +1347,53 @@ class Converter{filename: String} {
           "Unexpected unary operator: " + this.treeToString(tree),
         )
       },
+    )
+  }
+
+  fun convertEnsureExpression(
+    range: FileRange,
+    operand: ParseTree,
+  ): SkipAst.Expr_ {
+    match_expression = SkipAst.Call(
+      (
+        range,
+        SkipAst.Dot(this.convertExpression(operand), (range, "liftFailure")),
+      ),
+      Array[],
+      Positional(Array[]),
+    );
+    success_branch = (
+      List[
+        (
+          range,
+          SkipAst.Pat_type(
+            SkipAst.Tid_object(SkipAst.Tclass((range, "Success"))),
+            Some(Positional(Array[(range, SkipAst.Pat_var((range, "__x")))])),
+            SkipAst.Complete(),
+          ),
+        ),
+      ],
+      None(),
+      (range, SkipAst.Var((range, "__x"))),
+    );
+    early_return_branch = (
+      List[
+        (
+          range,
+          SkipAst.Pat_type(
+            SkipAst.Tid_object(SkipAst.Tclass((range, "Failure"))),
+            Some(Positional(Array[(range, SkipAst.Pat_var((range, "__x")))])),
+            SkipAst.Complete(),
+          ),
+        ),
+      ],
+      None(),
+      (range, SkipAst.Return((range, SkipAst.Var((range, "__x"))))),
+    );
+
+    SkipAst.Match(
+      (range, match_expression),
+      List[success_branch, early_return_branch],
     )
   }
 

--- a/compiler/src/printer.sk
+++ b/compiler/src/printer.sk
@@ -1659,6 +1659,8 @@ fun printTree(ctx: Context, t: ParseTree): Doc {
       printElseBranch(ctx, elseOpt, true),
     ];
     Doc.Group(res)
+  | ParseTree.EnsureExpressionTree{operand, operator} ->
+    Doc.Concat[print(ctx, operand), print(ctx, operator)]
   | ParseTree.UnaryExpressionTree{operator, operand} ->
     Doc.Concat[
       print(ctx, operator),

--- a/compiler/tests/syntax/invalid/ternary.exp_err
+++ b/compiler/tests/syntax/invalid/ternary.exp_err
@@ -1,6 +1,0 @@
-File "tests/syntax/invalid/ternary.sk", line 2, characters 5-5:
-Unexpected '?' token. If you are trying to write a ternary 'cond ? a : b', you should use an 'if' expression instead: 'if (cond) a else b'.
-1 | fun main(): String {
-2 |   a ? b : c
-  |     ^
-3 | }

--- a/compiler/tests/syntax/invalid/ternary.sk
+++ b/compiler/tests/syntax/invalid/ternary.sk
@@ -1,3 +1,0 @@
-fun main(): String {
-  a ? b : c
-}

--- a/compiler/tests/syntax/question_mark_operator.exp
+++ b/compiler/tests/syntax/question_mark_operator.exp
@@ -1,0 +1,4 @@
+Some(6)
+None()
+Success(6)
+Failure(OutOfBounds())

--- a/compiler/tests/syntax/question_mark_operator.sk
+++ b/compiler/tests/syntax/question_mark_operator.sk
@@ -1,0 +1,38 @@
+fun foo(x: Bool): ?String {
+  if (x) {
+    Some("5")
+  } else {
+    None()
+  }
+}
+
+fun foo2(): ?Int {
+  Some(foo(true)?.toInt() + 1)
+}
+
+fun foo3(): ?Int {
+  Some(foo(false)?.toInt() + 1)
+}
+
+fun bar(x: Bool): Result<String, Exception> {
+  if (x) {
+    Success("5")
+  } else {
+    Failure(OutOfBounds())
+  }
+}
+
+fun bar2(): Result<Int, Exception> {
+  Success(bar(true)?.toInt() + 1)
+}
+
+fun bar3(): Result<Int, Exception> {
+  Success(bar(false)?.toInt() + 1)
+}
+
+fun main(): void {
+  print_string(inspect(foo2()).toString());
+  print_string(inspect(foo3()).toString());
+  print_string(inspect(bar2()).toString());
+  print_string(inspect(bar3()).toString());
+}

--- a/prelude/src/core/Option.sk
+++ b/prelude/src/core/Option.sk
@@ -34,6 +34,10 @@ base class Option<+T> uses
   | Some(value: T)
   | None()
 
+  fun liftFailure<U>(): Result<T, None<U>>
+  | Some(val) -> Success(val)
+  | None() -> Failure(None())
+
   // For Some() values, returns a new Option with the result of applying the
   // mapping function to the contained value. Returns None() when this is None().
   fun map<T2>(f: T -> T2): ?T2

--- a/prelude/src/core/Result.sk
+++ b/prelude/src/core/Result.sk
@@ -28,6 +28,10 @@ base class Result<+T, +E> {
   | Failure(error: E)
   | Success(value: T)
 
+  fun liftFailure<U>(): Result<T, Failure<U, E>>
+  | Success(val) -> Success(val)
+  | Failure(err) -> Failure(Failure(err))
+
   // # Creating a Result
 
   // Execute the given function, returning as follows:

--- a/prelude/src/native/FastOption.sk
+++ b/prelude/src/native/FastOption.sk
@@ -71,6 +71,14 @@ private trait FastOptionTrait<+T>(protected valueIfSome: Unsafe.RawStorage<T>) {
 
 // Trait for always-available Option operations.
 private trait FastOptionCommonTrait<+T> extends FastOptionTrait<T> {
+  fun liftFailure<U>(): Result<T, None<U>> {
+    if (this.isSome()) {
+      Success(this.unsafeFromSome())
+    } else {
+      Failure(None())
+    }
+  }
+
   fun map<T2>(f: T -> T2): ?T2 {
     if (this.isSome()) {
       Some(f(this.unsafeFromSome()))


### PR DESCRIPTION
This commit introduces the postfix question mark operator, which semantically desugars as follows:

```
// For a value `x` of type `Result<T, E>`:
x?

// desugars to:
x match {
| Success(v) -> v
| Failure(err) -> return Failure(err)
}
```

```
// For a value `x` of type `Option<T>`:
x?

// desugars to:
x match {
| Some(v) -> v
| None _ -> return None()
}
```

In practice, it is actually desugared to:
```
x.branch() match {
| ControlFlowContinue(v) -> v
| ControlFlowBreak(r) -> return <ReturnType>::from_residual(r)
}
// where `<ReturnType>` is the return type of the current function.
```
which works on any type implementing the following `Try` trait:

```
trait Try<+TOutput, +TResidual> {
  fun branch(): ControlFlow<TOutput, TResidual>;
  static fun from_residual(r: TResidual): this;
}
```

NOTE: This is more of a proof of concept, as I am not too familiar with the typer, or with the `FastOption` implementation.