### PR TITLE
[sql] Fix bug resolving schemas with qualified select-star

### DIFF
--- a/sql/src/SqlCompile.sk
+++ b/sql/src/SqlCompile.sk
@@ -406,6 +406,7 @@ mutable class Compiler{
     );
 
     orderBy = this.compileOrderBy(
+      context,
       (select.core as P.SelectCoreQuery _).params,
       core.from,
       select.orderBy,
@@ -456,6 +457,7 @@ mutable class Compiler{
     | OFK_CSV() -> SKStore.OCSV(Range(0, core.params.size()).collect(Array))
     | OFK_Table() ->
       schema = static::getSchema(
+        context,
         (select.core as P.SelectCoreQuery _).params,
         core.from,
         core.params,
@@ -464,6 +466,7 @@ mutable class Compiler{
       SKStore.OTable(fieldNames)
     | OFK_JSON() ->
       schema = static::getSchema(
+        context,
         (select.core as P.SelectCoreQuery _).params,
         core.from,
         core.params,
@@ -473,6 +476,7 @@ mutable class Compiler{
     | OFK_SQL() -> SKStore.OSQL()
     | OFK_JS() ->
       schema = static::getSchema(
+        context,
         (select.core as P.SelectCoreQuery _).params,
         core.from,
         core.params,
@@ -701,6 +705,7 @@ mutable class Compiler{
       cselect = this.compileSelect(context, select, genSelectId(select), false);
       selectDir = evalSelect(context, cselect, None());
       static::getDirDescr(
+        context,
         (select.core as P.SelectCoreQuery _).params,
         cselect.from,
         cselect.params,
@@ -711,6 +716,7 @@ mutable class Compiler{
   }
 
   static fun getCols(
+    context: mutable SKStore.Context,
     params: Array<P.SelectResult>,
     from: Array<(DirDescr, ?Array<SKStore.KeyRange>)>,
   ): (SortedMap<P.Name, Int>, readonly Map<Int, P.Name>) {
@@ -745,7 +751,10 @@ mutable class Compiler{
         }
 
       | P.SelectStar(Some(tableName)) ->
-        dirDescr = origFromMap[tableName];
+        dirDescr = origFromMap.maybeGet(tableName) match {
+        | Some(x) -> x
+        | None() -> getTable(context, 0, tableName)
+        };
         for (tyName in dirDescr.colNames) {
           if (!cols.containsKey(tyName)) {
             !cols[tyName] = slot;
@@ -775,11 +784,12 @@ mutable class Compiler{
   }
 
   static fun getSchema(
+    context: mutable SKStore.Context,
     params: Array<P.SelectResult>,
     from: Array<(DirDescr, ?Array<SKStore.KeyRange>)>,
     cparams: Array<CGExpr>,
   ): Array<P.ColumnDefinition> {
-    (cols, invCols) = static::getCols(params, from);
+    (cols, invCols) = static::getCols(context, params, from);
     cparams.mapWithIndex((idx, param) -> {
       P.ColumnDefinition{
         name => invCols.maybeGet(idx) match {
@@ -796,6 +806,7 @@ mutable class Compiler{
   }
 
   static fun getDirDescr(
+    context: mutable SKStore.Context,
     params: Array<P.SelectResult>,
     from: Array<(DirDescr, ?Array<SKStore.KeyRange>)>,
     cparams: Array<CGExpr>,
@@ -803,7 +814,7 @@ mutable class Compiler{
     dirName: SKStore.DirName,
     view: Bool = false,
   ): DirDescr {
-    schema = static::getSchema(params, from, cparams);
+    schema = static::getSchema(context, params, from, cparams);
     DirDescr::create{
       name => selectId,
       schema,
@@ -952,6 +963,7 @@ mutable class Compiler{
   }
 
   mutable fun compileOrderBy(
+    context: mutable SKStore.Context,
     params: Array<P.SelectResult>,
     from: Array<(SKDB.DirDescr, ?Array<SKStore.KeyRange>)>,
     orderByOpt: ?Array<(P.Expr, P.IKind)>,
@@ -959,7 +971,7 @@ mutable class Compiler{
     orderByOpt match {
     | None() -> None()
     | Some(orderBy) ->
-      (cols, _) = static::getCols(params, from);
+      (cols, _) = static::getCols(context, params, from);
       Some(
         orderBy.map(kv -> {
           (order, kind) = kv;

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -559,7 +559,7 @@ class Evaluator{options: Options, user: ?UserFile} {
         true,
       );
 
-      (_, cols) = SKDB.Compiler::getCols(core.params, cselect.from);
+      (_, cols) = SKDB.Compiler::getCols(context, core.params, cselect.from);
 
       schema = cselect.params.mapWithIndex((idx, param) -> {
         P.ColumnDefinition{
@@ -1213,6 +1213,7 @@ class Evaluator{options: Options, user: ?UserFile} {
           dirName = SKStore.DirName::create("/" + viewName + "/");
           context.setWithSharedSubDirs(dirName);
           dirDescr = SKDB.Compiler::getDirDescr(
+            context,
             (selectAst.core as P.SelectCoreQuery _).params,
             cselect.from,
             cselect.params,
@@ -2354,6 +2355,7 @@ fun getReactiveQueryHandle(
           );
           selectDir = SKDB.evalSelect(context, cselect, None());
           schema = SKDB.Compiler::getSchema(
+            context,
             (selectAst.core as P.SelectCoreQuery _).params,
             cselect.from,
             cselect.params,

--- a/sql/src/SqlTables.sk
+++ b/sql/src/SqlTables.sk
@@ -409,6 +409,7 @@ private fun resetReactiveViews(
     _ = SKDB.evalSelect(context, newCSelect, None());
 
     dirDescr = SKDB.Compiler::getDirDescr(
+      context,
       (selectFile.select.core as P.SelectCoreQuery _).params,
       newCSelect.from,
       newCSelect.params,
@@ -600,6 +601,7 @@ fun getSubsDirs(
           selectDir = SKDB.evalSelect(context, cselect, None());
           edir = context.unsafeGetEagerDir(selectDir.dirName);
           dirDescr = Compiler::getDirDescr(
+            context,
             selectFile.sparams,
             cselect.from,
             cselect.params,
@@ -838,6 +840,7 @@ fun getTable(
       dirName = SKStore.DirName::create("/" + selectFile.cselect.id + "/");
       cselect = selectFile.cselect;
       dirDescr = SKDB.Compiler::getDirDescr(
+        context,
         selectFile.sparams,
         cselect.from,
         cselect.params,

--- a/sql/test/unit/test_qualified_select_star.sql
+++ b/sql/test/unit/test_qualified_select_star.sql
@@ -1,0 +1,9 @@
+create table t (x integer, id integer primary key);
+create table tt (y integer, id integer primary key);
+
+insert into t values (100,1);
+insert into tt values (42,1);
+
+select t.* from t inner join tt on t.id = tt.id;
+create reactive view vv as select t.* from t inner join tt on t.id = tt.id;
+select * from vv;

--- a/sql/unit_tests.sh
+++ b/sql/unit_tests.sh
@@ -351,3 +351,9 @@ if cat test/unit/test_alter_table_add_col.sql | $SKDB | tr '\n' 'S' | grep -q '1
 else
     fail "ALTER TABLE ADD COLUMN"
 fi
+
+if cat test/unit/test_qualified_select_star.sql| $SKDB --always-allow-joins | tr '\n' 'S' | grep -q '100|1S100|1S' ; then
+    pass "QUALIFIED SELECT-STAR"
+else
+    fail "QUALIFIED SELECT-STAR"
+fi


### PR DESCRIPTION
This fixes #240 -- turns out that the bug wasn't REPL-specific, but also applied to any reactive views that used a qualified select-star param, so was blocking the schema migration stuff I'm working on.  Sending this PR on its own as it was a pre-existing bug unrelated to that work.




