### PR TITLE
Support generating shared libraries.

### DIFF
--- a/compiler/src/compile.sk
+++ b/compiler/src/compile.sk
@@ -128,17 +128,24 @@ fun link(
       config.verbose,
     );
   } else {
+    flags = if (config.emit == "cdylib") {
+      Array["-fPIC", "-shared"]
+    } else {
+      Array["-no-pie"]
+    };
+
     runShell(
       Array[
         "clang++",
-        "-no-pie",
         `-O${config.optLevel}`,
         "-mllvm",
         "-inline-threshold=0",
         "-o",
         config.output,
         llFile,
-      ].concat(linker_args).concat(static_libs),
+      ].concat(flags)
+        .concat(linker_args)
+        .concat(static_libs),
       config.verbose,
     );
   }
@@ -342,7 +349,8 @@ fun compile(
 
         conf.emit match {
         | "llvm-ir" -> compile_llvm_ir(defs, conf)
-        | "link" ->
+        | "link" | "cdylib" ->
+          // TODO: Remove exports stuff once --emit=cdylib is supported.
           wasm_exports = outerIst
             .getFuns(context, defsProj)
             .filter(f ->

--- a/sknpm/src/sknpm.sk
+++ b/sknpm/src/sknpm.sk
@@ -301,7 +301,8 @@ fun manage(
     dfs(brunner, unit, units)
   };
   libraries = units.filter(u ->
-    (u.target.kind is Skargo.LibTarget _) &&
+    (u.target.kind is Skargo.LibTarget(Skargo.LibraryTypeSklib _)) &&
+      u.build_opts.relocation_model == "static" &&
       u.arch match {
       | Skargo.TargetArchHost() -> false
       | Skargo.TargetArchTriple(t) -> t.isWasm32()


### PR DESCRIPTION
This PR adds support for `--emit=cdylib` in `skc`, which generates a shared object from a skip library.
In order to trigger it from `skargo`, add the following to `Skargo.toml`:
```
[lib]
type = ["sklib", "cdylib"]
```
which causes `skargo build` to generate both `libfoo.sklib` and `libfoo.so`.