### PR TITLE
Rework can-mirror to locally check schemas and fail fast

### DIFF
--- a/sql/src/Main.sk
+++ b/sql/src/Main.sk
@@ -281,8 +281,15 @@ untracked fun main(): void {
     )
     .subcommand(
       Cli.Command("can-mirror")
-        .about("Check that a table is eligible for mirroring")
-        .arg(Cli.StringArg("table").positional().required().about("Table name"))
+        .about(
+          "Check that a table is eligible for mirroring under a given schema",
+        )
+        .arg(
+          Cli.StringArg("table")
+            .positional()
+            .required()
+            .about("Table signature of remote to mirror"),
+        )
         .arg(
           Cli.StringArg("schema")
             .positional()
@@ -718,14 +725,10 @@ fun execSubscribe(args: Cli.ParseResults, options: SKDB.Options): void {
 
 fun execCanMirror(args: Cli.ParseResults, options: SKDB.Options): void {
   ensureContext(args);
-  tableName = args.getString("table");
+  table = args.getString("table");
   schema = args.getString("schema");
   SKDB.runSql(options, context ~> {
-    SKCSV.reasonSchemaUnsupported(
-      context,
-      tableName.lowercase(),
-      schema.lowercase(),
-    ) match {
+    SKCSV.reasonSchemaUnsupported(context, table, schema.lowercase()) match {
     | None() -> void
     | Some(reason) -> print_string(reason)
     };

--- a/sql/src/SqlCsv.sk
+++ b/sql/src/SqlCsv.sk
@@ -162,60 +162,68 @@ fun parseCSVValue(kv: (Bool, String)): P.Value {
 
 fun reasonSchemaUnsupported(
   origContext: readonly SKStore.Context,
-  tableName: String,
-  schema: String,
+  table: String,
+  schemaStr: String,
 ): ?String {
   context = SKStore.Context::fromSaved(origContext.clone());
-  SKDB.getTableDir(context).maybeGet(context, SKStore.SID(tableName)) match {
-  | None() -> Some(`Table '${tableName}' does not exist.`)
-  | Some(dirDescr) ->
-    if (dirDescr.schema.any(x ~> x.unique is Some _)) {
-      return Some("Cannot mirror tables with unique constraints.")
-    };
-    dirDescr.cols.maybeGet(SKDB.skdbAccessColName) match {
-    | Some _ -> void
+
+  (tableName, actualSchema) = P.Parser::create(table).parseCreate() match {
+  | P.CreateTableSchema{name, schema} ->
+    (SKStore.SID(name.lower), schema.columns)
+  | _ -> return Some("Malformed create-table statement given.")
+  };
+
+  if (SKDB.getTableDir(context).maybeGet(context, tableName) is None()) {
+    return Some(`Table '${tableName}' does not exist.`)
+  };
+
+  if (actualSchema.any(x ~> x.unique is Some _)) {
+    return Some("Cannot mirror tables with unique constraints.")
+  };
+
+  if (actualSchema.all(x ~> x.name != SKDB.skdbAccessColName)) {
+    return Some(
+      `Cannot mirror tables without ${SKDB.skdbAccessColName.origName} column.`,
+    )
+  };
+
+  if (schemaStr != "*") {
+    try {
+      Some(P.Parser::create(schemaStr).parseCreateTableSchema().columns)
+    } catch {
+    | _exn -> None()
+    } match {
     | None() ->
       return Some(
-        `Cannot mirror tables without ${
-          SKDB.skdbAccessColName.origName
-        } column.`,
+        "Malformed schema: expects parenthesized column-separated list of column definitions.",
       )
-    };
+    | Some(requestedSchema) ->
+      for (col in requestedSchema) {
+        if (!actualSchema.contains(col)) {
+          return Some(
+            `Incompatible schema: unknown or incorrectly-defined column ${
+              col.name
+            }`,
+          )
+        }
+      };
 
-    if (schema != "*") {
-      try {
-        Some(P.Parser::create(schema).parseCreateTableSchema().columns)
-      } catch {
-      | _exn -> None()
-      } match {
-      | None() ->
-        return Some(
-          "Malformed schema: expects parenthesized column-separated list of column definitions.",
-        )
-      | Some(requestedSchema) ->
-        actualSchema = dirDescr.schema;
-
-        for (col in requestedSchema) {
-          if (!actualSchema.contains(col)) {
-            return Some(`Incompatible schema: unknown column ${col.name}`)
-          }
-        };
-
-        for (col in actualSchema) {
-          if (
-            col.notNull is Some _ &&
-            col.default is None _ &&
-            !requestedSchema.contains(col)
-          ) {
-            return Some(
-              `Incompatible schema: missing required column ${col.name}`,
-            )
-          }
+      for (col in actualSchema) {
+        if (
+          col.notNull is Some _ &&
+          col.default is None _ &&
+          !requestedSchema.contains(col)
+        ) {
+          return Some(
+            `Incompatible schema unsupported: missing required column ${
+              col.name
+            }`,
+          )
         }
       }
-    };
-    None()
+    }
   };
+  None()
 }
 
 // How to produce a value for a given column in translateFromSourceSchema:

--- a/sql/ts/src/skdb_database.ts
+++ b/sql/ts/src/skdb_database.ts
@@ -27,7 +27,7 @@ class SKDBMechanismImpl implements SKDBMechanism {
     session: string,
     watermarks: Map<string, bigint>,
   ) => ArrayBuffer | null;
-  assertCanBeMirrored: (tableName: string, schema: string) => void;
+  assertCanBeMirrored: (table: string, schema: string) => void;
   tableExists: (tableName: string) => boolean;
   exec: (query: string) => SKDBTable;
   toggleView: (tableName: string) => void;
@@ -40,8 +40,8 @@ class SKDBMechanismImpl implements SKDBMechanism {
     this.tableExists = (tableName: string) =>
       client.tableSchema(tableName) != "";
     this.exec = (query: string) => client.exec(query);
-    this.assertCanBeMirrored = (tableName: string, schema: string) =>
-      client.assertCanBeMirrored(tableName, schema);
+    this.assertCanBeMirrored = (table: string, schema: string) =>
+      client.assertCanBeMirrored(table, schema);
     this.watermark = (replicationId: string, table: string) => {
       return BigInt(
         client.runLocal(["watermark", "--source", replicationId, table], ""),
@@ -358,8 +358,8 @@ export class SKDBSyncImpl implements SKDBSync {
     return valueIndex;
   };
 
-  assertCanBeMirrored(tableName: string, schema: string): void {
-    const error = this.runLocal(["can-mirror", tableName, schema], "");
+  assertCanBeMirrored(table: string, schema: string): void {
+    const error = this.runLocal(["can-mirror", table, schema], "");
     if (error === "") {
       return;
     }

--- a/sql/ts/src/skdb_types.ts
+++ b/sql/ts/src/skdb_types.ts
@@ -125,7 +125,7 @@ export interface SKDBMechanism {
   ) => ArrayBuffer | null;
   tableExists: (tableName: string) => boolean;
   exec: (query: string) => SKDBTable;
-  assertCanBeMirrored: (tableName: string, schema: string) => void;
+  assertCanBeMirrored: (table: string, schema: string) => void;
   toggleView: (tableName: string) => void;
 }
 


### PR DESCRIPTION
`can-mirror` now explicitly compares a remote table/schema against the provided schema, instead of relying on the existing local table's schema.

The previous behavior delayed/obscured failure in some cases, causing the client to hang since failures were happening on the remote.  Now, there should be a local error if a user attempts to mirror a table with an incorrect or incompatible schema.