### PR TITLE
Disable warnings properly in SKDB Workers

### DIFF
--- a/sql/ts/src/skdb.ts
+++ b/sql/ts/src/skdb.ts
@@ -72,7 +72,8 @@ async function createWorker(disableWarnings: boolean, dbName?: string) {
     });
     worker = env.createWorkerWrapper(wrapped);
   }
+
   let skdb = new SKDBWorker(worker);
-  await skdb.create(dbName);
+  await skdb.create(dbName, disableWarnings);
   return skdb;
 }

--- a/sql/ts/src/skdb_wdatabase.ts
+++ b/sql/ts/src/skdb_wdatabase.ts
@@ -99,8 +99,13 @@ export class SKDBWorker implements SKDB {
     this.worker = new PromiseWorker(worker);
   }
 
-  create = async (dbName?: string): Promise<void> => {
-    return this.worker.post(new Function("create", [dbName])).send();
+  create = async (
+    dbName?: string,
+    disableWarnings: boolean = false,
+  ): Promise<void> => {
+    return this.worker
+      .post(new Function("create", [dbName, disableWarnings]))
+      .send();
   };
 
   exec = async (query: string, params: Params = new Map()) => {

--- a/sql/ts/src/skdb_wmessage.ts
+++ b/sql/ts/src/skdb_wmessage.ts
@@ -12,9 +12,10 @@ class DbCreator implements Creator<SKDB> {
     return "Database";
   }
 
-  create(dnName: string) {
+  create(dbName: string, disableWarnings: boolean) {
     return createSkdb({
-      dbName: dnName,
+      dbName,
+      disableWarnings,
       asWorker: false,
     });
   }


### PR DESCRIPTION
Previously, SKDB workers created with `createWorker` weren't being initialized with the specified `disableWarnings` option, resulting in warnings being printed during `make test-wasm`'s API tests.