### PR TITLE
[runtime][build] Obey specified OLEVEL when PROFILE missing

### DIFF
--- a/prelude/Makefile
+++ b/prelude/Makefile
@@ -4,17 +4,15 @@ LIB_DIR?=/usr/local/lib
 ifdef PROFILE
 PRFDEF=$(shell echo $(PROFILE) | tr  '[:lower:]' '[:upper:]')
 ifeq ($(PRFDEF),RELEASE)
-CFLAGS += -O3
+OLEVEL = -O3
 else
 ifeq ($(PRFDEF),DEBUG)
-CFLAGS += -O0
-else
-CFLAGS += -O2
+OLEVEL = -O0
 endif # ifeq ($(PRFDEF),DEBUG)
 endif # ifeq ($(PRFDEF),RELEASE)
-else
-CFLAGS += -O2 -g3
 endif # ifdef PROFILE
+OLEVEL ?= -O2
+CFLAGS += $(OLEVEL) -g3
 
 LBT_EXISTS=$(shell [ -e $(LIB_DIR)/libbacktrace.a ] && echo 1 || echo 0 )
 

--- a/prelude/runtime/Makefile
+++ b/prelude/runtime/Makefile
@@ -50,10 +50,10 @@ libskip_runtime64.a: $(OFILES) runtime64_specific.o $(ONATIVE_FILES)
 	$(AR) rcs $@ $^
 
 runtime64_specific.o: runtime64_specific.cpp
-	clang++ -std=c++11 $(CC64FLAGS) -g3 -o $@ -c $<
+	clang++ -std=c++11 $(CC64FLAGS) -o $@ -c $<
 
 %.o: %.c
-	clang $(CC64FLAGS) -g3 -o $@ -c $<
+	clang $(CC64FLAGS) -o $@ -c $<
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
and remove duplicate `-g3` flags.