### PR TITLE
Add bun lockfiles to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target
 skdb.wasm
 **/node_modules/
 .skgw.conf
+bun.lockb


### PR DESCRIPTION
These binary lock files get generated by bun during some of the skstore ts example make targets