### PR TITLE
[std] Support `cwd` in `Posix.Popen`.

### DIFF
--- a/prelude/src/stdlib/other/Posix.sk
+++ b/prelude/src/stdlib/other/Posix.sk
@@ -244,6 +244,7 @@ mutable class Popen(
     args: Array<String>,
     env: Map<String, String> = Map[],
     clear_env: Bool = false,
+    cwd: ?String = None(),
     stdin: Bool = false,
     stdout: Bool = false,
     stderr: Bool = false,
@@ -276,6 +277,13 @@ mutable class Popen(
       e.chill()
     };
     new_env = env.items().map(e -> `${e.i0}=${e.i1}`).collect(Array);
+
+    // NOTE: Since `posix_spawn()` does not provide a way for changing the
+    // working directory of the child process, we rely on GNU env.
+    cwd match {
+    | Some(path) -> !args = Array["env", "-C", path].concat(args)
+    | None() -> void
+    };
 
     p = spawnp(args, new_env, file_actions);
     file_actions.destroy();

--- a/prelude/src/stdlib/other/System.sk
+++ b/prelude/src/stdlib/other/System.sk
@@ -228,8 +228,16 @@ fun popen{
   clear_env: Bool = false,
   stdout: (String) -> void = _ -> void,
   stderr: (String) -> void = _ -> void,
+  cwd: ?String = None(),
 }: CompletedProcess {
-  p = Posix.Popen::create{args, env, clear_env, stdout => true, stderr => true};
+  p = Posix.Popen::create{
+    args,
+    env,
+    clear_env,
+    cwd,
+    stdout => true,
+    stderr => true,
+  };
   streams = Array[p.stdout.fromSome(), p.stderr.fromSome()];
   captured = Array[mutable Vector[], mutable Vector[]];
   handlers = Array[stdout, stderr];


### PR DESCRIPTION
This commit enables setting the child process' cwd when calling `Posix.Popen::create{}`/`System.popen{}`.