### PR TITLE
Simulation test fixes

### DIFF
--- a/sql/src/SqlTailer.sk
+++ b/sql/src/SqlTailer.sk
@@ -283,7 +283,7 @@ fun tailSub(
           // allow chunking, we stream the current state of the table
           // and begin tailing from here.
           (false, edir.unsafeGetFileIterNoReducer(None()).map(pair -> pair.i0))
-        } else if (!established) {
+        } else if (since.value > 1 && !established) {
           // we have a client that we've never seen before asking to
           // tail from a point in time that they cannot understand, as
           // they have no reference for our clock. we assume that this

--- a/sql/test/replication/test_no_pk.py
+++ b/sql/test/replication/test_no_pk.py
@@ -20,7 +20,7 @@ def test_client_server_single_orthogonal_insert_each():
   server = cluster.add(Server("s1", scheduler))
   client1 = cluster.add(Client("c1", scheduler))
 
-  cluster.mirror("test_without_pk", client1, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client1, server)
 
   client1.insertInto("test_without_pk", [0, 'foo'])
   server.insertInto("test_without_pk", [1, 'bar'])
@@ -45,8 +45,8 @@ def test_two_clients_single_server_two_conflicting_inserts_each():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_without_pk", client1, server)
-  cluster.mirror("test_without_pk", client2, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client1, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client2, server)
 
   client1.insertInto("test_without_pk", [0, 'foo'])
   server.insertInto("test_without_pk", [0, 'foo'])
@@ -71,8 +71,8 @@ def test_two_clients_single_server_two_conflicting_inserts_with_causality():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_without_pk", client1, server)
-  cluster.mirror("test_without_pk", client2, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client1, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client2, server)
 
   client1.insertInto("test_without_pk", [0, 'foo'])
   client1.insertInto("test_without_pk", [0, 'foo'])
@@ -98,8 +98,8 @@ def test_two_clients_single_server_single_conflicting_insert_each():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_without_pk", client1, server)
-  cluster.mirror("test_without_pk", client2, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client1, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client2, server)
 
   client1.insertInto("test_without_pk", [0, 'foo'])
   client2.insertInto("test_without_pk", [0, 'foo'])
@@ -129,8 +129,8 @@ def test_two_clients_single_server_multiple_inserts_on_client1_insert_on_each():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_without_pk", client1, server)
-  cluster.mirror("test_without_pk", client2, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client1, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client2, server)
 
   client1.insertInto("test_without_pk", [0, 'foo'])
   client1.insertInto("test_without_pk", [0, 'foo'])
@@ -160,8 +160,8 @@ def test_two_clients_insert_and_delete():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_without_pk", client1, server)
-  cluster.mirror("test_without_pk", client2, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client1, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client2, server)
 
   insert = client1.insertInto("test_without_pk", [0, 'foo'])
   delete = server.deleteFromWhere("test_without_pk", "id = 0")
@@ -193,9 +193,9 @@ def ignore_test_full_mesh_two_conflicting_inserts():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_without_pk", client1, server)
-  cluster.mirror("test_without_pk", client2, server)
-  cluster.mirror("test_without_pk", client1, client2)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client1, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client2, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client1, client2)
 
   client1.insertInto("test_without_pk", [0, 'foo'])
   server.insertInto("test_without_pk", [0, 'foo'])
@@ -221,9 +221,9 @@ def ignore_test_full_mesh_with_insert_and_delete():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_without_pk", client1, server)
-  cluster.mirror("test_without_pk", client2, server)
-  cluster.mirror("test_without_pk", client1, client2)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client1, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client2, server)
+  cluster.mirror("test_without_pk", "(id INTEGER, note TEXT)", client1, client2)
 
   insert = client1.insertInto("test_without_pk", [0, 'foo'])
   delete = server.deleteFromWhere("test_without_pk", "id = 0")

