### PR TITLE
[skc] Fix `Could not open file` in `catchErrors()`.

### DIFF
--- a/compiler/src/skipError.sk
+++ b/compiler/src/skipError.sk
@@ -91,8 +91,12 @@ fun throwFlattenedErrors(errors: Vector<Vector<Error>>): void {
 
 fun printErrorsAndExit<T>(
   errors: Array<SkipErrorException>,
-  get_file: String -> (String, String) = filename ->
-    (filename, FileSystem.readTextFile(filename)),
+  get_file: String -> (String, String) = filename -> {
+    if (filename.contains(":")) {
+      !filename = filename.splitFirst(":").i1
+    };
+    (filename, FileSystem.readTextFile(filename))
+  },
 ): T {
   SkipError.printErrors(
     errors.map(x -> x.errors).flatten().collect(Vector),


### PR DESCRIPTION
Fixes #198.