### PR TITLE
Support for client-specified schemas in mirror/tail operations

### DIFF
--- a/prelude/src/skstore/File.sk
+++ b/prelude/src/skstore/File.sk
@@ -194,14 +194,16 @@ class ArrayStringFile(value: Array<String>) extends File
 base class OutputFormat uses Orderable {
   children =
   | OSQL()
-  | OCSV()
+  // If present, fieldTransform specifies a subset/permutation of the existing columns.
+  // e.g. if it is Some([3,2,0]) then output the 3rd, 2nd, 0th columns in that order.
+  | OCSV(fieldTransform: ?Array<Int>)
   | OJSON(fieldNames: Array<String>)
   | OJS(fieldNames: Array<String>)
   | OTable(fieldNames: Array<String>)
 
   fun usesComma(): Bool
   | OSQL() -> false
-  | OCSV() -> true
+  | OCSV(_) -> true
   | OJSON(_) -> true
   | OTable(_) -> false
   | OJS _ ->
@@ -211,7 +213,7 @@ base class OutputFormat uses Orderable {
 
   fun usesDoubleQuotes(): Bool
   | OSQL() -> false
-  | OCSV() -> true
+  | OCSV(_) -> true
   | OJSON(_) -> true
   | OTable(_) -> true
   | OJS _ ->

--- a/rfc/003-protocol.org
+++ b/rfc/003-protocol.org
@@ -321,6 +321,8 @@ Where not specified, strings are UTF-8.
 - push promise
   - type = 0x3
   - reserved (24) - padding - must be zeroed
+  - schemas_length (16) - in bytes
+  - schemas (schema_length * 8) - JSON-encoded map from table names to schemas
 
 - schema
   - type = 0x4

--- a/rfc/003-protocol.org
+++ b/rfc/003-protocol.org
@@ -321,7 +321,7 @@ Where not specified, strings are UTF-8.
 - push promise
   - type = 0x3
   - reserved (24) - padding - must be zeroed
-  - schemas_length (16) - in bytes
+  - schemas_length (32) - in bytes
   - schemas (schema_length * 8) - JSON-encoded map from table names to schemas
 
 - schema

--- a/sql/server/core/src/main/kotlin/core/Mux.kt
+++ b/sql/server/core/src/main/kotlin/core/Mux.kt
@@ -510,7 +510,7 @@ class MuxedSocket(
                 signature = creds.sign(nonce, date),
                 deviceUuid = creds.deviceUuid ?: UUID.randomUUID().toString(),
                 date = date,
-                clientVersion = "kt-0.0.2", // TODO: this should be passed from above
+                clientVersion = "kt-0.0.3", // TODO: this should be passed from above
             )
         mutex.writeLock().lock()
         try {

--- a/sql/server/core/src/main/kotlin/core/Orchestration.kt
+++ b/sql/server/core/src/main/kotlin/core/Orchestration.kt
@@ -289,7 +289,7 @@ fun encodeProtoMsg(msg: ProtoMessage): ByteBuffer {
       buf.flip()
     }
     is ProtoPushPromise -> {
-      val buf = ByteBuffer.allocate(6 + msg.schemas.length * 4)
+      val buf = ByteBuffer.allocate(8 + msg.schemas.length * 4)
 
       buf.putInt(0x0)
       buf.put(0, 0x03.toByte())

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -46,7 +46,12 @@ data class ProcessOutput(val output: ByteArray, val exitCode: Int) {
   }
 }
 
-data class TailSpec(val since: Int, val filterExpr: String, val filterParams: Map<String, Any?>)
+data class TailSpec(
+    val since: Int,
+    val filterExpr: String,
+    val filterParams: Map<String, Any?>,
+    val expectedSchema: String
+)
 
 // super dumb, mostly synchronous, process facade
 class Skdb(val name: String, private val dbPath: String) {

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -137,7 +137,7 @@ class Skdb(val name: String, private val dbPath: String) {
   fun writeCsv(
       user: String,
       replicationId: String,
-      schemas: String,
+      schemas: ByteArray,
       callback: (ByteBuffer, shouldFlush: Boolean) -> Unit,
       closed: () -> Unit,
   ): Process {
@@ -159,7 +159,7 @@ class Skdb(val name: String, private val dbPath: String) {
     val proc = pb.start()
 
     val stdin = proc.outputStream.buffered()
-    stdin.write(schemas.toByteArray(StandardCharsets.UTF_8))
+    stdin.write(schemas)
     stdin.write("\n".toByteArray(StandardCharsets.UTF_8))
 
     // Don't close yet, as we still need to write actual CSV data

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -159,8 +159,7 @@ class Skdb(val name: String, private val dbPath: String) {
     val proc = pb.start()
 
     val stdin = proc.outputStream.buffered()
-    jsonMapper.writeValue(stdin, schemas)
-    stdin.write("\n".toByteArray(StandardCharsets.UTF_8))
+    stdin.write((schemas + "\n").toByteArray(StandardCharsets.UTF_8))
     stdin.close()
 
     // we work with text lines as it is convenient. there's a trivial

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -160,7 +160,9 @@ class Skdb(val name: String, private val dbPath: String) {
 
     val stdin = proc.outputStream.buffered()
     stdin.write((schemas + "\n").toByteArray(StandardCharsets.UTF_8))
-    stdin.close()
+
+    // Don't close yet, as we still need to write actual CSV data
+    stdin.flush()
 
     // we work with text lines as it is convenient. there's a trivial
     // amount of work going on to decode and re-encode here - just

--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -159,7 +159,8 @@ class Skdb(val name: String, private val dbPath: String) {
     val proc = pb.start()
 
     val stdin = proc.outputStream.buffered()
-    stdin.write((schemas + "\n").toByteArray(StandardCharsets.UTF_8))
+    stdin.write(schemas.toByteArray(StandardCharsets.UTF_8))
+    stdin.write("\n".toByteArray(StandardCharsets.UTF_8))
 
     // Don't close yet, as we still need to write actual CSV data
     stdin.flush()

--- a/sql/server/dev/src/main/kotlin/Service.kt
+++ b/sql/server/dev/src/main/kotlin/Service.kt
@@ -233,6 +233,7 @@ class RequestHandler(
             skdb.writeCsv(
                 accessKey,
                 replicationId,
+                request.schemas,
                 { data, shouldFlush -> stream.send(encodeProtoMsg(ProtoData(data, shouldFlush))) },
                 { stream.error(2000u, "Unexpected EOF") })
         return ProcessPipe(proc)

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -56,47 +56,6 @@ fun queryParams(options: SKDB.Options): Map<String, P.Value> {
   }
 }
 
-// Read a single line from stdin, decode it to a JSON Object, expected
-// to be a map from table names to corresponding schemas (both strings)
-fun readSchemas(): Map<String, Array<P.ColumnDefinition>> {
-  read_line() match {
-  | Some(line) ->
-    try {
-      JSON.decode(line)
-    } catch {
-    | exn ->
-      print_error(
-        "JSON decoding of schema expectations failed: \"" +
-          line +
-          "\"\n" +
-          exn.getMessage(),
-      );
-      skipExit(2)
-    } match {
-    | JSON.Object(obj) ->
-      obj
-        .map((_key, val) ->
-          val match {
-          | JSON.String("*") -> None()
-          | JSON.String(s) ->
-            schema = P.Parser::create(s).parseCreateTableSchema().columns;
-            Some(schema)
-          | _ ->
-            print_error("Malformed --expect-schemas JSON object\n");
-            skipExit(2)
-          }
-        )
-        .filterNone()
-    | _ ->
-      print_error("Non-object --expect-schemas JSON\n");
-      skipExit(2)
-    }
-  | None() ->
-    print_error("Reading stdin for expected schemas failed\n");
-    skipExit(2)
-  }
-}
-
 fun slurpStdin(): String {
   lines = mutable Vector[];
   try {
@@ -702,7 +661,12 @@ fun execWriteCsv(args: Cli.ParseResults, options: SKDB.Options): void {
 
   user = args.maybeGetString("user");
   schemas = if (args.getBool("expect-schemas")) {
-    readSchemas()
+    read_line() match {
+    | Some(line) -> decodeSchemas(line)
+    | None() ->
+      print_error("Reading stdin for expected schemas failed\n");
+      skipExit(2)
+    }
   } else {
     Map::createFromItems(Array[])
   };

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -56,6 +56,47 @@ fun queryParams(options: SKDB.Options): Map<String, P.Value> {
   }
 }
 
+// Read a single line from stdin, decode it to a JSON Object, expected
+// to be a map from table names to corresponding schemas (both strings)
+fun readSchemas(): Map<String, Array<P.ColumnDefinition>> {
+  read_line() match {
+  | Some(line) ->
+    try {
+      JSON.decode(line)
+    } catch {
+    | exn ->
+      print_error(
+        "JSON decoding of schema expectations failed: \"" +
+          line +
+          "\"\n" +
+          exn.getMessage(),
+      );
+      skipExit(2)
+    } match {
+    | JSON.Object(obj) ->
+      obj
+        .map((_key, val) ->
+          val match {
+          | JSON.String("*") -> None()
+          | JSON.String(s) ->
+            schema = P.Parser::create(s).parseCreateTableSchema().columns;
+            Some(schema)
+          | _ ->
+            print_error("Malformed --expect-schemas JSON object\n");
+            skipExit(2)
+          }
+        )
+        .filterNone()
+    | _ ->
+      print_error("Non-object --expect-schemas JSON\n");
+      skipExit(2)
+    }
+  | None() ->
+    print_error("Reading stdin for expected schemas failed\n");
+    skipExit(2)
+  }
+}
+
 fun slurpStdin(): String {
   lines = mutable Vector[];
   try {
@@ -221,6 +262,11 @@ untracked fun main(): void {
           Cli.BoolArg("enable-rebuilds").about(
             "Allow write-csv to apply rebuilds. Should only be used by single-peer clients." +
               " Used wrongly, can lead to data loss: if in doubt do not enable.",
+          ),
+        )
+        .arg(
+          Cli.BoolArg("expect-schemas").about(
+            "Read source-specified schemas from stdin.  They must be JSON-encoded in a map from table name to schema and written on one line before any CSV data.",
           ),
         ),
     )
@@ -654,12 +700,16 @@ fun execWriteCsv(args: Cli.ParseResults, options: SKDB.Options): void {
   | None() -> SKStore.genSym(0)
   };
 
+  user = args.maybeGetString("user");
+  schemas = if (args.getBool("expect-schemas")) {
+    readSchemas()
+  } else {
+    Map::createFromItems(Array[])
+  };
   rebuildsEnabled = args.getBool("enable-rebuilds");
-
-  SKDB.runSql(options, context ~> {
-    user = args.maybeGetString("user");
-    SKCSV.replayDiff(context, read_line, user, source, rebuildsEnabled)
-  })
+  SKDB.runSql(options, context ~>
+    SKCSV.replayDiff(context, read_line, user, source, schemas, rebuildsEnabled)
+  )
 }
 
 fun execSubscribe(args: Cli.ParseResults, options: SKDB.Options): void {

--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -590,7 +590,12 @@ fun execTail(args: Cli.ParseResults, options: SKDB.Options): void {
     name -> lookup.get(name)
   } else {
     _ -> {
-      TailSpec{since => defaultSince, filter => None(), params => Map[]}
+      TailSpec{
+        since => defaultSince,
+        filter => None(),
+        params => Map[],
+        columns => None(),
+      }
     }
   };
 

--- a/sql/src/SqlCompile.sk
+++ b/sql/src/SqlCompile.sk
@@ -451,7 +451,7 @@ mutable class Compiler{
       rest.isEmpty();
 
     format = this.options.format match {
-    | OFK_CSV() -> SKStore.OCSV()
+    | OFK_CSV() -> SKStore.OCSV(None())
     | OFK_Table() ->
       schema = static::getSchema(
         (select.core as P.SelectCoreQuery _).params,

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -894,7 +894,11 @@ fun replayDiff(
 
       | current @ Some(DiffParsingState(_, currentDiff)) ->
         currentDiff.lines.push(line); // capture the raw input for if we end up rejecting the txn
-        newRows = parseTableChange(immContext, currentDiff.table, line);
+        table = currentDiff.sourceSchema match {
+        | Some(schema) -> currentDiff.table with {schema}
+        | None() -> currentDiff.table
+        };
+        newRows = parseTableChange(immContext, table, line);
         currentDiff.rows.extend(newRows);
         current
       };

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -192,14 +192,25 @@ fun reasonSchemaUnsupported(
         return Some(
           "Malformed schema: expects parenthesized column-separated list of column definitions.",
         )
-      | Some(requestSchema) ->
-        if (
-          requestSchema.size() != dirDescr.schema.size() ||
-          requestSchema.zip(dirDescr.schema).any(cols ~> cols.i0 != cols.i1)
-        ) {
-          return Some(
-            "Cannot mirror table: provided schema does not match database.",
-          )
+      | Some(requestedSchema) ->
+        actualSchema = dirDescr.schema;
+
+        for (col in requestedSchema) {
+          if (!actualSchema.contains(col)) {
+            return Some(`Incompatible schema: unknown column ${col.name}`)
+          }
+        };
+
+        for (col in actualSchema) {
+          if (
+            col.notNull is Some _ &&
+            col.default is None _ &&
+            !requestedSchema.contains(col)
+          ) {
+            return Some(
+              `Incompatible schema: missing required column ${col.name}`,
+            )
+          }
         }
       }
     };

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -417,6 +417,12 @@ fun applyDiffStrategy(
       tableName = table.name.origName;
       authorCol = SKDB.getAuthorIdx(table);
       accessCol = SKDB.getAccessIdx(table);
+      rows = sourceSchema match {
+      | None() -> sourceRows.iterator()
+      | Some(schema) ->
+        translator = translateFromSourceSchema(schema, table.schema);
+        sourceRows.iterator().map(row -> translator(row, context))
+      };
       for (row in rows) {
         SKDB.checkUserCanWriteRow(
           context,

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -207,6 +207,67 @@ fun reasonSchemaUnsupported(
   };
 }
 
+// How to produce a value for a given column in translateFromSourceSchema:
+// CTSourceIdx -> get it from position `idx` in input row
+// CTNull -> nullable column, leave null
+// CTDefault -> column with default, evaluate the default expr
+base class ColumnTranslation {
+  children =
+  | CTSourceIdx(idx: Int)
+  | CTNull()
+  | CTDefault(expr: P.Expr)
+}
+
+fun translateFromSourceSchema(
+  sourceSchema: Array<P.ColumnDefinition>,
+  actualSchema: Array<P.ColumnDefinition>,
+): (SKDB.RowValues, mutable SKStore.Context) -> SKDB.RowValues {
+  rowConstructor = actualSchema.map(colDef ->
+    sourceSchema.indexOf(colDef) match {
+    | Some(idx) -> CTSourceIdx(idx)
+    | None() ->
+      colDef.default match {
+      | Some(P.CCDefault{expr}) -> CTDefault(expr)
+      | None() ->
+        colDef.notNull match {
+        | None() -> CTNull()
+        | Some(_) ->
+          invariant_violation(
+            "Can't transform to schema with missing non-nullable fields",
+          )
+        }
+      }
+    }
+  );
+  (row, context) -> {
+    values: Array<?SKDB.CValue> = rowConstructor.map(cTranslation ->
+      cTranslation match {
+      | CTNull() -> None()
+      | CTSourceIdx(idx) -> row.values[idx]
+      | CTDefault(expr) ->
+        expr match {
+        | P.VNull() -> None()
+        | P.VInt(n) -> Some(SKDB.CInt(n))
+        | P.VFloat(f) -> Some(SKDB.CFloat(f))
+        | P.VString(x) -> Some(SKDB.CString(x))
+        | P.VCurrentTime _ ->
+          Some(SKDB.CString(SKDB.strftime(context, "%H:%M:%S", "now", Array[])))
+        | P.VCurrentDate _ ->
+          Some(SKDB.CString(SKDB.strftime(context, "%Y-%m-%d", "now", Array[])))
+        | P.VCurrentTimestamp _ ->
+          Some(
+            SKDB.CString(
+              SKDB.strftime(context, "%Y-%m-%d %H:%M:%S", "now", Array[]),
+            ),
+          )
+        | _ -> invariant_violation("Invalid expression for default value")
+        }
+      }
+    );
+    SKDB.RowValues::create(values, row.repeat)
+  }
+}
+
 fun lwwEdits(
   table: SKDB.DirDescr,
   snapshot: Int,
@@ -276,7 +337,8 @@ fun applyDiffStrategy(
   table: SKDB.DirDescr,
   identity: Int,
   rebuild: Bool,
-  rows: Array<SKDB.RowValues>,
+  sourceRows: Array<SKDB.RowValues>,
+  sourceSchema: ?Array<P.ColumnDefinition>,
   checkpoint: ?Int,
   snapshot: ?Int,
   userFileOpt: ?SKDB.UserFile,
@@ -389,12 +451,18 @@ fun applyDiffStrategy(
     if (!privacyIsOk(newRoot)) {
       throw PrivacyWriteViolation()
     };
+    rows = sourceSchema match {
+    | None() -> sourceRows.iterator()
+    | Some(schema) ->
+      translator = translateFromSourceSchema(schema, table.schema);
+      sourceRows.iterator().map(row -> translator(row, newRoot))
+    };
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
 
     !dir = SKStore.withRegionFoldRec(
       Some(newRoot),
-      rows.iterator(),
+      rows,
       dir,
       (optContext, row, newDir) ~> {
         ctx = optContext.fromSome();
@@ -450,12 +518,18 @@ fun applyDiffStrategy(
     if (!privacyIsOk(newRoot)) {
       throw PrivacyWriteViolation()
     };
+    rows = sourceSchema match {
+    | None() -> sourceRows.iterator()
+    | Some(schema) ->
+      translator = translateFromSourceSchema(schema, table.schema);
+      sourceRows.iterator().map(row -> translator(row, newRoot))
+    };
 
     dir = newRoot.unsafeGetEagerDir(table.dirName);
 
     !dir = SKStore.withRegionFoldRec(
       Some(newRoot),
-      rows.iterator(),
+      rows,
       dir,
       (optContext, row, newDir) ~> {
         ctx = optContext.fromSome();
@@ -630,18 +704,31 @@ class FinalTableDiff(
   snapshot: ?Int,
   rebuild: Bool,
   rows: Array<SKDB.RowValues>,
+  sourceSchema: ?Array<P.ColumnDefinition>,
   lines: Array<String>,
 ) {}
 
 mutable class TableDiff(
   table: SKDB.DirDescr,
+  sourceSchema: ?Array<P.ColumnDefinition>,
   snapshot: ?Int,
   mutable rebuild: Bool,
   rows: mutable Vector<SKDB.RowValues>,
   lines: mutable Vector<String>,
 ) {
-  static fun create(table: SKDB.DirDescr, snapshot: ?Int): mutable this {
-    mutable static(table, snapshot, false, mutable Vector[], mutable Vector[])
+  static fun create(
+    table: SKDB.DirDescr,
+    sourceSchema: ?Array<P.ColumnDefinition>,
+    snapshot: ?Int,
+  ): mutable this {
+    mutable static(
+      table,
+      sourceSchema,
+      snapshot,
+      false,
+      mutable Vector[],
+      mutable Vector[],
+    )
   }
 
   readonly fun freeze(): FinalTableDiff {
@@ -650,6 +737,7 @@ mutable class TableDiff(
       this.snapshot,
       this.rebuild,
       this.rows.toArray(),
+      this.sourceSchema,
       this.lines.toArray(),
     )
   }
@@ -671,6 +759,7 @@ fun buildDiffChain(
       identity,
       td.rebuild,
       td.rows,
+      td.sourceSchema,
       Some(checkpoint),
       td.snapshot,
       userFileOpt,
@@ -713,6 +802,7 @@ fun replayDiff(
   getLine: () -> ?String,
   user: ?String,
   identity: Int,
+  schemas: Map<String, Array<P.ColumnDefinition>>,
   rebuildsEnabled: Bool,
 ): SKStore.ContextOp {
   SKDB.getFinalState(context, Some(identity)) match {
@@ -738,10 +828,11 @@ fun replayDiff(
 
       | None() ->
         (table, snapshot) = parseHeader(context, line);
+        schema = schemas.maybeGet(table.name.toString());
         Some(
           mutable DiffParsingState(
             mutable Vector[],
-            TableDiff::create(table, snapshot),
+            TableDiff::create(table, schema, snapshot),
           ),
         )
 
@@ -749,11 +840,12 @@ fun replayDiff(
         DiffParsingState(tableDiffs, currentDiff),
       ) if (String.getByte(line, 0) == 94) -> // startsWith("^")
         (table, snapshot) = parseHeader(context, line);
+        schema = schemas.maybeGet(table.name.toString());
         tableDiffs.push(currentDiff);
         Some(
           mutable DiffParsingState(
             tableDiffs,
-            TableDiff::create(table, snapshot),
+            TableDiff::create(table, schema, snapshot),
           ),
         )
 

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -112,6 +112,41 @@ fun decodeTailSpec(input: String, defaultSince: Int): Map<P.Name, TailSpec> {
   }
 }
 
+// Decode input string as a JSON Object, expected to be a map from table names
+// to corresponding schemas (both strings).
+fun decodeSchemas(input: String): Map<String, Array<P.ColumnDefinition>> {
+  try {
+    JSON.decode(input)
+  } catch {
+  | exn ->
+    print_error(
+      "JSON decoding of schema expectations failed: \"" +
+        input +
+        "\"\n" +
+        exn.getMessage(),
+    );
+    skipExit(2)
+  } match {
+  | JSON.Object(obj) ->
+    obj
+      .map((_key, val) ->
+        val match {
+        | JSON.String("*") -> None()
+        | JSON.String(s) ->
+          schema = P.Parser::create(s).parseCreateTableSchema().columns;
+          Some(schema)
+        | _ ->
+          print_error("Malformed --expect-schemas JSON object\n");
+          skipExit(2)
+        }
+      )
+      .filterNone()
+  | _ ->
+    print_error("Non-object --expect-schemas JSON\n");
+    skipExit(2)
+  }
+}
+
 fun computeTableDescr(
   name: P.Name,
   schema: Array<P.ColumnDefinition>,

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -80,6 +80,20 @@ fun decodeTailSpec(input: String, defaultSince: Int): Map<P.Name, TailSpec> {
                 .maybeGetObject("filterParams")
                 .map(o -> decodeParams(o))
                 .default(Map[]),
+              columns => obj.maybeGetString("expectedSchema") match {
+              | None() ->
+                print_error(
+                  "Tailer must specify an expected schema for each table",
+                );
+                skipExit(2)
+              | Some(schemaString) ->
+                if (schemaString == "*") None() else {
+                  Some(
+                    P.Parser::create(schemaString).parseCreateTableSchema()
+                      .columns,
+                  )
+                }
+              },
             },
           )
         | _ ->

--- a/sql/src/SqlTables.sk
+++ b/sql/src/SqlTables.sk
@@ -446,7 +446,7 @@ fun getSubsDirs(
         };
 
         format = request.format match {
-        | SKDB.OFK_CSV() -> SKStore.OCSV()
+        | SKDB.OFK_CSV() -> SKStore.OCSV(None())
         | SKDB.OFK_JSON() -> SKStore.OJSON(getFieldNames(context, edir.dirName))
         | SKDB.OFK_SQL() -> SKStore.OSQL()
         | SKDB.OFK_JS() -> SKStore.OJS(getFieldNames(context, edir.dirName))
@@ -617,14 +617,13 @@ fun getIndexByName(
 /* Tables. */
 /*****************************************************************************/
 
-fun getTables(origContext: readonly SKStore.Context): Array<DirDescr> {
+fun getDirDescrs(origContext: readonly SKStore.Context): Array<DirDescr> {
   context = SKStore.Context::fromSaved(origContext.clone());
-  handle = getTableDir(context);
-  handle
-    .items(context)
-    .flatMap(x -> x.i1)
-    .filter(x -> x.isInput)
-    .collect(Array);
+  getTableDir(context).items(context).flatMap(x -> x.i1).collect(Array);
+}
+
+fun getTables(origContext: readonly SKStore.Context): Array<DirDescr> {
+  getDirDescrs(origContext).filter(x -> x.isInput)
 }
 
 fun getTable(

--- a/sql/src/SqlTables.sk
+++ b/sql/src/SqlTables.sk
@@ -617,13 +617,23 @@ fun getIndexByName(
 /* Tables. */
 /*****************************************************************************/
 
-fun getDirDescrs(origContext: readonly SKStore.Context): Array<DirDescr> {
+fun getDirDescrs(
+  origContext: readonly SKStore.Context,
+): SortedMap<P.Name, SKDB.DirDescr> {
   context = SKStore.Context::fromSaved(origContext.clone());
-  getTableDir(context).items(context).flatMap(x -> x.i1).collect(Array);
+  getTableDir(context)
+    .items(context)
+    .flatMap(x -> x.i1)
+    .reduce((acc, curr) -> acc.set(curr.name, curr), SortedMap::create())
 }
 
 fun getTables(origContext: readonly SKStore.Context): Array<DirDescr> {
-  getDirDescrs(origContext).filter(x -> x.isInput)
+  context = SKStore.Context::fromSaved(origContext.clone());
+  getTableDir(context)
+    .items(context)
+    .flatMap(x -> x.i1)
+    .filter(x -> x.isInput)
+    .collect(Array);
 }
 
 fun getTable(

--- a/sql/src/SqlTailer.sk
+++ b/sql/src/SqlTailer.sk
@@ -171,7 +171,7 @@ fun tailSub(
       dirDescrs = getDirDescrs(gContext);
       sub with {
         dirSubs => sub.dirSubs.map(dirSub -> {
-          table = dirSub.dirName.toString().stripPrefix("/").stripSuffix("/");
+          table = getSqlTableName(dirSub.dirName);
           tableName = P.Name::create(table);
           dirDescr = dirDescrs.maybeGet(tableName) match {
           | Some(descr) -> descr

--- a/sql/src/SqlTailer.sk
+++ b/sql/src/SqlTailer.sk
@@ -82,10 +82,16 @@ fun buildTailFilter(
   };
 }
 
-fun buildSchemaTransform(
-  source: Array<P.ColumnDefinition>,
-  target: Array<P.ColumnDefinition>,
-): Array<Int> {
+fun buildCSVSchemaTransform(
+  dirDescr: SKDB.DirDescr,
+  tailSpec: TailSpec,
+): SKStore.OutputFormat {
+  source = dirDescr.schema;
+  target = tailSpec.columns match {
+  | None() -> return SKStore.OCSV(None())
+  | Some(targetSchema) -> targetSchema
+  };
+
   for (sourceCol in source) {
     if (
       sourceCol.notNull is Some _ &&
@@ -99,14 +105,16 @@ fun buildSchemaTransform(
     };
   };
 
-  target.map(targetCol -> {
+  schemaTransformation = target.map(targetCol -> {
     source.indexOf(targetCol) match {
     | None() ->
       print_error(`Incompatible schema: unknown column ${targetCol.name}`);
       skipExit(2)
     | Some(idx) -> idx
     }
-  })
+  });
+
+  SKStore.OCSV(Some(schemaTransformation));
 }
 
 fun tailShouldWake(
@@ -160,13 +168,7 @@ fun tailSub(
       print_error("Error: session not found");
       skipExit(2)
     | Some(sub) ->
-      dirDescrs: SortedMap<P.Name, SKDB.DirDescr> = {
-        dirsArray = getDirDescrs(gContext);
-        dirsArray.foldl(
-          (acc, curr) -> acc.set(curr.name, curr),
-          SortedMap::create(),
-        )
-      };
+      dirDescrs = getDirDescrs(gContext);
       sub with {
         dirSubs => sub.dirSubs.map(dirSub -> {
           table = dirSub.dirName.toString().stripPrefix("/").stripSuffix("/");
@@ -188,14 +190,7 @@ fun tailSub(
               dirDescr,
             ),
             format => options.format match {
-            | SKDB.OFK_CSV() ->
-              tailSpec.columns match {
-              | None() -> SKStore.OCSV(None())
-              | Some(targetSchema) ->
-                SKStore.OCSV(
-                  Some(buildSchemaTransform(dirDescr.schema, targetSchema)),
-                )
-              }
+            | SKDB.OFK_CSV() -> buildCSVSchemaTransform(dirDescr, tailSpec)
             | _ -> dirSub.format
             },
           }
@@ -234,7 +229,9 @@ fun tailSub(
         dirName = dirSub.dirName;
         edir = context.unsafeGetEagerDir(dirName);
         format = options.format match {
-        | SKDB.OFK_CSV() -> dirSub.format
+        | SKDB.OFK_CSV() ->
+          assert(dirSub.format is SKStore.OCSV(_));
+          dirSub.format
         | SKDB.OFK_JSON() -> SKStore.OJSON(getFieldNames(context, dirName))
         | SKDB.OFK_SQL() -> SKStore.OSQL()
         | SKDB.OFK_JS() -> SKStore.OJS(getFieldNames(context, dirName))

--- a/sql/src/SqlTailer.sk
+++ b/sql/src/SqlTailer.sk
@@ -2,7 +2,12 @@ module alias P = SQLParser;
 
 module SKDB;
 
-class TailSpec{since: Int, filter: ?String, params: Map<String, P.Value>}
+class TailSpec{
+  since: Int,
+  filter: ?String,
+  columns: ?Array<P.ColumnDefinition>,
+  params: Map<String, P.Value>,
+}
 
 fun buildTailFilter(
   context: readonly SKStore.Context,
@@ -10,7 +15,7 @@ fun buildTailFilter(
   dirSub: SKStore.DirSub,
   userId: ?String,
   tailSpec: TailSpec,
-  tableName: P.Name,
+  sqlTable: SKDB.DirDescr,
 ): (SKStore.Context, Bool) ~> (SKStore.Key -> Bool) {
   filter = tailSpec.filter match {
   | None() -> dirSub.filter
@@ -20,7 +25,7 @@ fun buildTailFilter(
     compilerContext = context.mclone();
     _ = compiler.compileFrom(
       compilerContext,
-      Array[P.FromTable{name => tableName, asName => None()}],
+      Array[P.FromTable{name => sqlTable.name, asName => None()}],
     );
     e = compiler.compileExpr(compilerContext, ast) match {
     | SKDB.CIExpr(x) -> x
@@ -57,8 +62,6 @@ fun buildTailFilter(
   | Some(userID) ->
     (context, isReset) ~> {
       user = SKDB.UserFile::create(context, userID);
-      sqlTable = getSqlTableFromDirName(context, dirSub.dirName);
-
       oldFilter = filter(context, isReset);
 
       baseName -> {
@@ -77,6 +80,33 @@ fun buildTailFilter(
       }
     }
   };
+}
+
+fun buildSchemaTransform(
+  source: Array<P.ColumnDefinition>,
+  target: Array<P.ColumnDefinition>,
+): Array<Int> {
+  for (sourceCol in source) {
+    if (
+      sourceCol.notNull is Some _ &&
+      sourceCol.default is None _ &&
+      !target.contains(sourceCol)
+    ) {
+      print_error(
+        `Incompatible schema: missing required column ${sourceCol.name}`,
+      );
+      skipExit(2)
+    };
+  };
+
+  target.map(targetCol -> {
+    source.indexOf(targetCol) match {
+    | None() ->
+      print_error(`Incompatible schema: unknown column ${targetCol.name}`);
+      skipExit(2)
+    | Some(idx) -> idx
+    }
+  })
 }
 
 fun tailShouldWake(
@@ -130,20 +160,44 @@ fun tailSub(
       print_error("Error: session not found");
       skipExit(2)
     | Some(sub) ->
+      dirDescrs: SortedMap<P.Name, SKDB.DirDescr> = {
+        dirsArray = getDirDescrs(gContext);
+        dirsArray.foldl(
+          (acc, curr) -> acc.set(curr.name, curr),
+          SortedMap::create(),
+        )
+      };
       sub with {
         dirSubs => sub.dirSubs.map(dirSub -> {
-          tableName = P.Name::create(
-            dirSub.dirName.toString().stripPrefix("/").stripSuffix("/"),
-          );
+          table = dirSub.dirName.toString().stripPrefix("/").stripSuffix("/");
+          tableName = P.Name::create(table);
+          dirDescr = dirDescrs.maybeGet(tableName) match {
+          | Some(descr) -> descr
+          | None _ ->
+            print_error(`Error: '${tableName}' not found`);
+            skipExit(2)
+          };
+          tailSpec = spec(tableName);
           dirSub with {
             filter => buildTailFilter(
               gContext,
               options,
               dirSub,
               userIDOpt,
-              spec(tableName),
-              tableName,
+              tailSpec,
+              dirDescr,
             ),
+            format => options.format match {
+            | SKDB.OFK_CSV() ->
+              tailSpec.columns match {
+              | None() -> SKStore.OCSV(None())
+              | Some(targetSchema) ->
+                SKStore.OCSV(
+                  Some(buildSchemaTransform(dirDescr.schema, targetSchema)),
+                )
+              }
+            | _ -> dirSub.format
+            },
           }
         }),
       }
@@ -180,7 +234,7 @@ fun tailSub(
         dirName = dirSub.dirName;
         edir = context.unsafeGetEagerDir(dirName);
         format = options.format match {
-        | SKDB.OFK_CSV() -> SKStore.OCSV()
+        | SKDB.OFK_CSV() -> dirSub.format
         | SKDB.OFK_JSON() -> SKStore.OJSON(getFieldNames(context, dirName))
         | SKDB.OFK_SQL() -> SKStore.OSQL()
         | SKDB.OFK_JS() -> SKStore.OJS(getFieldNames(context, dirName))

--- a/sql/src/SqlValue.sk
+++ b/sql/src/SqlValue.sk
@@ -234,8 +234,7 @@ extension class RowValues extends Row {
 
   fun toStringSingle(format: SKStore.OutputFormat): String {
     values = this.values;
-    size = values.size();
-    if (!(format is SKStore.OJSON _) && size == 1) {
+    if (!(format is SKStore.OJSON _) && values.size() == 1) {
       values[0] match {
       | None() -> return ""
       | Some(v) -> return v.toStringWithFormat(format)
@@ -250,8 +249,9 @@ extension class RowValues extends Row {
     // schemas which permute and/or elide columns
     indices = format match {
     | SKStore.OCSV(Some(permutation)) -> permutation
-    | _ -> Range(0, size).collect(Array)
+    | _ -> Range(0, values.size()).collect(Array)
     };
+    size = indices.size();
 
     for (index in Range(0, size - 1)) {
       i = indices[index];

--- a/sql/src/SqlValue.sk
+++ b/sql/src/SqlValue.sk
@@ -245,7 +245,12 @@ extension class RowValues extends Row {
     if (format is SKStore.OJSON _) {
       result.push("{");
     };
-    for (i in Range(0, size - 1)) {
+    indices = format match {
+    | SKStore.OCSV(Some(permutation)) -> permutation
+    | _ -> Range(0, size - 1)
+    };
+
+    for (i in indices) {
       format match {
       | SKStore.OJSON(fieldNames) -> result.push("\"" + fieldNames[i] + "\":")
       | _ -> void

--- a/sql/src/SqlValue.sk
+++ b/sql/src/SqlValue.sk
@@ -245,12 +245,16 @@ extension class RowValues extends Row {
     if (format is SKStore.OJSON _) {
       result.push("{");
     };
+
+    // This layer of indirection over indices is to support client-specified
+    // schemas which permute and/or elide columns
     indices = format match {
     | SKStore.OCSV(Some(permutation)) -> permutation
-    | _ -> Range(0, size - 1)
+    | _ -> Range(0, size).collect(Array)
     };
 
-    for (i in indices) {
+    for (index in Range(0, size - 1)) {
+      i = indices[index];
       format match {
       | SKStore.OJSON(fieldNames) -> result.push("\"" + fieldNames[i] + "\":")
       | _ -> void
@@ -266,7 +270,7 @@ extension class RowValues extends Row {
       result.push("\"" + fieldNames[size - 1] + "\":")
     | _ -> void
     };
-    values[size - 1] match {
+    values[indices[size - 1]] match {
     | None() -> if (format is SKStore.OJSON _) result.push("null") else void
     | Some(v) -> result.push(v.toStringWithFormat(format))
     };

--- a/sql/test_tail_filter_param.sh
+++ b/sql/test_tail_filter_param.sh
@@ -27,7 +27,7 @@ echo "create table t1 (a INTEGER);" | $skdb_copy
 
 sessionID=`$skdb subscribe t1 --connect`
 
-echo '{"t1": {"filterExpr": "a > @bound", "filterParams": { "bound": 500 }}}' \
+echo '{"t1": {"filterExpr": "a > @bound", "filterParams": { "bound": 500 }, "expectedSchema": "(a INTEGER)"}}' \
 | $skdb tail $sessionID --follow --read-spec > $tailfile &
 tailerID=$!
 


### PR DESCRIPTION
This PR adds support for client-specified schemas; instead of enforcing that schemas exactly match between replicas, we allow tailers to specify an expected schema.  That schema is allowed to (a) reorder columns and (b) drop any columns that are nullable or include a default value.  All data-layer communication happens in the given schema, with translations on the server for both the write and read path. 

Still a WIP -- the bulk of the functionality is in place, but needs more thorough testing.