### PR TITLE
Expose SKDBTransaction

### DIFF
--- a/sql/ts/src/skdb.ts
+++ b/sql/ts/src/skdb.ts
@@ -4,9 +4,10 @@ import type { Wrk, ModuleInit } from "#std/sk_types.js";
 import type { SKDB, SKDBSync, SKDBShared } from "./skdb_types.js";
 import { SKDBWorker } from "./skdb_wdatabase.js";
 export { SKDBTable } from "./skdb_util.js";
-export type { SKDB, RemoteSKDB } from "./skdb_types.js";
+export type { SKDB, RemoteSKDB, MirrorDefn, SKDBGroup } from "./skdb_types.js";
 export type { Creds, MuxedSocket } from "./skdb_orchestration.js";
 export type { Environment } from "#std/sk_types.js";
+export { SKDBTransaction } from "./skdb_util.js";
 import { getWasmUrl } from "./skdb_wasm_locator.js";
 
 var modules: ModuleInit[];


### PR DESCRIPTION
This was missing so effectively unusable by downstream apps.

Also, while here, expose types for MirrorDefn and SKDBGroup in case
users wish to pass these around.