### PR TITLE
[std] Make `spawnp` errors recoverable.

### DIFF
--- a/cc/src/utils.sk
+++ b/cc/src/utils.sk
@@ -61,7 +61,12 @@ mutable class ProcessBuilder(
     stdout: (String) -> void = _ -> void,
     stderr: (String) -> void = _ -> void,
   ): System.CompletedProcess {
-    System.popen{args => this.get_argv(), env => this.get_env(), stdout, stderr}
+    System.popen{
+      args => this.get_argv(),
+      env => this.get_env(),
+      stdout,
+      stderr,
+    }.fromSuccess()
   }
 }
 

--- a/compiler/src/compile.sk
+++ b/compiler/src/compile.sk
@@ -160,7 +160,7 @@ fun runShell(args: Array<String>, verbose: Bool = false): void {
         print_error_raw(s)
       }
     },
-  );
+  ).fromSuccess();
   if (!p.success()) {
     if (!verbose) {
       print_error_raw(p.stderr)
@@ -172,7 +172,7 @@ fun runShell(args: Array<String>, verbose: Bool = false): void {
 fun ensureCompatibleLLVMVersion(): void {
   kLLVMVersion = "15.";
 
-  p = System.subprocess(Array["llvm-config", "--version"]);
+  p = System.subprocess(Array["llvm-config", "--version"]).fromSuccess();
   if (!p.success()) {
     print_error_raw(p.stderr);
     skipExit(1)
@@ -429,7 +429,7 @@ fun compile_sklib(conf: Config.Config): void {
     };
     ar_file.close();
 
-    p = System.subprocess(Array["llvm-ar", "s", conf.output]);
+    p = System.subprocess(Array["llvm-ar", "s", conf.output]).fromSuccess();
     if (!p.success()) {
       print_error(`ranlib failed: ${p.stdout} ${p.stderr}`);
       skipExit(3)

--- a/compiler/tests/tests.sk
+++ b/compiler/tests/tests.sk
@@ -20,14 +20,14 @@ private fun compile_cmd(
 private fun genValidTest(basename: String): void {
   p = System.subprocess(
     compile_cmd(Array[basename + ".sk"], basename + ".bin"),
-  );
+  ).fromSuccess();
   if (!p.success()) {
     T.fail(
       `Unexpected compile error\nstdout: ${p.stdout}\nstderr:\n${p.stderr}`,
     );
   };
 
-  !p = System.subprocess(Array[basename + ".bin"]);
+  !p = System.subprocess(Array[basename + ".bin"]).fromSuccess();
 
   if (!p.success()) {
     T.fail(`Unexpected error\nstdout: ${p.stdout}\nstderr:\n${p.stderr}`);
@@ -42,7 +42,7 @@ private fun genValidTest(basename: String): void {
 private fun genInvalidTest(basename: String): void {
   p = System.subprocess(
     compile_cmd(Array[basename + ".sk"], basename + ".bin"),
-  );
+  ).fromSuccess();
 
   if (p.success()) {
     T.fail("Expected compile error")

--- a/pkg-config/src/lib.sk
+++ b/pkg-config/src/lib.sk
@@ -115,7 +115,10 @@ class Config(
 
   private fun run(name: String, args: Array<String>): Result<String, Error> {
     cmd = this.cmd().concat(Array[name]).concat(args);
-    p = System.subprocess(cmd);
+    p = System.subprocess(cmd) match {
+    | Success(p) -> p
+    | Failure _ -> return Failure(ErrorCommand(cmd.join(" ")))
+    };
 
     if (p.success()) {
       Success(p.stdout)
@@ -145,6 +148,7 @@ class Config(
 
 base class Error {
   children =
+  | ErrorCommand(cmd: String)
   | ErrorProbeFailure(name: String, command: String, output: String)
 }
 

--- a/prelude/build.sk
+++ b/prelude/build.sk
@@ -46,7 +46,7 @@ class Env(
       // TODO: colors
       print_error(`>> ${args.join(" ")}`)
     };
-    p = System.subprocess(args, print_string, this.printError);
+    p = System.subprocess(args, print_string, this.printError).fromSuccess();
     if (this.verbose || !p.success()) {
       print_error_raw(p.stdout);
       print_error_raw(p.stderr);

--- a/prelude/runtime/posix.c
+++ b/prelude/runtime/posix.c
@@ -260,15 +260,13 @@ int64_t SKIP_posix_spawnp(char* skargv, char* skenvp, char* file_actionsp) {
   int rv =
       posix_spawnp(&pid, argv[0], (posix_spawn_file_actions_t*)file_actionsp,
                    NULL, argv, envp);
-  if (rv != 0) {
-    errno = rv;
-    fprintf(stderr, "posix_spawnp (%s): ", argv[0]);
-    perror(NULL);
-    exit(EXIT_FAILURE);
-  }
-
   free(argv);
   free(envp);
+
+  if (rv != 0) {
+    return (int64_t)(-rv);
+  }
+
   return (int64_t)pid;
 }
 

--- a/prelude/src/stdlib/other/Posix.sk
+++ b/prelude/src/stdlib/other/Posix.sk
@@ -248,7 +248,7 @@ mutable class Popen(
     stdin: Bool = false,
     stdout: Bool = false,
     stderr: Bool = false,
-  }: mutable Popen {
+  }: Result<mutable Popen, IO.Error> {
     file_actions = SpawnFileActions::init();
     stdin_pipe = if (stdin) Some(pipe()) else None();
     stdout_pipe = if (stdout) Some(pipe()) else None();
@@ -292,11 +292,13 @@ mutable class Popen(
     stdout_pipe.each(pipe -> close(pipe.input));
     stderr_pipe.each(pipe -> close(pipe.input));
 
-    mutable Popen(
-      p,
-      stdin_pipe.map(pipe -> mutable IO.File(pipe.input)),
-      stdout_pipe.map(pipe -> mutable IO.File(pipe.output)),
-      stderr_pipe.map(pipe -> mutable IO.File(pipe.output)),
+    p.map(p ->
+      mutable Popen(
+        p,
+        stdin_pipe.map(pipe -> mutable IO.File(pipe.input)),
+        stdout_pipe.map(pipe -> mutable IO.File(pipe.output)),
+        stderr_pipe.map(pipe -> mutable IO.File(pipe.output)),
+      )
     )
   }
 
@@ -388,9 +390,13 @@ fun spawnp(
   argv: Array<String>,
   env: Array<String>,
   file_actions: readonly SpawnFileActions,
-): mutable Process {
+): Result<mutable Process, IO.Error> {
   pid = internalSpawnp(argv, env, file_actions);
-  mutable Process(pid)
+  if (pid < 0) {
+    return Failure(IO.Error(-pid))
+  };
+
+  Success(mutable Process(pid))
 }
 
 module end;

--- a/prelude/src/stdlib/other/System.sk
+++ b/prelude/src/stdlib/other/System.sk
@@ -218,7 +218,7 @@ fun subprocess(
   args: Array<String>,
   stdout: (String) -> void = _ -> void,
   stderr: (String) -> void = _ -> void,
-): CompletedProcess {
+): Result<CompletedProcess, IO.Error> {
   popen{args, stdout, stderr}
 }
 
@@ -229,7 +229,7 @@ fun popen{
   stdout: (String) -> void = _ -> void,
   stderr: (String) -> void = _ -> void,
   cwd: ?String = None(),
-}: CompletedProcess {
+}: Result<CompletedProcess, IO.Error> {
   p = Posix.Popen::create{
     args,
     env,
@@ -237,7 +237,7 @@ fun popen{
     cwd,
     stdout => true,
     stderr => true,
-  };
+  }?;
   streams = Array[p.stdout.fromSome(), p.stderr.fromSome()];
   captured = Array[mutable Vector[], mutable Vector[]];
   handlers = Array[stdout, stderr];
@@ -273,11 +273,13 @@ fun popen{
     }
   };
   exitstatus = p.wait();
-  CompletedProcess(
-    args,
-    exitstatus,
-    String::fromUtf8(captured[0].toArray()),
-    String::fromUtf8(captured[1].toArray()),
+  Success(
+    CompletedProcess(
+      args,
+      exitstatus,
+      String::fromUtf8(captured[0].toArray()),
+      String::fromUtf8(captured[1].toArray()),
+    ),
   )
 }
 

--- a/skargo/src/commands/clean.sk
+++ b/skargo/src/commands/clean.sk
@@ -23,7 +23,7 @@ fun clean(): (Cli.Command, (GlobalContext, Cli.ParseResults) ~> void) {
 fun execClean(gctx: GlobalContext, args: Cli.ParseResults): void {
   ws = workspace(args, gctx);
   // TODO: Clean only for a specific arch specified with `--target`?
-  p = System.subprocess(Array["rm", "-rf", ws.target_dir()]);
+  p = System.subprocess(Array["rm", "-rf", ws.target_dir()]).fromSuccess();
   if (!p.success()) {
     gctx.console.error(subprocess_error_message(p));
     skipExit(2);

--- a/skargo/src/commands/fmt.sk
+++ b/skargo/src/commands/fmt.sk
@@ -20,7 +20,7 @@ fun execFmt(gctx: GlobalContext, args: Cli.ParseResults): void {
     f.endsWith(".sk")
   ).toArray();
 
-  p = System.subprocess(Array["skfmt", "-i"].concat(files));
+  p = System.subprocess(Array["skfmt", "-i"].concat(files)).fromSuccess();
   if (!p.success()) {
     gctx.console.error(subprocess_error_message(p));
     skipExit(2);

--- a/skargo/src/commands/test.sk
+++ b/skargo/src/commands/test.sk
@@ -1,7 +1,7 @@
 module Skargo;
 
 fun nproc(): Int {
-  p = System.subprocess(Array["nproc"]);
+  p = System.subprocess(Array["nproc"]).fromSuccess();
   p.exitstatus match {
   | Posix.WExited(0) ->
     p.stdout.trim().toIntOption() match {

--- a/skargo/src/skc.sk
+++ b/skargo/src/skc.sk
@@ -64,7 +64,7 @@ mutable class ProcessBuilder{
       cwd => this.process_cwd,
       stdout,
       stderr,
-    }
+    }.fromSuccess()
   }
 }
 

--- a/skargo/src/target_info.sk
+++ b/skargo/src/target_info.sk
@@ -24,7 +24,7 @@ class SkcTargetData{
 }
 
 private fun get_host_target(gctx: GlobalContext): TargetTriple {
-  p = System.subprocess(Array["llvm-config", "--host-target"]);
+  p = System.subprocess(Array["llvm-config", "--host-target"]).fromSuccess();
   if (!p.success()) {
     gctx.console.error(subprocess_error_message(p));
     skipExit(3)

--- a/skbuild/src/checker.sk
+++ b/skbuild/src/checker.sk
@@ -25,7 +25,7 @@ class TimeChecker(optTime: ?Int = None()) {
 
 fun mtime(path: String): ?Int {
   if (FileSystem.exists(path)) {
-    p = System.subprocess(Array["stat", "-c", "%Y", path]);
+    p = System.subprocess(Array["stat", "-c", "%Y", path]).fromSuccess();
     if (!p.success()) {
       None()
     } else {

--- a/skbuild/src/harness.sk
+++ b/skbuild/src/harness.sk
@@ -73,7 +73,11 @@ class Env(
       Environ.set_current_dir(dir);
       current
     });
-    p = System.subprocess(args, this.printString, this.printError);
+    p = System.subprocess(
+      args,
+      this.printString,
+      this.printError,
+    ).fromSuccess();
     optCurrent.each(c -> Environ.set_current_dir(c));
     if (!p.success()) {
       if (!this.verbose) {
@@ -311,7 +315,7 @@ fun run(args: Array<String>, verbose: Bool): void {
     // TODO: colors
     print_error(`>> ${args.join(" ")}`)
   };
-  p = System.subprocess(args);
+  p = System.subprocess(args).fromSuccess();
   if (!p.success()) {
     print_raw(p.stdout);
     print_error_raw(p.stderr);

--- a/sknpm/src/sknpm.sk
+++ b/sknpm/src/sknpm.sk
@@ -127,7 +127,7 @@ private fun skargo(
     cmd_args.toArray(),
     printer.printString,
     printer.printError,
-  );
+  ).fromSuccess();
   printer.flush();
   if (!p.success()) {
     Failure(void)
@@ -211,7 +211,7 @@ private fun exec(
   } else {
     ((_) -> void, (_) -> void)
   };
-  p = System.subprocess(args, stdout_cb, stderr_cb);
+  p = System.subprocess(args, stdout_cb, stderr_cb).fromSuccess();
   printer.flush();
   if (!p.success()) {
     if (console.verbosity < verbosity) {

--- a/sknpm/src/utils.sk
+++ b/sknpm/src/utils.sk
@@ -32,7 +32,7 @@ fun syncDirs(
 }
 
 fun checkDir(dir: String): void {
-  _ = System.subprocess(Array["mkdir", "-p", dir]);
+  _ = System.subprocess(Array["mkdir", "-p", dir]).fromSuccess();
 }
 
 fun withTarget(args: Cli.ParseResults): Cli.ParseResults {
@@ -49,7 +49,7 @@ fun withTarget(args: Cli.ParseResults): Cli.ParseResults {
 
 fun mtime(path: String): ?Int {
   if (FileSystem.exists(path)) {
-    p = System.subprocess(Array["stat", "-c", "%Y", path]);
+    p = System.subprocess(Array["stat", "-c", "%Y", path]).fromSuccess();
     if (!p.success()) {
       None()
     } else {
@@ -152,7 +152,7 @@ fun i(v: Bool): Int {
 fun copy(src: String, dst: String, optConsole: ?Skargo.Console = None()): void {
   cmd = Array["cp", src, dst];
   optConsole.each(console -> console.status_verbose("Command", cmd.join(" ")));
-  _ = System.subprocess(cmd);
+  _ = System.subprocess(cmd).fromSuccess();
 }
 
 fun targets(
@@ -181,7 +181,7 @@ fun runService(
   if (FileSystem.exists(serviceFile)) {
     cmd = Array["make", "-f", serviceFile, `ROOT_DIR=${root}`];
     console.status_verbose("Command", cmd.join(" "));
-    p = System.subprocess(cmd, s -> if (verbose) print_raw(s));
+    p = System.subprocess(cmd, s -> if (verbose) print_raw(s)).fromSuccess();
     if (verbose || !p.success()) {
       if (!verbose) print_raw(p.stdout);
       print_error_raw(p.stderr);

--- a/sktest/extra/src/host.sk
+++ b/sktest/extra/src/host.sk
@@ -108,7 +108,7 @@ fun test_harness(tests: readonly Map<String, readonly Sequence<Test>>): void {
       ],
       stdout => true,
       stderr => true,
-    }
+    }.fromSuccess()
   });
   readers = Array::createFromItems(
     procs.map(p -> mutable IO.BufferedReader(p.stdout.fromSome())),


### PR DESCRIPTION
This changes the return type of `Posix.spawnp()` (as well as that of `Posix.Popen::create()`, `Posix.popen()`, and `System.subprocess()`) to a `Result<_, IO.Error>` instead of having the runtime `spawnp()` function to call `exit()` (for instance when attempting to execute a binary that cannot be found in the current path).

The call sites are updated to maintain current behavior (that is, failing upon `Failure()` being returned).