### PR TITLE
[sql] Extend privacy model with explicit group ownership

### DIFF
--- a/sql/privacy/init.sql
+++ b/sql/privacy/init.sql
@@ -21,13 +21,15 @@ CREATE TABLE skdb_user_permissions(
 
 -- groupID: which group are we talking about?
 -- skdb_author: who is the creator of the group?
--- adminID: who should be able to be admin of the group?
--- skdb_access: who should be able to see/modify the administrators
+-- adminID: who should be able to change permissions for the group
+-- ownerID: who should be able to delete the group and override admins
+-- skdb_access: who should be able to see the group
 
 CREATE TABLE skdb_groups(
   groupID TEXT PRIMARY KEY,
   skdb_author TEXT,
   adminID TEXT NOT NULL,
+  ownerID TEXT NOT NULL,
   skdb_access TEXT NOT NULL
 );
 
@@ -57,9 +59,9 @@ CREATE UNIQUE INDEX skdb_groups_users_unique ON skdb_groups_users(groupID);
 -------------------------------------------------------------------------------
 
 INSERT INTO skdb_groups VALUES
-  ('read-only', NULL, 'root', 'read-only'),
-  ('read-write', NULL, 'root', 'read-only'),
-  ('write-only', NULL, 'root', 'read-only')
+  ('read-only', NULL, 'root', 'root', 'read-only'),
+  ('read-write', NULL, 'root', 'root', 'read-only'),
+  ('write-only', NULL, 'root', 'root', 'read-only')
 ;
 
 INSERT INTO skdb_group_permissions VALUES

--- a/sql/src/SqlPrivacy.sk
+++ b/sql/src/SqlPrivacy.sk
@@ -53,6 +53,7 @@ const skdbAccessColName: P.Name = P.Name::create("skdb_access");
 const groupIDColName: P.Name = P.Name::create("groupID");
 const userIDColName: P.Name = P.Name::create("userID");
 const adminIDColName: P.Name = P.Name::create("adminID");
+const ownerIDColName: P.Name = P.Name::create("ownerID");
 const permissionsColName: P.Name = P.Name::create("permissions");
 
 /*****************************************************************************/
@@ -460,6 +461,17 @@ fun checkUserCanReadRow(
   row: RowValues,
 ): AccessResult {
   access = AccessSolver::create(context, user.name);
+
+  // Owners can always see their own groups
+  if (table.name == SKDBGroups::name) {
+    ownerGroupID = row.getValue(skdbGroups.getColNbr(ownerIDColName)) match {
+    | Some(CString(id)) -> id
+    | _ -> throw SqlError(0, "ownerID is a non-null string in skdb_groups")
+    };
+    if (access.canRead(context, ownerGroupID)) return AROK()
+  };
+
+  // Users can always see permissions that affect them or they have admin rights over
   if (table.name == SKDBGroupPermissions::name) {
     groupID = row.getValue(
       skdbGroupPermissions.getColNbr(groupIDColName),
@@ -493,15 +505,18 @@ fun checkUserCanReadRow(
       | Some(CString(userID)) if (userID == user.name) -> return AROK()
       | _ ->
         groupIndex = skdbGroups.getIndex(context);
-        adminID = groupIndex.get(skdbGroups.makeKey(groupID)) match {
-        | Some(r) -> r.getString(adminIDColName)
+        (adminID, ownerID) = groupIndex.get(skdbGroups.makeKey(groupID)) match {
+        | Some(r) -> (r.getString(adminIDColName), r.getString(ownerIDColName))
         | None() ->
           throw SqlError(
             0,
             "malformed predefined table skdb_groups while checking read",
           )
         };
-        if (access.canRead(context, adminID)) {
+        if (
+          access.canRead(context, adminID) ||
+          access.canRead(context, ownerID)
+        ) {
           return AROK();
         } else {
           return ARError(ARENotAdmin{userID => user.name, groupID => groupID})

--- a/sql/src/SqlPrivacy.sk
+++ b/sql/src/SqlPrivacy.sk
@@ -600,8 +600,15 @@ fun checkUserCanWriteRow(
       groupIndex.get(skdbGroups.makeKey(groupID)) match {
       | Some(r) ->
         adminID = r.getString(adminIDColName);
-        (row.repeat == 0 && access.canDelete(context, adminID)) ||
-          access.canInsert(context, adminID)
+        ownerID = r.getString(ownerIDColName);
+        if (row.repeat == 0) {
+          access.canDelete(context, adminID) ||
+            access.canDelete(context, ownerID)
+        } else {
+          access.canInsert(context, adminID) ||
+            access.canInsert(context, ownerID)
+        }
+
       | None() -> return AROK()
       };
     };

--- a/sql/src/SqlPrivacy.sk
+++ b/sql/src/SqlPrivacy.sk
@@ -337,6 +337,7 @@ class SKDBGroups extends PredefinedTable {
   groupID TEXT PRIMARY KEY,
   skdb_author TEXT,
   adminID TEXT NOT NULL,
+  ownerID TEXT NOT NULL,
   skdb_access TEXT NOT NULL
   )`;
 

--- a/sql/src/SqlPrivacy.sk
+++ b/sql/src/SqlPrivacy.sk
@@ -395,6 +395,7 @@ base class AccessResultError{userID: String} uses Show {
   | ARENullAuthor{}
   | AREWrongAuthor{foundUserName: String}
   | AREWrongAuthorType{}
+  | ARENotOwner{groupID: String}
   | ARENotAdmin{groupID: String}
   | ARECannotDelete{groupID: String}
   | ARECannotInsert{groupID: String}
@@ -428,6 +429,8 @@ base class AccessResultError{userID: String} uses Show {
       " (user " +
       this.userID +
       ")"
+  | ARENotOwner{groupID} ->
+    "not an owner of group " + groupID + " (user " + this.userID + ")"
   | ARECannotDelete{groupID} ->
     "cannot delete with skdb_access set to " +
       groupID +
@@ -564,6 +567,22 @@ fun checkUserCanWriteRow(
   groupIdxOption: ?Int,
   row: RowValues,
 ): AccessResult {
+  if (tableName.lowercase() == SKDBGroups::name.lower) {
+    ownerIDIdx = skdbGroups.getColNbr(ownerIDColName);
+    ownerID = row.getValue(ownerIDIdx) match {
+    | Some(CString(id)) -> id
+    | _ -> throw SqlError(0, "ownerID is a non-null string in skdb_groups")
+    };
+    if (row.repeat == 0 && !access.canDelete(context, ownerID)) {
+      groupIDIdx = skdbGroups.getColNbr(groupIDColName);
+      groupID = row.getValue(groupIDIdx) match {
+      | Some(CString(id)) -> id
+      | _ -> throw SqlError(0, "groupID is a non-null string in skdb_groups")
+      };
+      return ARError(ARENotOwner{userID => access.userID, groupID})
+    }
+  };
+
   if (tableName.lowercase() == SKDBGroupPermissions::name.lower) {
     // Check that only group admins can insert/delete rows
     // to SKDBGroupPermissions for that group

--- a/sql/test_cyclic_replication.sh
+++ b/sql/test_cyclic_replication.sh
@@ -24,7 +24,7 @@ setup_server() {
     echo "INSERT INTO skdb_users VALUES('test_user', 'pass');" | $SKDB
     echo "INSERT INTO skdb_users VALUES('test_alt_user', 'pass');" | $SKDB
 
-    echo "INSERT INTO skdb_groups VALUES ('G2', NULL, 'root', 'root');" | $SKDB
+    echo "INSERT INTO skdb_groups VALUES ('G2', NULL, 'root', 'root', 'root');" | $SKDB
     echo "INSERT INTO skdb_group_permissions VALUES ('G2', 'test_alt_user', 7, 'root');" | $SKDB
 
     echo "CREATE TABLE test (id INTEGER, note TEXT, skdb_access TEXT);" | $SKDB

--- a/sql/test_privacy.sh
+++ b/sql/test_privacy.sh
@@ -43,7 +43,7 @@ done | $SKDB
 ###############################################################################
 
 # We need a group that doesn't restrict anyone.
-echo "insert into skdb_groups values('myGroup', NULL, 'root', 'root');" | $SKDB
+echo "insert into skdb_groups values('myGroup', NULL, 'root', 'root', 'root');" | $SKDB
 echo "insert into skdb_group_permissions values ('myGroup', NULL, skdb_permission('rid'), 'root');" | $SKDB
 
 # Let's check that user permissions are respected
@@ -81,7 +81,7 @@ fi
 
 # Let's create a group
 # user1 can write, all the others can only read
-echo "insert into skdb_groups values('ID22', NULL, 'root', 'root');" | $SKDB
+echo "insert into skdb_groups values('ID22', NULL, 'root', 'root', 'root');" | $SKDB
 echo "insert into skdb_group_permissions values ('ID22', 'ID1', skdb_permission('rw'), 'root');" | $SKDB
 echo "insert into skdb_group_permissions values ('ID22', 'ID2', skdb_permission('r'), 'root');" | $SKDB
 echo "insert into skdb_group_permissions values ('ID22', 'ID3', skdb_permission('r'), 'root');" | $SKDB
@@ -149,7 +149,7 @@ fi
 
 # Let's create a block list
 # Everybody can read/insert/delete, except for user1 who can only read
-echo "insert into skdb_groups values('ID23', NULL, 'root', 'root');" | $SKDB
+echo "insert into skdb_groups values('ID23', NULL, 'root', 'root', 'root');" | $SKDB
 echo "insert into skdb_group_permissions values ('ID23', 'ID1', skdb_permission('r'), 'root');" | $SKDB
 echo "insert into skdb_group_permissions values ('ID23', NULL, skdb_permission('rw'), 'root');" | $SKDB
 echo "insert into skdb_user_permissions values ('ID2', skdb_permission('ri'), 'root');" | $SKDB
@@ -209,7 +209,7 @@ echo "insert into skdb_users VALUES ('julienv', 'pass');" | $SKDB
 echo "insert into skdb_users VALUES ('daniell', 'pass');" | $SKDB
 
 # Prepare a group with only one member, julienv
-echo -e "^skdb_groups\n1\t\"myAdminGroup\", \"julienv\",\"julienv\", \"julienv\"\n:1" |
+echo -e "^skdb_groups\n1\t\"myAdminGroup\", \"julienv\", \"julienv\", \"julienv\", \"julienv\"\n:1" |
   $SKDB write-csv --user julienv --source 1234 > /dev/null
 echo -e "^skdb_group_permissions\n1\t\"myAdminGroup\", \"julienv\",7, \"julienv\"\n:2" |
   $SKDB write-csv --user julienv --source 1234 > /dev/null
@@ -231,7 +231,7 @@ echo -e "^skdb_group_permissions\n1\t\"myAdminGroup\", \"julienv\",7, \"julienv\
 # happen in the same transaction, otherwise we would lose access after
 # the delete.
 (echo -e "^skdb_groups";
- echo -e "0\t\"myAdminGroup\", \"julienv\",\"julienv\", \"julienv\"";
+ echo -e "0\t\"myAdminGroup\", \"julienv\", \"julienv\", \"julienv\", \"julienv\"";
  echo -e "1\t\"myAdminGroup\", \"julienv\",\"myAdminGroup\", \"myAdminGroup\"\n:4") |
   $SKDB write-csv --user julienv --source 1234 > /dev/null
 

--- a/sql/test_privacy.sh
+++ b/sql/test_privacy.sh
@@ -232,7 +232,7 @@ echo -e "^skdb_group_permissions\n1\t\"myAdminGroup\", \"julienv\",7, \"julienv\
 # the delete.
 (echo -e "^skdb_groups";
  echo -e "0\t\"myAdminGroup\", \"julienv\", \"julienv\", \"julienv\", \"julienv\"";
- echo -e "1\t\"myAdminGroup\", \"julienv\",\"myAdminGroup\", \"myAdminGroup\"\n:4") |
+ echo -e "1\t\"myAdminGroup\", \"julienv\",\"myAdminGroup\", \"myAdminGroup\", \"myAdminGroup\"\n:4") |
   $SKDB write-csv --user julienv --source 1234 > /dev/null
 
 # We have successfully create a group that is controlled by

--- a/sql/test_replication_primary_key.sh
+++ b/sql/test_replication_primary_key.sh
@@ -1085,7 +1085,7 @@ test_user_privacy_control() {
     replicate_to_local skdb_groups test_user
     replicate_to_local skdb_group_permissions test_user
 
-    $SKDB_BIN --data $LOCAL_DB <<< "INSERT INTO skdb_groups VALUES('new_group', 'test_user', 'test_user','read-write');"
+    $SKDB_BIN --data $LOCAL_DB <<< "INSERT INTO skdb_groups VALUES('new_group', 'test_user', 'test_user', 'test_user', 'read-write');"
     $SKDB_BIN --data $LOCAL_DB <<< "INSERT INTO skdb_group_permissions VALUES('new_group', 'test_user', skdb_permission('rw'), 'read-write');"
     replicate_to_server test_user
 

--- a/sql/ts/src/skdb_database.ts
+++ b/sql/ts/src/skdb_database.ts
@@ -199,7 +199,7 @@ export class SKDBSyncImpl implements SKDBSync {
       {
         table: "skdb_groups",
         expectedColumns:
-          "(groupID TEXT PRIMARY KEY, skdb_author TEXT, adminID TEXT NOT NULL, skdb_access TEXT NOT NULL)",
+          "(groupID TEXT PRIMARY KEY, skdb_author TEXT, adminID TEXT NOT NULL, ownerID TEXT NOT NULL, skdb_access TEXT NOT NULL)",
       },
     );
     this.exec(
@@ -384,7 +384,7 @@ export class SKDBSyncImpl implements SKDBSync {
       {
         table: "skdb_groups",
         expectedColumns:
-          "(groupID TEXT PRIMARY KEY, skdb_author TEXT, adminID TEXT NOT NULL, skdb_access TEXT NOT NULL)",
+          "(groupID TEXT PRIMARY KEY, skdb_author TEXT, adminID TEXT NOT NULL, ownerID TEXT NOT NULL, skdb_access TEXT NOT NULL)",
       },
     ]) {
       if (!tables.some(is_mirror_def_of(metatable.table)))

--- a/sql/ts/src/skdb_group.ts
+++ b/sql/ts/src/skdb_group.ts
@@ -64,13 +64,13 @@ export class SKDBGroupImpl implements SKDBGroup {
         "INSERT INTO skdb_group_permissions VALUES (@groupID, @userID, skdb_permission('rw'), @adminGroupID);",
       )
       .add(
-        "INSERT INTO skdb_groups VALUES (@adminGroupID, @userID, @ownerGroupID, @adminGroupID);",
+        "INSERT INTO skdb_groups VALUES (@adminGroupID, @userID, @adminGroupID, @ownerGroupID, @adminGroupID);",
       )
       .add(
-        "INSERT INTO skdb_groups VALUES (@groupID, @userID, @adminGroupID, 'read-write')",
+        "INSERT INTO skdb_groups VALUES (@groupID, @userID, @adminGroupID, @ownerGroupID, 'read-write')",
       )
       .add(
-        "INSERT INTO skdb_groups VALUES (@ownerGroupID, @userID, @ownerGroupID, @ownerGroupID);",
+        "INSERT INTO skdb_groups VALUES (@ownerGroupID, @userID, @ownerGroupID, @ownerGroupID, @ownerGroupID);",
       )
       .commit({ groupID, adminGroupID, ownerGroupID, userID });
 

--- a/sql/ts/src/skdb_group.ts
+++ b/sql/ts/src/skdb_group.ts
@@ -47,10 +47,8 @@ export class SKDBGroupImpl implements SKDBGroup {
 
   static async create(skdb: SKDB): Promise<SKDBGroup> {
     const userID = skdb.currentUser!;
-
-    // First, create the primary group and get its auto-generated groupID
-    // (initially managed/accessed exclusively by userID, since we haven't created admin/owner groups yet)
     const groupID = (await skdb.exec("SELECT id()")).scalarValue();
+
     const group = new SKDBGroupImpl(skdb, groupID);
     const adminGroupID = group.adminGroupID;
     const ownerGroupID = group.ownerGroupID;

--- a/sql/ts/tests/apitests.ts
+++ b/sql/ts/tests/apitests.ts
@@ -702,7 +702,7 @@ async function testJSPrivacy(skdb: SKDB, skdb2: SKDB) {
   await skdb.mirror(test_pk, view_pk);
   await skdb2.mirror(test_pk_subset_schema, view_pk);
   await skdb.exec(
-    "INSERT INTO skdb_groups VALUES ('my_group', @uid, @uid, 'read-write');",
+    "INSERT INTO skdb_groups VALUES ('my_group', @uid, @uid, @uid, 'read-write');",
     { uid: skdb.currentUser },
   );
   await skdb.exec(


### PR DESCRIPTION
I was thinking through our group owner/admin model (looking at Greg's draft docs and some related conversations) and realized that the previous setup didn't really match up with my intuitions around application-level group ownership and administration.

Very open to discussion on this and aware that others might have different expectations or opinions on how these things should work!

## Background

Before this PR, an SKDB group specified a corresponding admin group and skdb_access; when a user created a group using the TS API, we set up three groups as follows

```
GROUP | ADMIN_GROUP | SKDB_ACCESS
---------------------------------
base  | admin       | read-write
admin | owner       | admin
owner | owner       | owner
```

That is, we have a globally-visible `base` group administered by an `admin` group, which is visible only to `admins` and itself administered by an `owner` group, which is administered by and visible only to itself.

This works, but doesn't line up perfectly with typical notions of admins/owners, namely in that:
* we can't enforce the property that only _owners_ can delete any of the three groups 
* admins are unable to add/remove other admins

## This PR

I think the simplest solution is to bake "ownership" into the model rather than encoding it with multiple "admin" relationships.

This PR does just that, adding an `owner` column to records in `skdb_groups` and enforcing that (1) owners have full admin privilege, regardless of their privileges in the admin group and (2) only owners can delete groups.

Now, when a user creates a group using the TS API, we set up the three groups as follows

```
GROUP | ADMIN_GROUP | OWNER_GROUP | SKDB_ACCESS
-----------------------------------------------
base  | admin       | owner       | read-write
admin | admin       | owner       | admin
owner | owner       | owner       | owner
```

Note that admins can now add/remove other admins.