### PR TITLE
[skfmt] Minor arg improvements

### DIFF
--- a/bin/git_hooks/check_format.sh
+++ b/bin/git_hooks/check_format.sh
@@ -9,7 +9,7 @@ check-file () {
     file=$1
     # select formatter based on filename extension, must transform stdin to stdout
     if [[ "$file" == *.sk ]]; then # keep in sync with fmt-sk in Makefile
-        fmt="skfmt"
+        fmt="skfmt --assume-filename=$file"
     elif [[ "$file" =~ .*\.[ch](pp)?$ ]]; then # keep in sync with fmt-c in Makefile
         fmt="clang-format --assume-filename=$file"
     elif [[ "$file" =~ .*\.(css|html|js|json|mjs|ts|tsx)$ ]]; then # keep in sync with .prettierignore

--- a/compiler/src/skfmt.sk
+++ b/compiler/src/skfmt.sk
@@ -42,6 +42,7 @@ untracked fun main(): void {
   filenames = args.getArray("files");
   for (file in filenames) {
     contents = if (file == "-") {
+      invariant(!inplace, "Cannot use both - and -i");
       !file = "<stdin>";
       buf = mutable Vector[];
       IO.stdin().read_to_end(buf) match {

--- a/compiler/src/skfmt.sk
+++ b/compiler/src/skfmt.sk
@@ -57,7 +57,12 @@ untracked fun main(): void {
     | Failure(error) ->
       print_error_ln(
         SkipError.errorsToString(Vector[error], filename ->
-          (filename, FileSystem.readTextFile(filename))
+          (
+            filename,
+            if (filename == file) contents else {
+              FileSystem.readTextFile(filename)
+            },
+          )
         ),
       );
       skipExit(1)

--- a/compiler/src/skfmt.sk
+++ b/compiler/src/skfmt.sk
@@ -35,11 +35,17 @@ untracked fun main(): void {
         .short("i")
         .about("Inplace edit file(s), if specified"),
     )
+    .arg(
+      Cli.Arg::string("assume-filename")
+        .value_name("FILENAME")
+        .about("File name used to report errors on stdin"),
+    )
     .help()
     .parseArgs();
 
   inplace = args.getBool("inplace");
   filenames = args.getArray("files");
+  assumeFilename = args.maybeGetString("assume-filename");
   for (file in filenames) {
     contents = if (file == "-") {
       invariant(!inplace, "Cannot use both - and -i");
@@ -52,6 +58,10 @@ untracked fun main(): void {
         skipExit(1)
       }
     } else {
+      invariant(
+        assumeFilename == None(),
+        "Cannot use --assume-filename with real file names",
+      );
       FileSystem.readTextFile(file)
     };
     prettyPrint(contents, file) match {
@@ -59,7 +69,7 @@ untracked fun main(): void {
       print_error_ln(
         SkipError.errorsToString(Vector[error], filename ->
           (
-            filename,
+            assumeFilename.default(filename),
             if (filename == file) contents else {
               FileSystem.readTextFile(filename)
             },


### PR DESCRIPTION
I am plugging skfmt in a vscode extension. When formatting-on-save, I get both the filename and the buffer contents. I have to use `skfmt` with stdin because the new contents is not written yet.
- Though `skfmt` failed are reporting syntax errors on stdin. Here is a fix.
- I also want those errors to be reported with the correct filename, hence a new option to do it.