### PR TITLE
Fix: propagate updates when in a transaction

### DIFF
--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -1485,6 +1485,7 @@ class Evaluator{options: Options, user: ?UserFile} {
       error(pos, "OR REPLACE not supported in transactions")
     } else if (inTransaction) {
       this.insertTable(context, table, rows);
+      context.update();
       None()
     } else if (onConflict is Some(P.OCUpdate(_))) {
       onConflict match {

--- a/sql/unit_tests.sh
+++ b/sql/unit_tests.sh
@@ -138,7 +138,7 @@ else
     fail "LOCAL SEQUENCE NUMBER"
 fi
 
-if cat test/unit/test_seqnum2.sql | $SKDB | tr '\n' S | grep -q "9S16S22S29"; then
+if cat test/unit/test_seqnum2.sql | $SKDB | tr '\n' S | grep -q "9S17S24S32"; then
     pass "LOCAL SEQUENCE NUMBER 2"
 else
     fail "LOCAL SEQUENCE NUMBER 2"


### PR DESCRIPTION
I noticed that if tailing a reactive view built on a table I:

- do an insert in to the source table, the tail outputs the update instantly

- do the same insert wrapped in a transaction, it does not update
  until the condvar times out

Digging in, this seems to be because the context isn't update()d and
so the changed dir names do not include the view, so notify never
triggers the condvar.