### PR TITLE
Fix usage of parallel in Makefile and check_format.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,11 @@ clean:
 
 .PHONY: fmt-sk
 fmt-sk:
-	find . -path ./compiler/tests -not -prune -or -name \*.sk | parallel skfmt -i :::
+	find . -path ./compiler/tests -not -prune -or -name \*.sk | parallel skfmt -i {}
 
 .PHONY: fmt-c
 fmt-c:
-	find . -path ./prelude/libbacktrace -not -prune -or -path ./sql/test/TPC-h/tnt-tpch -not -prune -or -regex '.*\.[ch]\(pp\)*' | parallel clang-format -i :::
+	find . -path ./prelude/libbacktrace -not -prune -or -path ./sql/test/TPC-h/tnt-tpch -not -prune -or -regex '.*\.[ch]\(pp\)*' | parallel clang-format -i {}
 
 .PHONY: fmt-js
 fmt-js:

--- a/bin/git_hooks/check_format.sh
+++ b/bin/git_hooks/check_format.sh
@@ -31,4 +31,4 @@ check-file () {
 export -f check-file
 
 # get list of staged files and check them in parallel
-git diff-index --cached --name-only HEAD | parallel check-file :::
+git diff-index --cached --name-only HEAD | parallel check-file {}


### PR DESCRIPTION
`parallel command :::` expects arguments to follow `:::` (as used correctly in `test_date.sh`)

But it seems that older versions of `parallel` (such as 20210822) behaves as if `:::` is not here if no arguments follow, where as newer versions (such as 20231122) do not and just do nothing.
