### PR TITLE
[build] Add a target to skargo check everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,14 @@ build/init.sql: sql/privacy/init.sql
 # dev workflow orchestration
 ################################################################################
 
+CHECK_TARGETS=$(patsubst %/Skargo.toml,check-%,$(shell ls -1 */Skargo.toml))
+
+check-%:
+	cd $* && skargo check
+
+.PHONY: check
+check: $(CHECK_TARGETS)
+
 .PHONY: clean
 clean:
 	rm -Rf build


### PR DESCRIPTION
Since skargo check does not chase reverse dependencies a local skargo
check can fail to uncover issues in other directories. This PR adds a
target to skargo check everything.