### PR TITLE
[sknpm] Do not indent output of failed subprocesses

### DIFF
--- a/sknpm/src/sknpm.sk
+++ b/sknpm/src/sknpm.sk
@@ -216,17 +216,14 @@ private fun exec(
   if (!p.success()) {
     if (console.verbosity < verbosity) {
       console.error(
-        "command exited with non-zero status\n\n" +
-          "Caused by:\n" +
-          "  process did not exit successfully: \`" +
-          args[0] +
-          `\` (exit status: ${p.exitcode()})\n` +
-          "  --- stdout\n" +
-          p.stdout.split("\n").map(l -> "  " + l).join("\n") +
-          "\n" +
-          "  --- stderr\n" +
-          p.stderr.split("\n").map(l -> "  " + l).join("\n") +
-          "\n",
+        `command exited with non-zero status\n\n` +
+          `Caused by:\n` +
+          `  process did not exit successfully: \`${args[0]}\`` +
+          ` (exit status: ${p.exitcode()})\n` +
+          `  --- stdout\n` +
+          `${p.stdout}\n` +
+          `  --- stderr\n` +
+          `${p.stderr}\n`,
       );
     };
     Failure(void)


### PR DESCRIPTION
If a subprocess produces an error, some tools parse the messages and
expect them to start at the left margin. To avoid friction with these,
do not indent the contents of stdout and stderr when reporting the
output of failed subprocesses.