--- a/sql/test/replication/test_pk.py
+++ b/sql/test/replication/test_pk.py
@@ -20,7 +20,7 @@ def test_client_server_single_orthogonal_insert_each():
   server = cluster.add(Server("s1", scheduler))
   client1 = cluster.add(Client("c1", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
 
   client1.insertInto("test_with_pk", [0, 'foo'])
   server.insertInto("test_with_pk", [1, 'bar'])
@@ -45,8 +45,8 @@ def test_two_clients_single_server_two_conflicting_inserts_each():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   clientInsert = client1.insertOrReplace("test_with_pk", [0, 'foo'])
   serverInsert = server.insertOrReplace("test_with_pk", [0, 'bar'])
@@ -77,8 +77,8 @@ def test_two_clients_single_server_two_conflicting_inserts_with_causality():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   client1.insertOrReplace("test_with_pk", [0, 'foo'])
   client1.insertOrReplace("test_with_pk", [0, 'bar'])
@@ -104,8 +104,8 @@ def test_two_clients_single_server_single_conflicting_insert_each():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   client1.insertOrReplace("test_with_pk", [0, 'foo'])
   client2.insertOrReplace("test_with_pk", [0, 'bar'])
@@ -131,8 +131,8 @@ def test_two_clients_single_server_multiple_inserts_on_client1_insert_on_client2
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   client1.insertOrReplace("test_with_pk", [0, 'foo'])
   client1.insertOrReplace("test_with_pk", [0, 'bar'])
@@ -158,8 +158,8 @@ def test_two_clients_single_server_repeat_inserts_on_client1_purge_on_server():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   server.purgeAllAtSomePointFromNow()
 
@@ -203,8 +203,8 @@ def test_two_clients_single_server_multiple_inserts_on_client1_delete_on_client2
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   client1.insertOrReplace("test_with_pk", [0, 'foo'])
   client1.insertOrReplace("test_with_pk", [0, 'bar'])
@@ -230,8 +230,8 @@ def test_two_clients_single_server_multiple_inserts_on_client1_delete_on_client2
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   server.purgeAllAtSomePointFromNow()
 
@@ -260,8 +260,8 @@ def test_two_clients_single_server_multiple_inserts_on_client1_delete_on_client2
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   client1.insertOrReplace("test_with_pk", [0, 'foo'])
   client1.insertOrReplace("test_with_pk", [1, 'bar'])
@@ -287,8 +287,8 @@ def test_two_clients_single_server_multiple_inserts_on_client1_delete_on_client2
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   server.purgeAllAtSomePointFromNow()
 
@@ -313,8 +313,8 @@ def test_two_clients_single_server_multiple_inserts_on_client1_update_on_client2
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   client1.insertOrReplace("test_with_pk", [0, 'foo'])
   client1.insertOrReplace("test_with_pk", [0, 'bar'])
@@ -340,8 +340,8 @@ def test_two_clients_single_server_multiple_inserts_on_client1_update_on_client2
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   server.purgeAllAtSomePointFromNow()
 
@@ -370,8 +370,8 @@ def test_two_clients_single_server_multiple_inserts_on_client1_update_on_client2
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   client1.insertOrReplace("test_with_pk", [0, 'foo'])
   client1.insertOrReplace("test_with_pk", [1, 'bar'])
@@ -397,8 +397,8 @@ def test_two_clients_single_server_multiple_inserts_on_client1_update_on_client2
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   server.purgeAllAtSomePointFromNow()
 
@@ -423,8 +423,8 @@ def test_two_clients_single_server_updates_purge_happens_on_server():
   client1 = cluster.add(Client("c1", scheduler))
   client2 = cluster.add(Client("c2", scheduler))
 
-  cluster.mirror("test_with_pk", client1, server)
-  cluster.mirror("test_with_pk", client2, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client1, server)
+  cluster.mirror("test_with_pk", "(id INTEGER PRIMARY KEY, note TEXT)", client2, server)
 
   server.purgeAllAtSomePointFromNow()
 


### PR DESCRIPTION
These tests had gotten stale in two ways:

 * Client-specified schemas are now required when tailing
 * Rebuild semantics have been tweaked and resets removed from the protocol

 (these changes are orthogonal to the column-extraction PR #247, so sending as separate PR)