### PR TITLE
[sktest] Improve failure output.

### DIFF
--- a/sktest/src/expectations.sk
+++ b/sktest/src/expectations.sk
@@ -9,12 +9,7 @@ class ExpectationError(
   actual: String,
 ) extends Exception {
   fun getMessage(): String {
-    "ExpectationError: " +
-      this.msg +
-      "\n expected: " +
-      this.expected +
-      "\n actual: " +
-      this.actual
+    this.msg + "\n\texpected: " + this.expected + "\n\tactual: " + this.actual
   }
 }
 

--- a/sktest/src/harness.sk
+++ b/sktest/src/harness.sk
@@ -14,12 +14,12 @@ fun run_test(test: Test, res: TestResult): TestResult {
     _ = test.func();
     res with {result => "success", time => time() - start}
   } catch {
-  | ExpectationError(msg, _, _) ->
+  | exn @ ExpectationError _ ->
     res with {
       result => "failure",
       time => time() - start,
       failure_type => "ExpectationError",
-      failure_message => msg,
+      failure_message => exn.getMessage(),
     }
   | exn ->
     res with {


### PR DESCRIPTION
Before:
```
[FAILURE] FooTests foo
ExpectationError: expected equality
```

After:
```
[FAILURE] FooTests foo
ExpectationError: expected equality
        expected: 2
        actual: 1
```