### PR TITLE
Force a rebuild when a client reconnects to a new server

### DIFF
--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -715,7 +715,7 @@ fun replayDiff(
   identity: Int,
   rebuildsEnabled: Bool,
 ): SKStore.ContextOp {
-  SKDB.getFinalState(context, Some(identity)) match {
+  SKDB.getReplicationState(context, Some(identity)) match {
   | Some(SKDB.RSError()) ->
     print_raw(":reboot\n");
     return SKStore.CStop(None())
@@ -777,7 +777,7 @@ fun replayDiff(
         line == "!rebuild"
       ) ->
         if (!rebuildsEnabled) {
-          SKDB.setFinalState(context, identity, SKDB.RSError());
+          SKDB.setReplicationState(context, identity, SKDB.RSError());
           invariant_violation("Received rebuild when processing disabled.")
         };
         currentDiff.!rebuild = true;

--- a/sql/src/SqlTables.sk
+++ b/sql/src/SqlTables.sk
@@ -407,7 +407,7 @@ fun getSubsDirs(
           selectFiles = viewsDir.getArrayRaw(SKStore.SID(viewName.toString()));
           invariant(selectFiles.size() <= 1);
           if (selectFiles.size() == 0) {
-            print_error(`Error: view ${viewName.toString()} doesn't exists`);
+            print_error(`Error: view ${viewName.toString()} doesn't exist`);
             skipExit(3)
           };
           selectFile = SKDB.SelectFile::type(selectFiles[0]);

--- a/sql/src/SqlTables.sk
+++ b/sql/src/SqlTables.sk
@@ -80,14 +80,16 @@ fun resetWatermark(
 }
 
 base class ReplicationState {
-  // gds: I envision an RSGarbageCollected to help with vector clock
-  // growth, thus the base class
   children =
   | RSError()
+  // once a downstream has fully caught up to a checkpoint and is now
+  // 'tailing since', they are considered established. this is useful
+  // to determine if this is a new-to-this-server client.
+  | RSEstablished()
 }
 class ReplicationStateFile(state: ReplicationState) extends SKStore.File
 
-fun getFinalState(
+fun getReplicationState(
   context: readonly SKStore.Context,
   replicationSource: ?Int,
 ): ?ReplicationState {
@@ -108,7 +110,7 @@ fun getFinalState(
   }
 }
 
-fun setFinalState(
+fun setReplicationState(
   context: mutable SKStore.Context,
   replicationSource: Int,
   state: ReplicationState,
@@ -120,9 +122,19 @@ fun setFinalState(
   };
   key = SKStore.IID(replicationSource);
   arr = replicationDir.unsafeGetArray(context, key);
-  // all states are final states, first writer wins
   if (arr.size() < 1) {
     replicationDir.writeArray(context, key, Array[ReplicationStateFile(state)])
+  } else {
+    arr[0] match {
+    | ReplicationStateFile(RSError()) ->
+      void // final state
+    | ReplicationStateFile(RSEstablished()) ->
+      replicationDir.writeArray(
+        context,
+        key,
+        Array[ReplicationStateFile(state)],
+      )
+    }
   }
 }
 
@@ -134,7 +146,11 @@ fun errorAllExistingSubs(
     if (sub.destinationSource is Some _) {
       for (dirSub in sub.dirSubs) {
         if (dirSub.dirName == dir) {
-          setFinalState(context, sub.destinationSource.fromSome(), RSError());
+          setReplicationState(
+            context,
+            sub.destinationSource.fromSome(),
+            RSError(),
+          );
           lock = SKStore.unfreezeLock(sub.lock);
           SKStore.mutexLock(lock);
           cond = SKStore.unfreezeCond(sub.cond);

--- a/sql/src/SqlTailer.sk
+++ b/sql/src/SqlTailer.sk
@@ -84,7 +84,7 @@ fun tailShouldWake(
   sub: SKStore.Sub,
   tick: SKStore.Tick,
 ): Bool {
-  SKDB.getFinalState(context, sub.destinationSource) match {
+  SKDB.getReplicationState(context, sub.destinationSource) match {
   | Some(SKDB.RSError()) -> return true
   | _ -> void
   };
@@ -164,11 +164,15 @@ fun tailSub(
       | Some(_) -> void
       };
 
-      SKDB.getFinalState(context, sub.destinationSource) match {
-      | Some(SKDB.RSError()) ->
+      established = SKDB.getReplicationState(
+        context,
+        sub.destinationSource,
+      ) match {
+      | Some(RSError()) ->
         print_raw(":reboot\n");
         return None()
-      | _ -> void
+      | Some(RSEstablished()) -> true
+      | _ -> sub.destinationSource is None()
       };
 
       writer = mutable Debug.BufferedWriter(print_raw, 4096);
@@ -187,7 +191,15 @@ fun tailSub(
         | SKDB.OFK_Table() -> SKStore.OTable(getFieldNames(context, dirName))
         };
         since = tailFrom(spec, dirSub, tailWatermark);
-        (shouldRebuild, changes) = if (since.value > 0) {
+        (shouldRebuild, changes) = if (since.value > 0 && !established) {
+          // we have a client that we've never seen before asking to
+          // tail from a point in time that they cannot understand, as
+          // they have no reference for our clock. we assume that this
+          // indicates they've moved from a different server to us and
+          // so need to reset their concept of the server's time.
+          !chunkingDisabled = true;
+          (true, Array[].iterator())
+        } else if (since.value > 0) {
           // we can only chunk while tables are since 0 as we'll emit
           // zero checkpoints. once a nonzero request is handled, we must
           // make sure that it doesn't ultimately get sent back as part of a
@@ -248,6 +260,19 @@ fun tailSub(
       }
     });
 
+    // we are now considered established, even if we're about to fail.
+    if (init && sub.destinationSource is Some _) {
+      runSql(options, (ctx) ~> {
+        SKDB.setReplicationState(
+          ctx,
+          sub.destinationSource.fromSome(),
+          RSEstablished(),
+        );
+        SKStore.CStop(None())
+      })
+    };
+    !init = false;
+
     !tailWatermark = tick match {
     // if we cannot follow changes from here - regardless of whether
     // we want to - this is a failure to honour the request. i.e.
@@ -257,7 +282,7 @@ fun tailSub(
     | None() -> break false
     | Some(_) -> tick
     };
-    !init = false;
+
     !forceReset = false;
     lock = SKStore.unfreezeLock(sub.lock);
     cond = SKStore.unfreezeCond(sub.cond);


### PR DESCRIPTION
Why? Because a new server loses watermarks and has a different tick.
This breaks all the metadata that replication relies on. The rebuild
mechanism is fundamentally: reset your view of the server's clock and
resync your data to this. So it is a perfect fit to solve this
problem.

I disregarded trying to port the watermark data and initialise a new
server with the same tick as the old. We would also have to dump and
import all the Source data for each and every row. This is a much
bigger lift and all becomes irrelevant with upcoming vector clocks.