### PR TITLE
Ensure multiple `select id()` produce differing results

### DIFF
--- a/sql/src/SqlSelect.sk
+++ b/sql/src/SqlSelect.sk
@@ -694,27 +694,31 @@ class SelectEvaluator{
   }
 
   fun evalEmptyFrom(context: mutable SKStore.Context): void {
-    dirName = this.selectName2;
-    if (context.unsafeMaybeGetEagerDir(dirName) is None()) {
-      evaluator = ExprEvaluator(Array[], this.select.from, this.up);
+    evaluator = ExprEvaluator(Array[], this.select.from, this.up);
+    whereVal = evaluator.evalWhere(context, this.select.where);
+    row = whereVal match {
+    | ANull()
+    | ADef(0) ->
+      static::evalRow(context, evaluator, Array[CGNull()], 1)
+    | AUndef()
+    | ADef(_) ->
+      static::evalRow(context, evaluator, this.select.params, 1)
+    };
 
-      whereVal = evaluator.evalWhere(context, this.select.where);
-      row = whereVal match {
-      | ANull()
-      | ADef(0) ->
-        static::evalRow(context, evaluator, Array[CGNull()], 1)
-      | AUndef()
-      | ADef(_) ->
-        static::evalRow(context, evaluator, this.select.params, 1)
-      };
+    dirName = this.selectName2;
+    context.unsafeMaybeGetEagerDir(dirName) match {
+    | None() ->
       _dir = context.mkdir(
         SKStore.IID::keyType,
         Row::type,
         dirName,
         Array[(SKStore.IID(0), row)],
-      );
-    } else {
-      context.!newDirs = context.newDirs.set(dirName);
+      )
+    | Some(dir) ->
+      context.setDir(
+        dirName,
+        dir.writeArrayReturnDir(context, SKStore.IID(0), Array[row]),
+      )
     }
   }
 

--- a/sql/test/unit/test_select_multiple_id.sql
+++ b/sql/test/unit/test_select_multiple_id.sql
@@ -1,0 +1,4 @@
+select id();
+select id();
+select id() from (select 1);
+select id() from (select 1);

--- a/sql/unit_tests.sh
+++ b/sql/unit_tests.sh
@@ -323,3 +323,9 @@ if cat test/unit/test_length.sql | $SKDB | grep -q '|0|||test|4|literal|7' ; the
 else
     fail "LENGTH"
 fi
+
+if cat test/unit/test_select_multiple_id.sql | $SKDB | sort | uniq | wc -l | xargs test 4 -eq; then
+    pass "MULTIPLE ID"
+else
+    fail "MULTIPLE ID"
+fi


### PR DESCRIPTION
The gist is we need to ensure re-evaluation as the id function is
non-deterministic.

The fix is for when there is no from clause as this seems to be
somewhat special cased. We already re-evaluate when there is a from
clause, both when from is a query or a table.