### PR TITLE
Fix: dumping tables with > 1024 rows would contain spurious commits

### DIFF
--- a/sql/src/SqlTables.sk
+++ b/sql/src/SqlTables.sk
@@ -809,29 +809,28 @@ fun dumpInserts(origContext: readonly SKStore.Context): void {
     (context, _writer, _key, values) ~> {
       dirDescr = values.first;
       if (!dirDescr.isInput) return void;
-      o = print_raw;
       fileIter = context
         .unsafeGetEagerDir(dirDescr.dirName)
         .unsafeGetFileIter();
       count = 1;
-      o("BEGIN TRANSACTION;\n");
+      print_raw("BEGIN TRANSACTION;\n");
       for (kv in fileIter) {
         if (count % 1024 == 0) {
-          o("COMMIT;\n");
-          o("BEGIN TRANSACTION;\n");
+          print_raw("COMMIT;\n");
+          print_raw("BEGIN TRANSACTION;\n");
         };
         (_, files) = kv;
         for (file in files) {
           row = RowValues::type(file);
           for (_ in Range(0, row.repeat)) {
-            o("INSERT INTO " + dirDescr.name + " VALUES ");
-            o(row.toString());
-            o(";\n");
+            print_raw("INSERT INTO " + dirDescr.name + " VALUES ");
+            print_raw(row.toString());
+            print_raw(";\n");
             !count = count + 1;
           };
         };
       };
-      o("COMMIT;\n");
+      print_raw("COMMIT;\n");
       flushStdout();
     },
   );


### PR DESCRIPTION
We have some logic to commit every 1024 rows in dumpInserts. We:

```
o("COMMIT;\n");
o("BEGIN TRANSACTION;\n");
```

In prod I see import failing because only the COMMIT line is printed.

Looks like a compiler issue. In the disassembly of dumpInserts I see
only one call to SKIP_print_raw. Setting a breakpoint, stepping and
checking, sure enough the commit string is passed but we never get
called with 'begin transaction'. Here's a relevant chunk of the asm:

```
   0x00000000005521cc <+412>:	mov	w9, #0x400                 	// #1024
   0x00000000005521d0 <+416>:	mov	w10, w9
   0x00000000005521d4 <+420>:	sdiv	x9, x8, x10
   0x00000000005521d8 <+424>:	mul	x9, x9, x10
   0x00000000005521dc <+428>:	subs	x8, x8, x9
   0x00000000005521e0 <+432>:	subs	x8, x8, #0x0
   0x00000000005521e4 <+436>:	cset	w8, ne  // ne = any
   0x00000000005521e8 <+440>:	tbnz	w8, #0, 0x5521fc <sk.SKDB_dumpInserts__Closure1__call(void)+460>
   0x00000000005521ec <+444>:	b	0x5521f0 <sk.SKDB_dumpInserts__Closure1__call(void)+448>
   0x00000000005521f0 <+448>:	ldur	x0, [x29, #-64]
   0x00000000005521f4 <+452>:	bl	0x5f3ac0 <SKIP_print_raw(char*)>
   0x00000000005521f8 <+456>:	b	0x5521fc <sk.SKDB_dumpInserts__Closure1__call(void)+460>
   0x00000000005521fc <+460>:	ldur	x0, [x29, #-152]
   0x0000000000552200 <+464>:	ldur	x8, [x0, #-8]
   0x0000000000552204 <+468>:	ldr	x8, [x8, #104]
```

Changing the code to not rename the function got me the output I was
hoping for:

```
   0x00000000005521f4 <+412>:	mov	w9, #0x400                 	// #1024
   0x00000000005521f8 <+416>:	mov	w10, w9
   0x00000000005521fc <+420>:	sdiv	x9, x8, x10
   0x0000000000552200 <+424>:	mul	x9, x9, x10
   0x0000000000552204 <+428>:	subs	x8, x8, x9
   0x0000000000552208 <+432>:	subs	x8, x8, #0x0
   0x000000000055220c <+436>:	cset	w8, ne  // ne = any
   0x0000000000552210 <+440>:	tbnz	w8, #0, 0x55222c <sk.SKDB_dumpInserts__Closure1__call(void)+468>
   0x0000000000552214 <+444>:	b	0x552218 <sk.SKDB_dumpInserts__Closure1__call(void)+448>
   0x0000000000552218 <+448>:	ldur	x0, [x29, #-64]
   0x000000000055221c <+452>:	bl	0x5f3b54 <SKIP_print_raw(char*)>
   0x0000000000552220 <+456>:	ldur	x0, [x29, #-72]
   0x0000000000552224 <+460>:	bl	0x5f3b54 <SKIP_print_raw(char*)>
   0x0000000000552228 <+464>:	b	0x55222c <sk.SKDB_dumpInserts__Closure1__call(void)+468>
   0x000000000055222c <+468>:	ldur	x0, [x29, #-152]
   0x0000000000552230 <+472>:	ldur	x8, [x0, #-8]
   0x0000000000552234 <+476>:	ldr	x8, [x8, #104]
   0x0000000000552238 <+480>:	blr	x8
```

And sure enough, just to check the newly added call does the right thing:

```
(gdb) b *0x0552224
Breakpoint 1 at 0x552224: file skdb:/skfs/sql/src/SqlTables.sk, line 836.
(gdb) r --data /var/db/test.db dump > /tmp/dump
Starting program: /skfs/build/skdb --data /var/db/test.db dump > /tmp/dump
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".

Breakpoint 1, sk.SKDB_dumpInserts__Closure1__call(void) () at skdb:/skfs/sql/src/SqlTables.sk:836
836	skdb:/skfs/sql/src/SqlTables.sk: No such file or directory.
(gdb) x/1s $x0
0x63a3a8 <.sstr.BEGIN_TRANSACTION__+8>:	"BEGIN TRANSACTION;\n"
```