### PR TITLE
VSCode extension for Skip basic language support

### DIFF
--- a/ide/skip/README
+++ b/ide/skip/README
@@ -1,0 +1,2 @@
+        Search for "SkipLang" on the extension marketplace
+        


### PR DESCRIPTION
Mostly done by @skiplabsdaniel 

Can be easily installed with a symbolic link to it in `~/.vscode/extensions`