### PR TITLE
Prompt for an NPM one-time-password when ready to publish in release script

### DIFF
--- a/bin/release_npm_skdb.sh
+++ b/bin/release_npm_skdb.sh
@@ -20,4 +20,12 @@ make build/sknpm
 
 make test-wasm
 
-(cd sql/ts && ../../build/sknpm publish --release)
+read -r -p "Enter 6-digit NPM 2FA code (or press enter to attempt publish without 2FA) " otp
+if [[ "$otp" =~ ^([0-9]{6})$ ]];
+then
+    echo "Publishing with OTP $otp"
+    (cd sql/ts && ../../build/sknpm publish --release -- --otp=$otp)
+else
+    echo "Publishing without OTP"
+    (cd sql/ts && ../../build/sknpm publish --release)
+fi


### PR DESCRIPTION
With 2fa enabled on an NPM account, you need to provide a one-time password to npm publish.  Since standard auth codes are valid only for 30 seconds, we wait until after building/testing before prompting for input.