### PR TITLE
[test] Fix incorrect size of SKIP_utf8_test_string

### DIFF
--- a/prelude/runtime/string.c
+++ b/prelude/runtime/string.c
@@ -359,8 +359,7 @@ static unsigned int test_utf8_data[] = {
     157, 153, 137, 224, 167, 166, 206, 161, 240, 157, 151, 164, 201,
     140, 240, 157, 147, 162, 200, 154, 208, 166, 240, 157, 146, 177};
 
-static unsigned char
-    string_utf8_buffer[sizeof(test_utf8_data) / sizeof(int) + 1];
+static unsigned char string_utf8_buffer[sizeof(test_utf8_data) / sizeof(int)];
 
 char* SKIP_utf8_test_string() {
   unsigned int i;

--- a/prelude/tests/skfs/TestString.sk
+++ b/prelude/tests/skfs/TestString.sk
@@ -21,8 +21,8 @@ fun testString(): void {
   T.expectEq(str, sub2, "Compare strings sub");
   T.expectEq(str.hash(), sub2.hash(), "Compare hashes sub");
   T.expectEq("3", str.substring(iter.forward(2)), "Compare sub");
-  T.expectEq(utf8.length(), 24, "Utf8 length");
-  T.expectEq(String.byteSize(utf8), UInt32::truncate(66), "Utf8 byteSize");
+  T.expectEq(utf8.length(), 23, "Utf8 length");
+  T.expectEq(String.byteSize(utf8), UInt32::truncate(65), "Utf8 byteSize");
   T.expectEq(
     utf8,
     String::fromChars(utf8.chars().toArray()),


### PR DESCRIPTION
This bug is only triggered if string.c is compiled with -O0.