### PR TITLE
Implement JS Iterable interface on NonEmptyIterators

### DIFF
--- a/prelude/src/skstore/Handle.sk
+++ b/prelude/src/skstore/Handle.sk
@@ -65,8 +65,22 @@ mutable class NonEmptyIterator<+T>(
   mutable isPastFirstValue: Bool = false,
   mutable materializedIter: ?Array<T> = None(),
 ) extends FileIterator<T> {
+  // Materialize `iter` into an array to support multiple/repeat iterations
+  // This operation is deferred until necessary, to avoid materialization in
+  // cases where only the `first` element is accessed
+  private mutable fun materializeIter(): void {
+    this.materializedIter match {
+    | None() ->
+      array = this.iter.collect(Array);
+      this.!materializedIter = Some(array);
+      this.!iter = (array.iterator() : mutable Iterator<T>)
+    | Some(_) -> void
+    };
+  }
+
   mutable fun next(): ?T {
     if (this.isPastFirstValue) {
+      this.materializeIter();
       this.iter.next()
     } else {
       this.!isPastFirstValue = true;
@@ -97,20 +111,12 @@ mutable class NonEmptyIterator<+T>(
     }
   }
   mutable fun clone(): mutable NonEmptyIterator<T> {
-    array: Array<T> = this.materializedIter match {
-    | None() ->
-      array = this.iter.collect(Array);
-      this.!materializedIter = Some(array);
-      this.!iter = (array.iterator() : mutable Iterator<T>);
-      array
-    | Some(array) -> array
-    };
-
+    this.materializeIter();
     mutable NonEmptyIterator(
       this.first,
-      array.iterator(),
-      this.isPastFirstValue,
-      Some(array),
+      this.materializedIter.fromSome().iterator(),
+      false,
+      this.materializedIter,
     )
   }
 }

--- a/prelude/src/skstore/Handle.sk
+++ b/prelude/src/skstore/Handle.sk
@@ -60,9 +60,10 @@ mutable class EmptyIterator<T>() extends FileIterator<T> {
 }
 
 mutable class NonEmptyIterator<+T>(
-  mutable first: T,
-  iter: mutable Iterator<T>,
+  first: T,
+  mutable iter: mutable Iterator<T>,
   mutable isPastFirstValue: Bool = false,
+  mutable materializedIter: ?Array<T> = None(),
 ) extends FileIterator<T> {
   mutable fun next(): ?T {
     if (this.isPastFirstValue) {
@@ -94,6 +95,23 @@ mutable class NonEmptyIterator<+T>(
     | None() -> void
     | Some _ -> err()
     }
+  }
+  mutable fun clone(): mutable NonEmptyIterator<T> {
+    array: Array<T> = this.materializedIter match {
+    | None() ->
+      array = this.iter.collect(Array);
+      this.!materializedIter = Some(array);
+      this.!iter = (array.iterator() : mutable Iterator<T>);
+      array
+    | Some(array) -> array
+    };
+
+    mutable NonEmptyIterator(
+      this.first,
+      array.iterator(),
+      this.isPastFirstValue,
+      Some(array),
+    )
   }
 }
 

--- a/skstore/src/Extern.sk
+++ b/skstore/src/Extern.sk
@@ -117,6 +117,13 @@ fun iteratorNext(values: mutable NonEmptyIterator<JSONFile>): ?SKJSON.CJSON {
   values.next().map(v -> v.value)
 }
 
+@export("SKIP_SKStore_cloneIterator")
+fun cloneIterator(
+  values: mutable NonEmptyIterator<JSONFile>,
+): mutable NonEmptyIterator<JSONFile> {
+  values.clone()
+}
+
 class FnHandle private (eptr: SKStore.ExternalPointer) extends File {
   static fun make(id: UInt32): this {
     static(SKStore.ExternalPointer::create(id, detachHandle))

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -314,16 +314,19 @@ class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
     return Array.from(this);
   };
 
-  *iterator() {
-    let value = this.next();
-    while (value != null) {
-      yield value;
-      value = this.next();
-    }
-  }
+  [Symbol.iterator](): Iterator<T> {
+    const cloned_iter = new NonEmptyIteratorImpl<T>(
+      this.skjson,
+      this.exports,
+      this.exports.SKIP_SKStore_cloneIterator(this.pointer),
+    );
 
-  [Symbol.iterator]() {
-    return this.iterator();
+    return {
+      next() {
+        const value = cloned_iter.next();
+        return { value, done: value == null } as IteratorResult<T>;
+      },
+    };
   }
 }
 

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -291,24 +291,23 @@ class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
     this.pointer = pointer;
   }
 
-  next: () => Opt<T> = () => {
+  next(): Opt<T> {
     return this.skjson.importOptJSON(
       this.exports.SKIP_SKStore_iteratorNext(this.pointer),
     );
-  };
+  }
 
-  first: () => T = () => {
+  first(): T {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_iteratorFirst(this.pointer),
-    ) as T;
-  };
+    );
+  }
 
-  uniqueValue: () => Opt<T> = () => {
-    const jsObj = this.skjson.importOptJSON(
+  uniqueValue(): Opt<T> {
+    return this.skjson.importOptJSON(
       this.exports.SKIP_SKStore_iteratorUniqueValue(this.pointer),
     );
-    return jsObj != null ? (jsObj as T) : null;
-  };
+  }
 
   toArray: () => T[] = () => {
     return Array.from(this);

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -311,14 +311,20 @@ class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
   };
 
   toArray: () => T[] = () => {
-    const array: T[] = [];
+    return Array.from(this);
+  };
+
+  *iterator() {
     let value = this.next();
     while (value != null) {
-      array.push(value);
+      yield value;
       value = this.next();
     }
-    return array;
-  };
+  }
+
+  [Symbol.iterator]() {
+    return this.iterator();
+  }
 }
 
 class WriterImpl<K, T> {

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -68,6 +68,7 @@ class WasmHandle {
 }
 
 function getValue(hdl: WasmHandle): any {
+  if (hdl.pointer == 0) return null;
   const type = hdl.access.SKIP_SKJSON_typeOf(hdl.pointer);
   switch (type) {
     case Type.Null:

--- a/skstore/ts/src/prv/skstore_types.ts
+++ b/skstore/ts/src/prv/skstore_types.ts
@@ -148,6 +148,7 @@ export interface FromWasm {
   SKIP_SKStore_iteratorNext(it: ptr): Opt<ptr>;
   SKIP_SKStore_iteratorUniqueValue(it: ptr): Opt<ptr>;
   SKIP_SKStore_iteratorFirst(it: ptr): ptr;
+  SKIP_SKStore_cloneIterator(it: ptr): ptr;
   // Writer
   SKIP_SKStore_writerSet(writer: ptr, key: ptr, value: ptr): void;
 

--- a/skstore/ts/src/skstore_api.ts
+++ b/skstore/ts/src/skstore_api.ts
@@ -210,7 +210,7 @@ export interface Accumulator<T extends TJSON, V extends TJSON> {
 /**
  * A mutable iterator with at least one element
  */
-export interface NonEmptyIterator<T> {
+export interface NonEmptyIterator<T> extends Iterable<T> {
   /**
    * Return the next element of the iteration.
    *   `first` cannot be called after `next`


### PR DESCRIPTION
This enables things like for-each loops and passing NonEmptyIterators to functions that expect an iterable input