### PR TITLE
[runtime] Use `mmap()` even in non-persistent mode.

### DIFF
--- a/prelude/runtime/memory.c
+++ b/prelude/runtime/memory.c
@@ -179,8 +179,6 @@ void* sk_malloc(size_t size) {
     SKIP_throw_cruntime(ERROR_OUT_OF_MEMORY);
   }
 
-  sk_lower_static(result);
-
 #ifdef MEMORY_CHECK
   static size_t alloc_count = 0;
   if (sk_init_over) {

--- a/prelude/runtime/palloc.c
+++ b/prelude/runtime/palloc.c
@@ -57,6 +57,22 @@ uint64_t SKIP_genSym(uint64_t largerThan) {
 }
 
 /*****************************************************************************/
+/* The global information structure. */
+/*****************************************************************************/
+
+typedef struct ginfo {
+  void* ftable[FTABLE_SIZE];
+  void* context;
+  char* head;
+  char* end;
+  char* fileName;
+  char* break_ptr;
+  size_t total_palloc_size;
+} ginfo_t;
+
+ginfo_t* ginfo = NULL;
+
+/*****************************************************************************/
 /* Global locking. */
 /*****************************************************************************/
 
@@ -67,7 +83,7 @@ pthread_mutex_t* gmutex = (void*)1234;
 int sk_is_locked = 0;
 
 void sk_check_has_lock() {
-  if ((gmutex != NULL) && !sk_is_locked) {
+  if ((ginfo->fileName != NULL) && !sk_is_locked) {
     fprintf(stderr, "INTERNAL ERROR: unsafe operation\n");
     SKIP_throw_cruntime(ERROR_INTERNAL_LOCK);
   }
@@ -83,7 +99,7 @@ void sk_global_lock_init() {
 }
 
 void sk_global_lock() {
-  if (gmutex == NULL) {
+  if (ginfo->fileName == NULL) {
     return;
   }
 
@@ -106,7 +122,7 @@ void sk_global_lock() {
 }
 
 void sk_global_unlock() {
-  if (gmutex == NULL) {
+  if (ginfo->fileName == NULL) {
     return;
   }
 
@@ -212,22 +228,6 @@ int32_t SKIP_cond_timedwait(pthread_cond_t* x, pthread_mutex_t* y,
 int32_t SKIP_cond_broadcast(void* c) {
   return (int32_t)pthread_cond_broadcast(c);
 }
-
-/*****************************************************************************/
-/* The global information structure. */
-/*****************************************************************************/
-
-typedef struct ginfo {
-  void* ftable[FTABLE_SIZE];
-  void* context;
-  char* head;
-  char* end;
-  char* fileName;
-  char* break_ptr;
-  size_t total_palloc_size;
-} ginfo_t;
-
-ginfo_t* ginfo = NULL;
 
 /*****************************************************************************/
 /* Debugging support for contexts. Set CTX_TABLE to 1 to use. */

--- a/prelude/runtime/palloc.c
+++ b/prelude/runtime/palloc.c
@@ -582,13 +582,7 @@ void sk_load_mapping(char* fileName) {
 /*****************************************************************************/
 
 int sk_is_static(void* ptr) {
-  return (char*)ptr <= ginfo->break_ptr;
-}
-
-void sk_lower_static(void* ptr) {
-  if ((char*)ptr < ginfo->break_ptr) {
-    ginfo->break_ptr = ptr;
-  }
+  return !(ginfo->head <= (char*)ptr && (char*)ptr < ginfo->end);
 }
 
 /*****************************************************************************/

--- a/prelude/runtime/palloc.c
+++ b/prelude/runtime/palloc.c
@@ -458,17 +458,21 @@ struct file_mapping {
 /*****************************************************************************/
 
 void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
-  if (access(fileName, F_OK) == 0) {
+  if (fileName != NULL && access(fileName, F_OK) == 0) {
     fprintf(stderr, "ERROR: File %s already exists!\n", fileName);
     exit(ERROR_MAPPING_EXISTS);
   }
-  int fd = open(fileName, O_RDWR | O_CREAT, 0600);
-  lseek(fd, icapacity, SEEK_SET);
-  (void)write(fd, "", 1);
+  file_mapping_t* mapping;
   int prot = PROT_READ | PROT_WRITE;
-  file_mapping_t* mapping =
-      mmap(BOTTOM_ADDR, icapacity, prot, MAP_SHARED | MAP_FIXED, fd, 0);
-  close(fd);
+  if (fileName == NULL) {
+    mapping = mmap(NULL, icapacity, prot, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  } else {
+    int fd = open(fileName, O_RDWR | O_CREAT, 0600);
+    lseek(fd, icapacity, SEEK_SET);
+    (void)write(fd, "", 1);
+    mapping = mmap(BOTTOM_ADDR, icapacity, prot, MAP_SHARED | MAP_FIXED, fd, 0);
+    close(fd);
+  }
 
   if (mapping == MAP_FAILED) {
     perror("ERROR (MAP FAILED)");
@@ -485,7 +489,7 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   capacity = &mapping->capacity;
   pconsts = &mapping->pconsts;
 
-  size_t fileName_length = strlen(fileName) + 1;
+  size_t fileName_length = (fileName != NULL) ? strlen(fileName) + 1 : 0;
   char* persistent_fileName = mapping->persistent_fileName;
 
   char* head = persistent_fileName + fileName_length;
@@ -496,7 +500,11 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
     exit(ERROR_MAPPING_MEMORY);
   }
 
-  memcpy(persistent_fileName, fileName, fileName_length);
+  if (fileName != NULL) {
+    memcpy(persistent_fileName, fileName, fileName_length);
+  } else {
+    persistent_fileName = "";
+  }
 
   int i;
   for (i = 0; i < FTABLE_SIZE; i++) {
@@ -511,7 +519,7 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
 
   ginfo->head = head;
   ginfo->end = end;
-  ginfo->fileName = persistent_fileName;
+  ginfo->fileName = (fileName != NULL) ? persistent_fileName : NULL;
   ginfo->context = NULL;
   *gid = 1;
   if (icapacity != DEFAULT_CAPACITY) {
@@ -520,7 +528,9 @@ void sk_create_mapping(char* fileName, char* static_limit, size_t icapacity) {
   *capacity = icapacity;
   *pconsts = NULL;
 
-  sk_global_lock_init();
+  if (ginfo->fileName != NULL) {
+    sk_global_lock_init();
+  }
 }
 
 /*****************************************************************************/
@@ -621,6 +631,7 @@ typedef struct {
   void** pconsts;
 } no_file_t;
 
+#ifdef __APPLE__
 static void sk_init_no_file(char* static_limit) {
   no_file_t* no_file = malloc(sizeof(no_file_t));
   if (no_file == NULL) {
@@ -638,6 +649,7 @@ static void sk_init_no_file(char* static_limit) {
   *gid = 1;
   *pconsts = NULL;
 }
+#endif
 
 int sk_is_nofile_mode() {
   return (ginfo->fileName == NULL);
@@ -666,9 +678,7 @@ void SKIP_memory_init(int argc, char** argv) {
   sk_init_no_file(program_break);
 
 #else   // __APPLE__
-  if (fileName == NULL) {
-    sk_init_no_file(program_break);
-  } else if (is_create) {
+  if (is_create || fileName == NULL) {
     size_t capacity = DEFAULT_CAPACITY;
     capacity = parse_capacity(argc, argv);
     sk_create_mapping(fileName, program_break, capacity);
@@ -690,14 +700,6 @@ void SKIP_print_persistent_size() {
 }
 
 void* sk_palloc(size_t size) {
-  if (ginfo->fileName == NULL) {
-    void* result = malloc(size);
-    if (result == NULL) {
-      perror("malloc");
-      exit(1);
-    }
-    return result;
-  }
   sk_check_has_lock();
   size = sk_pow2_size(size);
   ginfo->total_palloc_size += size;
@@ -715,10 +717,6 @@ void* sk_palloc(size_t size) {
 }
 
 void sk_pfree_size(void* chunk, size_t size) {
-  if (ginfo->fileName == NULL) {
-    free(chunk);
-    return;
-  }
   sk_check_has_lock();
   size = sk_pow2_size(size);
   ginfo->total_palloc_size -= size;

--- a/prelude/runtime/runtime.h
+++ b/prelude/runtime/runtime.h
@@ -379,7 +379,6 @@ uint32_t sk_get_external_pointer_value(char* obj);
 uint32_t sk_get_magic_number(char* obj);
 void sk_call_external_pointer_destructor(char*, uint32_t);
 int sk_is_nofile_mode();
-void sk_lower_static(void*);
 void sk_check_has_lock();
 void sk_free_obj(sk_stack_t* st, char* obj);
 void sk_free_external_pointers();

--- a/prelude/runtime/runtime64_specific.cpp
+++ b/prelude/runtime/runtime64_specific.cpp
@@ -269,11 +269,6 @@ void SKIP_unsetenv(char* name) {
 
 void SKIP_memory_init(int pargc, char** pargv);
 void sk_persist_consts();
-extern void* program_break;
-
-void __attribute__((constructor)) premain() {
-  program_break = sbrk(0);
-}
 
 int main(int pargc, char** pargv) {
   sk_saved_obstack_t* saved;


### PR DESCRIPTION
This PR homogenizes the memory allocators between persistent and non-persistent modes. 