### PR TITLE
Fix: dumping indices broken if we make use of an index first

### DIFF
--- a/sql/src/SqlTables.sk
+++ b/sql/src/SqlTables.sk
@@ -13,6 +13,7 @@ const subsOutput: SKStore.DirName = SKStore.DirName::create("/subsOutput/");
 const indexInput: SKStore.DirName = SKStore.DirName::create("/indexInput/");
 const indexOutput: SKStore.DirName = SKStore.DirName::create("/indexOutput/");
 const indexByCol: SKStore.DirName = SKStore.DirName::create("/indexByCol/");
+const indexByName: SKStore.DirName = SKStore.DirName::create("/indexByName/");
 const watermarks: SKStore.DirName = SKStore.DirName::create("/watermarks/");
 const replication: SKStore.DirName = SKStore.DirName::create("/replication/");
 
@@ -598,12 +599,12 @@ fun getIndexByName(
   context: mutable SKStore.Context,
 ): SKStore.EHandle<SKStore.Key, IndexDescr> {
   indexes = getIndexOutputDir(context);
-  makeDir(IndexDescr::type, context, indexByCol, () -> {
+  makeDir(IndexDescr::type, context, indexByName, () -> {
     indexes.map(
       x ~> x,
       IndexDescr::type,
       context,
-      indexByCol,
+      indexByName,
       (_context, writer, _key, values) ~> {
         indexDescr = values.first;
         writer.set(SKStore.SID(indexDescr.tableName.lower), indexDescr)


### PR DESCRIPTION
Looks like a simple copy paste error that has been around forever. Due
to getIndexByColNbr and getIndexByName both using the same dir name,
there's a race to see who gets there first. If getIndexByColNbr wins
then we don't dump indices, otherwise we (probably, I didn't test)
don't use indices.