### PR TITLE
[skstore] Allow mappers to close only over handles

### DIFF
--- a/skstore/.prettierignore
+++ b/skstore/.prettierignore
@@ -1,0 +1,1 @@
+../.prettierignore

--- a/skstore/.prettierrc
+++ b/skstore/.prettierrc
@@ -1,0 +1,1 @@
+../.prettierrc

--- a/skstore/Makefile
+++ b/skstore/Makefile
@@ -36,3 +36,6 @@ nodeplay-%: ../build/sknpm
 	tsc --project ts/examples/tsconfig.json
 	cd ts/examples && echo "play 1\nexit\n" | node dist/wmain.js -f  dist/$*.js -m io
 
+.PHONY: fmt
+fmt:
+	npx prettier --log-level warn --write .

--- a/skstore/Makefile
+++ b/skstore/Makefile
@@ -1,6 +1,7 @@
 
 SKARGO_PROFILE?=release
 
+.PHONY: ../build/sknpm
 ../build/sknpm:
 	cd .. && make build/sknpm
 

--- a/skstore/Makefile
+++ b/skstore/Makefile
@@ -15,12 +15,12 @@ bunrun-%: ../build/sknpm
 	bun run ts/examples/wmain.ts -f ts/examples/$*.ts -m io
 
 check: ../build/sknpm
-	cd ts/examples && npm install
+	cd ts/examples && npm install --no-progress
 	../build/sknpm b -r --nowasm --out-dir ts/examples/node_modules/skstore
 	tsc --project ts/examples/tsconfig.json
 
 noderun-%: ../build/sknpm
-	cd ts/examples && npm install
+	cd ts/examples && npm install --no-progress
 	../build/sknpm b -r --out-dir ts/examples/node_modules/skstore
 	tsc --project ts/examples/tsconfig.json
 	cd ts/examples && node dist/wmain.js -f dist/$*.js -m io
@@ -31,7 +31,7 @@ bunplay-%: ../build/sknpm
 	echo "play 1\nexit\n" | bun run ts/examples/wmain.ts -f ts/examples/$*.ts -m io
 
 nodeplay-%: ../build/sknpm
-	cd ts/examples && npm install
+	cd ts/examples && npm install --no-progress
 	../build/sknpm b -r --out-dir ts/examples/node_modules/skstore
 	tsc --project ts/examples/tsconfig.json
 	cd ts/examples && echo "play 1\nexit\n" | node dist/wmain.js -f  dist/$*.js -m io

--- a/skstore/ts/examples/sum.ts
+++ b/skstore/ts/examples/sum.ts
@@ -34,7 +34,11 @@ class T2SIdentify<K extends TJSON, V extends TJSON>
 }
 
 class Add implements Mapper<number, number, number, number> {
-  constructor(private other: EHandle<number, number>) {}
+  private other: EHandle<number, number>;
+
+  constructor(eparams: EHandle<any, any>[], lparams: LHandle<any, any>[]) {
+    this.other = eparams[0];
+  }
 
   mapElement(
     key: number,

--- a/skstore/ts/examples/sum.ts
+++ b/skstore/ts/examples/sum.ts
@@ -5,6 +5,7 @@ import type {
   TJSON,
   Mapper,
   EHandle,
+  LHandle,
   NonEmptyIterator,
   OutputMapper,
 } from "skstore";
@@ -62,13 +63,10 @@ export function initSKStore(
   input2: TableHandle<[number, number]>,
   output: TableHandle<[number, number]>,
 ) {
-  const eager1 = input1.map<number, number, typeof T2SIdentify>(T2SIdentify);
-  const eager2 = input2.map<number, number, typeof T2SIdentify>(T2SIdentify);
-  const eager3 = eager1.map<number, number, typeof Add>(Add, eager2);
-  eager3.mapTo<[number, number], typeof ToOutput<number, number>>(
-    output,
-    ToOutput,
-  );
+  const eager1 = input1.map(T2SIdentify<number, number>, [], []);
+  const eager2 = input2.map(T2SIdentify<number, number>, [], []);
+  const eager3 = eager1.map(Add, [eager2], []);
+  eager3.mapTo(output, ToOutput, [], []);
 }
 
 export function scenarios() {


### PR DESCRIPTION
This diff removes the class type argument from map functions in the
SKStore API, and changes the parameters for the Mapper class
constructors from effectively
```
...params: any[]
```
to
```
eparams: EHandle<any, any>[],
lparams: LHandle<any, any>[]
```

The benefit of these changes is that calls to the `map` functions no
longer need to specify the type of the class. This helps since type
inference is not strong enough to elaborate the type parameters
automatically. Also, specifying the types of each parameter as only
either `EHandle` or `LHandle` gives API users help to only close over
state that the SKStore incremental computation engine is aware of.

A drawback is that splitting the params into a pair of arrays rather
than one varargs list is less convenient at call sites. Additionally,
the `constructor` functions of mapper classes have a uniform
signature that is only very weakly typed: the number and order of the
actual class constructor parameters must be ensured manually.