### PR TITLE
[runtime] Give static linkage to obstack globals.

### DIFF
--- a/prelude/runtime/obstack.c
+++ b/prelude/runtime/obstack.c
@@ -33,30 +33,25 @@
      -------------
 */
 
-// page: The beginning of the current obstack page
-// head: The current position in the page.
-// end: The end of the page.
-
 #ifdef SKIP32
-
 // In 32bits mode there are no threads, so the obstack does not have to be
 // thread local. This is because wasm doesn't support threads (at least not
 // well).
+#define __thread
+#endif
 
-struct sk_obstack* page = NULL;
-char* head = NULL;
-char* end = NULL;
-struct sk_obstack* free_list = NULL;
-
-unsigned char* decr_heap_end(size_t size);
-void reset_heap_end();
-
-#else
-
+// page: The beginning of the current obstack page
+// head: The current position in the page.
+// end: The end of the page.
 __thread struct sk_obstack* page = NULL;
 __thread char* head = NULL;
 __thread char* end = NULL;
 
+#ifdef SKIP32
+struct sk_obstack* free_list = NULL;
+
+unsigned char* decr_heap_end(size_t size);
+void reset_heap_end();
 #endif
 
 /*****************************************************************************/
@@ -75,11 +70,8 @@ typedef struct sk_obstack {
   sk_saved_obstack_t saved;
   char user_data[0];
 } sk_obstack_t;
-#ifdef SKIP32
-sk_saved_obstack_t init_saved = {NULL, NULL, NULL};
-#else
+
 __thread sk_saved_obstack_t init_saved = {NULL, NULL, NULL};
-#endif
 
 size_t sk_page_size(sk_obstack_t* page) {
   return page->size;

--- a/prelude/runtime/obstack.c
+++ b/prelude/runtime/obstack.c
@@ -43,12 +43,12 @@
 // page: The beginning of the current obstack page
 // head: The current position in the page.
 // end: The end of the page.
-__thread struct sk_obstack* page = NULL;
-__thread char* head = NULL;
-__thread char* end = NULL;
+static __thread struct sk_obstack* page = NULL;
+static __thread char* head = NULL;
+static __thread char* end = NULL;
 
 #ifdef SKIP32
-struct sk_obstack* free_list = NULL;
+static struct sk_obstack* free_list = NULL;
 
 unsigned char* decr_heap_end(size_t size);
 void reset_heap_end();
@@ -71,7 +71,7 @@ typedef struct sk_obstack {
   char user_data[0];
 } sk_obstack_t;
 
-__thread sk_saved_obstack_t init_saved = {NULL, NULL, NULL};
+static __thread sk_saved_obstack_t init_saved = {NULL, NULL, NULL};
 
 size_t sk_page_size(sk_obstack_t* page) {
   return page->size;


### PR DESCRIPTION
This prevents name clashes (notably for the `end` symbol which is
defined such that its address points near the end of the `.bss`
segment, cf. [man](https://man7.org/linux/man-pages/man3/end.3.html)).