### PR TITLE
[stdlib] Conditionally build with `-fPIC`.

### DIFF
--- a/prelude/build.sk
+++ b/prelude/build.sk
@@ -20,6 +20,7 @@ fun main(): void {
   target = Environ.var("TARGET");
   host = Environ.var("HOST");
   out_dir = Environ.var("OUT_DIR");
+  pic = (Environ.var("RELOCATION_MODEL") == "pic");
 
   profile match {
   | "release" -> Environ.set_var("OPT_LEVEL", "3")
@@ -50,7 +51,7 @@ fun main(): void {
     "runtime/xoroshiro128plus.c",
   ];
 
-  cfg = Cc.Build().flags(kCflags).files(srcs).file(magic_c);
+  cfg = Cc.Build().pic(pic).flags(kCflags).files(srcs).file(magic_c);
   srcs.each(f -> print_string(`skargo:rerun-if-changed=${f}`));
 
   // TODO: `skargo:rerun-if-changed` on sources.
@@ -70,6 +71,7 @@ fun main(): void {
     libbacktrace_include = build_libbacktrace(
       Path.join(out_dir, "libbacktrace"),
       host == target,
+      pic,
     );
 
     native_srcs = Array[
@@ -84,8 +86,10 @@ fun main(): void {
     native_cpp_srcs.each(f -> print_string(`skargo:rerun-if-changed=${f}`));
     Cc.Build()
       .cpp(true)
+      .pic(pic)
       .files(native_cpp_srcs)
       .define("SKIP64")
+      .define(if (pic) "SKIP_LIBRARY" else "SKIP_BINARY")
       .include(libbacktrace_include)
       .compile("skip_runtime64");
     print_string("skargo:skc-preamble=preamble/preamble64.ll");
@@ -93,8 +97,12 @@ fun main(): void {
   }
 }
 
-fun build_libbacktrace(out_dir: String, try_pkgconfig: Bool): String {
-  if (try_pkgconfig) {
+fun build_libbacktrace(
+  out_dir: String,
+  host_is_target: Bool,
+  pic: Bool,
+): String {
+  if (host_is_target && !pic) {
     // Try using system installed libbacktrace.
     PkgConfig.Config().skargo_metadata(true).probe("libbacktrace") match {
     | Success(cfg) ->
@@ -106,7 +114,9 @@ fun build_libbacktrace(out_dir: String, try_pkgconfig: Bool): String {
 
   // Resort to building libbacktrace from source.
   p = System.popen{
-    args => Array["./configure", "--prefix", out_dir],
+    args => Array["./configure", "--prefix", out_dir].concat(
+      if (pic) Array["--with-pic"] else Array[],
+    ),
     stdout => print_error_raw,
     stderr => print_error_raw,
     cwd => Some("./libbacktrace"),


### PR DESCRIPTION
Also define `SKIP_LIBRARY`/`SKIP_BINARY` when compiling `runtime64_specific.cpp`.