### PR TITLE
[skargo] Ensure `build/` directory exists.

### DIFF
--- a/skargo/src/build_runner.sk
+++ b/skargo/src/build_runner.sk
@@ -271,6 +271,7 @@ mutable class BuildRunner(
   }
 
   private mutable fun prepare_unit(unit: Unit): void {
+    this.create_dir(this.layout_for(unit).build);
     fingerprint_path = dirname(this.fingerprint_file_for(unit));
     this.create_dir(fingerprint_path);
 


### PR DESCRIPTION
This has not been an issue so far because the `build/` directory would be explicitly created when building the `build.sk` for `std`, which so far has always been the first thing to be built during a `skargo build` run.