### PR TITLE
[JS] Extend "get" interfaces and apply consistent naming

### DIFF
--- a/skstore/src/Extern.sk
+++ b/skstore/src/Extern.sk
@@ -407,16 +407,6 @@ fun toSkdb(
   DBUtils.toTable(eager, table, context, mapHandle.toRow)
 }
 
-@export("SKIP_SKStore_get")
-fun get(
-  context: mutable Context,
-  handleId: String,
-  key: SKJSON.CJSON,
-): SKJSON.CJSON {
-  eager = EHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));
-  eager.get(context, JSONID(key)).value
-}
-
 @export("SKIP_SKStore_getFromTable")
 fun getFromTable(
   _context: mutable Context,
@@ -427,6 +417,26 @@ fun getFromTable(
   invariant_violation("TODO")
 }
 
+@export("SKIP_SKStore_getArray")
+fun getArray(
+  context: mutable Context,
+  handleId: String,
+  key: SKJSON.CJSON,
+): SKJSON.CJSON {
+  eager = EHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));
+  SKJSON.CJArray(eager.getArray(context, JSONID(key)).map(v -> v.value))
+}
+
+@export("SKIP_SKStore_get")
+fun get(
+  context: mutable Context,
+  handleId: String,
+  key: SKJSON.CJSON,
+): SKJSON.CJSON {
+  eager = EHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));
+  eager.get(context, JSONID(key)).value
+}
+
 @export("SKIP_SKStore_maybeGet")
 fun maybeGet(
   context: mutable Context,
@@ -434,10 +444,20 @@ fun maybeGet(
   key: SKJSON.CJSON,
 ): SKJSON.CJSON {
   eager = EHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));
-  eager
-    .maybeGet(context, JSONID(key))
-    .map(v -> v.value)
-    .default(SKJSON.CJNull())
+  eager.maybeGet(context, JSONID(key)) match {
+  | Some(v) -> v.value
+  | None() -> SKJSON.CJNull()
+  }
+}
+
+@export("SKIP_SKStore_getArrayLazy")
+fun getArrayLazy(
+  context: mutable Context,
+  handleId: String,
+  key: SKJSON.CJSON,
+): SKJSON.CJSON {
+  lazy = LHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));
+  getArraySelf(context, lazy, key)
 }
 
 @export("SKIP_SKStore_getLazy")
@@ -449,7 +469,24 @@ fun getLazy(
   lazy = LHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));
   getSelf(context, lazy, key)
 }
+@export("SKIP_SKStore_maybeGetLazy")
+fun maybeGetLazy(
+  context: mutable Context,
+  handleId: String,
+  key: SKJSON.CJSON,
+): SKJSON.CJSON {
+  lazy = LHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));
+  maybeGetSelf(context, lazy, key)
+}
 
+@export("SKIP_SKStore_getArraySelf")
+fun getArraySelf(
+  context: mutable Context,
+  handle: LHandle<JSONID, JSONFile>,
+  key: SKJSON.CJSON,
+): SKJSON.CJSON {
+  SKJSON.CJArray(handle.getArray(context, JSONID(key)).map(v -> v.value))
+}
 @export("SKIP_SKStore_getSelf")
 fun getSelf(
   context: mutable Context,
@@ -458,7 +495,17 @@ fun getSelf(
 ): SKJSON.CJSON {
   handle.get(context, JSONID(key)).value
 }
-
+@export("SKIP_SKStore_maybeGetSelf")
+fun maybeGetSelf(
+  context: mutable Context,
+  handle: LHandle<JSONID, JSONFile>,
+  key: SKJSON.CJSON,
+): SKJSON.CJSON {
+  handle.maybeGet(context, JSONID(key)) match {
+  | Some(v) -> v.value
+  | None() -> SKJSON.CJNull()
+  }
+}
 @export("SKIP_SKStore_size")
 fun size(context: mutable Context, handleId: String): Float {
   eager = EHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));

--- a/skstore/ts/examples/sheet.ts
+++ b/skstore/ts/examples/sheet.ts
@@ -42,7 +42,7 @@ class ComputeExpression implements LazyCompute<[string, string], string> {
     key: [string, string],
   ): string | null {
     const getComputed = (key: [string, string]) => {
-      const v = selfHdl.get(key);
+      const v = selfHdl.getSingle(key);
       if (typeof v == "number") return v;
       if (typeof v == "string") {
         const nv = parseFloat(v);
@@ -53,7 +53,7 @@ class ComputeExpression implements LazyCompute<[string, string], string> {
       );
     };
     const sheet = key[0];
-    const v = this.skall.maybeGet(key);
+    const v = this.skall.maybeGetSingle(key);
     if (v && v.charAt(0) == "=") {
       try {
         // Fake evaluator in this exemple
@@ -94,7 +94,7 @@ class CallCompute
   ): Iterable<[[string, string], string]> {
     const v = it.uniqueValue();
     if (typeof v == "string" && v.charAt(0) == "=") {
-      return Array([key, this.evaluator.get(key)]);
+      return Array([key, this.evaluator.getSingle(key)]);
     }
     if (v == null) {
       throw new Error("(sheet, cell) pair must be unique.");

--- a/skstore/ts/examples/sheet.ts
+++ b/skstore/ts/examples/sheet.ts
@@ -42,7 +42,7 @@ class ComputeExpression implements LazyCompute<[string, string], string> {
     key: [string, string],
   ): string | null {
     const getComputed = (key: [string, string]) => {
-      const v = selfHdl.getFirst(key);
+      const v = selfHdl.getOne(key);
       if (typeof v == "number") return v;
       if (typeof v == "string") {
         const nv = parseFloat(v);
@@ -94,7 +94,7 @@ class CallCompute
   ): Iterable<[[string, string], string]> {
     const v = it.uniqueValue();
     if (typeof v == "string" && v.charAt(0) == "=") {
-      return Array([key, this.evaluator.getFirst(key)]);
+      return Array([key, this.evaluator.getOne(key)]);
     }
     if (v == null) {
       throw new Error("(sheet, cell) pair must be unique.");

--- a/skstore/ts/examples/sheet.ts
+++ b/skstore/ts/examples/sheet.ts
@@ -42,7 +42,7 @@ class ComputeExpression implements LazyCompute<[string, string], string> {
     key: [string, string],
   ): string | null {
     const getComputed = (key: [string, string]) => {
-      const v = selfHdl.getSingle(key);
+      const v = selfHdl.getFirst(key);
       if (typeof v == "number") return v;
       if (typeof v == "string") {
         const nv = parseFloat(v);
@@ -53,7 +53,7 @@ class ComputeExpression implements LazyCompute<[string, string], string> {
       );
     };
     const sheet = key[0];
-    const v = this.skall.maybeGetSingle(key);
+    const v = this.skall.maybeGetFirst(key);
     if (v && v.charAt(0) == "=") {
       try {
         // Fake evaluator in this exemple
@@ -94,7 +94,7 @@ class CallCompute
   ): Iterable<[[string, string], string]> {
     const v = it.uniqueValue();
     if (typeof v == "string" && v.charAt(0) == "=") {
-      return Array([key, this.evaluator.getSingle(key)]);
+      return Array([key, this.evaluator.getFirst(key)]);
     }
     if (v == null) {
       throw new Error("(sheet, cell) pair must be unique.");

--- a/skstore/ts/examples/sum.ts
+++ b/skstore/ts/examples/sum.ts
@@ -40,7 +40,7 @@ class Add implements Mapper<number, number, number, number> {
     it: NonEmptyIterator<number>,
   ): Iterable<[number, number]> {
     const v = it.first();
-    const ev = this.other.maybeGetSingle(key);
+    const ev = this.other.maybeGetFirst(key);
     if (ev !== null) {
       return Array([key, v + (ev ?? 0)]);
     }

--- a/skstore/ts/examples/sum.ts
+++ b/skstore/ts/examples/sum.ts
@@ -40,7 +40,7 @@ class Add implements Mapper<number, number, number, number> {
     it: NonEmptyIterator<number>,
   ): Iterable<[number, number]> {
     const v = it.first();
-    const ev = this.other.maybeGet(key);
+    const ev = this.other.maybeGetSingle(key);
     if (ev !== null) {
       return Array([key, v + (ev ?? 0)]);
     }

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -63,12 +63,12 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     return this.context.getArray(this.eagerHdl, key);
   }
 
-  getFirst(key: K): V {
-    return this.context.getFirst(this.eagerHdl, key);
+  getOne(key: K): V {
+    return this.context.getOne(this.eagerHdl, key);
   }
 
-  maybeGetFirst(key: K): Opt<V> {
-    return this.context.maybeGetFirst(this.eagerHdl, key);
+  maybeGetOne(key: K): Opt<V> {
+    return this.context.maybeGetOne(this.eagerHdl, key);
   }
 
   size = () => {
@@ -689,12 +689,12 @@ class LHandleImpl<K extends TJSON, V extends TJSON> implements LHandle<K, V> {
     return this.context.getArrayLazy(this.lazyHdl, key);
   }
 
-  getFirst(key: K): V {
-    return this.context.getFirstLazy(this.lazyHdl, key);
+  getOne(key: K): V {
+    return this.context.getOneLazy(this.lazyHdl, key);
   }
 
-  maybeGetFirst(key: K): Opt<V> {
-    return this.context.maybeGetFirstLazy(this.lazyHdl, key);
+  maybeGetOne(key: K): Opt<V> {
+    return this.context.maybeGetOneLazy(this.lazyHdl, key);
   }
 }
 
@@ -717,11 +717,11 @@ export class LSelfImpl<K extends TJSON, V extends TJSON>
   getArray(key: K): V[] {
     return this.context.getArraySelf(this.lazyHdl, key);
   }
-  getFirst(key: K): V {
-    return this.context.getFirstSelf(this.lazyHdl, key);
+  getOne(key: K): V {
+    return this.context.getOneSelf(this.lazyHdl, key);
   }
-  maybeGetFirst(key: K): Opt<V> {
-    return this.context.maybeGetFirstSelf(this.lazyHdl, key);
+  maybeGetOne(key: K): Opt<V> {
+    return this.context.maybeGetOneSelf(this.lazyHdl, key);
   }
 }
 

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -59,12 +59,16 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     return new EHandleImpl<K2, V2>(this.context, eagerHdl);
   }
 
-  get(key: K): V {
+  get(key: K): V[] {
     return this.context.get(this.eagerHdl, key);
   }
 
-  maybeGet(key: K): Opt<V> {
-    return this.context.maybeGet(this.eagerHdl, key);
+  getSingle(key: K): V {
+    return this.context.getSingle(this.eagerHdl, key);
+  }
+
+  maybeGetSingle(key: K): Opt<V> {
+    return this.context.maybeGetSingle(this.eagerHdl, key);
   }
 
   size = () => {
@@ -681,8 +685,16 @@ class LHandleImpl<K extends TJSON, V extends TJSON> implements LHandle<K, V> {
     });
   }
 
-  get(key: K): V {
+  get(key: K): V[] {
     return this.context.getLazy(this.lazyHdl, key);
+  }
+
+  getSingle(key: K): V {
+    return this.context.getSingleLazy(this.lazyHdl, key);
+  }
+
+  maybeGetSingle(key: K): Opt<V> {
+    return this.context.maybeGetSingleLazy(this.lazyHdl, key);
   }
 }
 
@@ -702,8 +714,14 @@ export class LSelfImpl<K extends TJSON, V extends TJSON>
     });
   }
 
-  get(key: K): V {
+  get(key: K): V[] {
     return this.context.getSelf(this.lazyHdl, key);
+  }
+  getSingle(key: K): V {
+    return this.context.getSingleSelf(this.lazyHdl, key);
+  }
+  maybeGetSingle(key: K): Opt<V> {
+    return this.context.maybeGetSingleSelf(this.lazyHdl, key);
   }
 }
 

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -59,16 +59,16 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     return new EHandleImpl<K2, V2>(this.context, eagerHdl);
   }
 
-  get(key: K): V[] {
-    return this.context.get(this.eagerHdl, key);
+  getArray(key: K): V[] {
+    return this.context.getArray(this.eagerHdl, key);
   }
 
-  getSingle(key: K): V {
-    return this.context.getSingle(this.eagerHdl, key);
+  getFirst(key: K): V {
+    return this.context.getFirst(this.eagerHdl, key);
   }
 
-  maybeGetSingle(key: K): Opt<V> {
-    return this.context.maybeGetSingle(this.eagerHdl, key);
+  maybeGetFirst(key: K): Opt<V> {
+    return this.context.maybeGetFirst(this.eagerHdl, key);
   }
 
   size = () => {
@@ -685,16 +685,16 @@ class LHandleImpl<K extends TJSON, V extends TJSON> implements LHandle<K, V> {
     });
   }
 
-  get(key: K): V[] {
-    return this.context.getLazy(this.lazyHdl, key);
+  getArray(key: K): V[] {
+    return this.context.getArrayLazy(this.lazyHdl, key);
   }
 
-  getSingle(key: K): V {
-    return this.context.getSingleLazy(this.lazyHdl, key);
+  getFirst(key: K): V {
+    return this.context.getFirstLazy(this.lazyHdl, key);
   }
 
-  maybeGetSingle(key: K): Opt<V> {
-    return this.context.maybeGetSingleLazy(this.lazyHdl, key);
+  maybeGetFirst(key: K): Opt<V> {
+    return this.context.maybeGetFirstLazy(this.lazyHdl, key);
   }
 }
 
@@ -714,14 +714,14 @@ export class LSelfImpl<K extends TJSON, V extends TJSON>
     });
   }
 
-  get(key: K): V[] {
-    return this.context.getSelf(this.lazyHdl, key);
+  getArray(key: K): V[] {
+    return this.context.getArraySelf(this.lazyHdl, key);
   }
-  getSingle(key: K): V {
-    return this.context.getSingleSelf(this.lazyHdl, key);
+  getFirst(key: K): V {
+    return this.context.getFirstSelf(this.lazyHdl, key);
   }
-  maybeGetSingle(key: K): Opt<V> {
-    return this.context.maybeGetSingleSelf(this.lazyHdl, key);
+  maybeGetFirst(key: K): Opt<V> {
+    return this.context.maybeGetFirstSelf(this.lazyHdl, key);
   }
 }
 

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -171,7 +171,7 @@ export class ContextImpl implements Context {
     ) as V[];
   };
 
-  getFirst = <K, V>(eagerHdl: string, key: K) => {
+  getOne = <K, V>(eagerHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_get(
         this.pointer(),
@@ -181,7 +181,7 @@ export class ContextImpl implements Context {
     ) as V;
   };
 
-  maybeGetFirst = <K, V>(eagerHdl: string, key: K) => {
+  maybeGetOne = <K, V>(eagerHdl: string, key: K) => {
     const res = this.exports.SKIP_SKStore_maybeGet(
       this.pointer(),
       this.skjson.exportString(eagerHdl),
@@ -200,7 +200,7 @@ export class ContextImpl implements Context {
     ) as V[];
   };
 
-  getFirstLazy = <K, V>(lazyHdl: string, key: K) => {
+  getOneLazy = <K, V>(lazyHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getLazy(
         this.pointer(),
@@ -210,7 +210,7 @@ export class ContextImpl implements Context {
     ) as V;
   };
 
-  maybeGetFirstLazy = <K, V>(lazyHdl: string, key: K) => {
+  maybeGetOneLazy = <K, V>(lazyHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_maybeGetLazy(
         this.pointer(),
@@ -229,7 +229,7 @@ export class ContextImpl implements Context {
       ),
     ) as V[];
   };
-  getFirstSelf = <K, V>(lazyHdl: ptr, key: K) => {
+  getOneSelf = <K, V>(lazyHdl: ptr, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getSelf(
         this.pointer(),
@@ -238,7 +238,7 @@ export class ContextImpl implements Context {
       ),
     ) as V;
   };
-  maybeGetFirstSelf = <K, V>(lazyHdl: ptr, key: K) => {
+  maybeGetOneSelf = <K, V>(lazyHdl: ptr, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_maybeGetSelf(
         this.pointer(),

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -161,7 +161,7 @@ export class ContextImpl implements Context {
     ) as R[];
   };
 
-  get = <K, V>(eagerHdl: string, key: K) => {
+  getArray = <K, V>(eagerHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getArray(
         this.pointer(),
@@ -171,7 +171,7 @@ export class ContextImpl implements Context {
     ) as V[];
   };
 
-  getSingle = <K, V>(eagerHdl: string, key: K) => {
+  getFirst = <K, V>(eagerHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_get(
         this.pointer(),
@@ -181,7 +181,7 @@ export class ContextImpl implements Context {
     ) as V;
   };
 
-  maybeGetSingle = <K, V>(eagerHdl: string, key: K) => {
+  maybeGetFirst = <K, V>(eagerHdl: string, key: K) => {
     const res = this.exports.SKIP_SKStore_maybeGet(
       this.pointer(),
       this.skjson.exportString(eagerHdl),
@@ -190,7 +190,7 @@ export class ContextImpl implements Context {
     return this.skjson.importJSON(res) as Opt<V>;
   };
 
-  getLazy = <K, V>(lazyHdl: string, key: K) => {
+  getArrayLazy = <K, V>(lazyHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getArrayLazy(
         this.pointer(),
@@ -200,7 +200,7 @@ export class ContextImpl implements Context {
     ) as V[];
   };
 
-  getSingleLazy = <K, V>(lazyHdl: string, key: K) => {
+  getFirstLazy = <K, V>(lazyHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getLazy(
         this.pointer(),
@@ -210,7 +210,7 @@ export class ContextImpl implements Context {
     ) as V;
   };
 
-  maybeGetSingleLazy = <K, V>(lazyHdl: string, key: K) => {
+  maybeGetFirstLazy = <K, V>(lazyHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_maybeGetLazy(
         this.pointer(),
@@ -220,7 +220,7 @@ export class ContextImpl implements Context {
     ) as Opt<V>;
   };
 
-  getSelf = <K, V>(lazyHdl: ptr, key: K) => {
+  getArraySelf = <K, V>(lazyHdl: ptr, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getArraySelf(
         this.pointer(),
@@ -229,7 +229,7 @@ export class ContextImpl implements Context {
       ),
     ) as V[];
   };
-  getSingleSelf = <K, V>(lazyHdl: ptr, key: K) => {
+  getFirstSelf = <K, V>(lazyHdl: ptr, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getSelf(
         this.pointer(),
@@ -238,7 +238,7 @@ export class ContextImpl implements Context {
       ),
     ) as V;
   };
-  maybeGetSingleSelf = <K, V>(lazyHdl: ptr, key: K) => {
+  maybeGetFirstSelf = <K, V>(lazyHdl: ptr, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_maybeGetSelf(
         this.pointer(),
@@ -284,9 +284,8 @@ export class ContextImpl implements Context {
     mapper: (key: K, it: NonEmptyIterator<V>) => Iterable<[K2, V2]>,
   ) => {
     const computeFnId = this.handles.register(mapper);
-    const pointer = this.pointer();
     const resHdlPtr = this.exports.SKIP_SKStore_map(
-      pointer,
+      this.pointer(),
       this.skjson.exportString(eagerHdl),
       this.skjson.exportString(name),
       computeFnId,

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -150,16 +150,6 @@ export class ContextImpl implements Context {
     return this.skjson.importString(resHdlPtr);
   };
 
-  get = <K, V>(eagerHdl: string, key: K) => {
-    return this.skjson.importJSON(
-      this.exports.SKIP_SKStore_get(
-        this.pointer(),
-        this.skjson.exportString(eagerHdl),
-        this.skjson.exportJSON(key),
-      ),
-    ) as V;
-  };
-
   getFromTable = <K, R>(table: string, key: K, index?: string) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getFromTable(
@@ -171,7 +161,27 @@ export class ContextImpl implements Context {
     ) as R[];
   };
 
-  maybeGet = <K, V>(eagerHdl: string, key: K) => {
+  get = <K, V>(eagerHdl: string, key: K) => {
+    return this.skjson.importJSON(
+      this.exports.SKIP_SKStore_getArray(
+        this.pointer(),
+        this.skjson.exportString(eagerHdl),
+        this.skjson.exportJSON(key),
+      ),
+    ) as V[];
+  };
+
+  getSingle = <K, V>(eagerHdl: string, key: K) => {
+    return this.skjson.importJSON(
+      this.exports.SKIP_SKStore_get(
+        this.pointer(),
+        this.skjson.exportString(eagerHdl),
+        this.skjson.exportJSON(key),
+      ),
+    ) as V;
+  };
+
+  maybeGetSingle = <K, V>(eagerHdl: string, key: K) => {
     const res = this.exports.SKIP_SKStore_maybeGet(
       this.pointer(),
       this.skjson.exportString(eagerHdl),
@@ -182,6 +192,16 @@ export class ContextImpl implements Context {
 
   getLazy = <K, V>(lazyHdl: string, key: K) => {
     return this.skjson.importJSON(
+      this.exports.SKIP_SKStore_getArrayLazy(
+        this.pointer(),
+        this.skjson.exportString(lazyHdl),
+        this.skjson.exportJSON(key),
+      ),
+    ) as V[];
+  };
+
+  getSingleLazy = <K, V>(lazyHdl: string, key: K) => {
+    return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getLazy(
         this.pointer(),
         this.skjson.exportString(lazyHdl),
@@ -190,7 +210,26 @@ export class ContextImpl implements Context {
     ) as V;
   };
 
+  maybeGetSingleLazy = <K, V>(lazyHdl: string, key: K) => {
+    return this.skjson.importJSON(
+      this.exports.SKIP_SKStore_maybeGetLazy(
+        this.pointer(),
+        this.skjson.exportString(lazyHdl),
+        this.skjson.exportJSON(key),
+      ),
+    ) as Opt<V>;
+  };
+
   getSelf = <K, V>(lazyHdl: ptr, key: K) => {
+    return this.skjson.importJSON(
+      this.exports.SKIP_SKStore_getArraySelf(
+        this.pointer(),
+        lazyHdl,
+        this.skjson.exportJSON(key),
+      ),
+    ) as V[];
+  };
+  getSingleSelf = <K, V>(lazyHdl: ptr, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getSelf(
         this.pointer(),
@@ -198,6 +237,15 @@ export class ContextImpl implements Context {
         this.skjson.exportJSON(key),
       ),
     ) as V;
+  };
+  maybeGetSingleSelf = <K, V>(lazyHdl: ptr, key: K) => {
+    return this.skjson.importJSON(
+      this.exports.SKIP_SKStore_maybeGetSelf(
+        this.pointer(),
+        lazyHdl,
+        this.skjson.exportJSON(key),
+      ),
+    ) as Opt<V>;
   };
 
   size = (eagerHdl: string) => {

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -336,7 +336,7 @@ class SKJSONShared implements SKJSON {
   }
 
   importOptJSON(value: Opt<ptr>, copy?: boolean) {
-    if (value == null) {
+    if (value === null || value === 0) {
       return null;
     }
     return this.importJSON(value, copy);

--- a/skstore/ts/src/prv/skstore_types.ts
+++ b/skstore/ts/src/prv/skstore_types.ts
@@ -67,16 +67,16 @@ export interface Context {
   getFromTable: <K, R>(table: string, key: K, index?: string) => R[];
 
   getArray: <K, V>(eagerHdl: string, key: K) => V[];
-  getFirst: <K, V>(eagerHdl: string, key: K) => V;
-  maybeGetFirst: <K, V>(eagerHdl: string, key: K) => Opt<V>;
+  getOne: <K, V>(eagerHdl: string, key: K) => V;
+  maybeGetOne: <K, V>(eagerHdl: string, key: K) => Opt<V>;
 
   getArrayLazy: <K, V>(eagerHdl: string, key: K) => V[];
-  getFirstLazy: <K, V>(eagerHdl: string, key: K) => V;
-  maybeGetFirstLazy: <K, V>(eagerHdl: string, key: K) => Opt<V>;
+  getOneLazy: <K, V>(eagerHdl: string, key: K) => V;
+  maybeGetOneLazy: <K, V>(eagerHdl: string, key: K) => Opt<V>;
 
   getArraySelf: <K, V>(lazyHdl: ptr, key: K) => V[];
-  getFirstSelf: <K, V>(lazyHdl: ptr, key: K) => V;
-  maybeGetFirstSelf: <K, V>(lazyHdl: ptr, key: K) => Opt<V>;
+  getOneSelf: <K, V>(lazyHdl: ptr, key: K) => V;
+  maybeGetOneSelf: <K, V>(lazyHdl: ptr, key: K) => Opt<V>;
 
   size: (eagerHdl: string) => number;
 

--- a/skstore/ts/src/prv/skstore_types.ts
+++ b/skstore/ts/src/prv/skstore_types.ts
@@ -66,17 +66,17 @@ export interface Context {
 
   getFromTable: <K, R>(table: string, key: K, index?: string) => R[];
 
-  get: <K, V>(eagerHdl: string, key: K) => V[];
-  getSingle: <K, V>(eagerHdl: string, key: K) => V;
-  maybeGetSingle: <K, V>(eagerHdl: string, key: K) => Opt<V>;
+  getArray: <K, V>(eagerHdl: string, key: K) => V[];
+  getFirst: <K, V>(eagerHdl: string, key: K) => V;
+  maybeGetFirst: <K, V>(eagerHdl: string, key: K) => Opt<V>;
 
-  getLazy: <K, V>(eagerHdl: string, key: K) => V[];
-  getSingleLazy: <K, V>(eagerHdl: string, key: K) => V;
-  maybeGetSingleLazy: <K, V>(eagerHdl: string, key: K) => Opt<V>;
+  getArrayLazy: <K, V>(eagerHdl: string, key: K) => V[];
+  getFirstLazy: <K, V>(eagerHdl: string, key: K) => V;
+  maybeGetFirstLazy: <K, V>(eagerHdl: string, key: K) => Opt<V>;
 
-  getSelf: <K, V>(lazyHdl: ptr, key: K) => V[];
-  getSingleSelf: <K, V>(lazyHdl: ptr, key: K) => V;
-  maybeGetSingleSelf: <K, V>(lazyHdl: ptr, key: K) => Opt<V>;
+  getArraySelf: <K, V>(lazyHdl: ptr, key: K) => V[];
+  getFirstSelf: <K, V>(lazyHdl: ptr, key: K) => V;
+  maybeGetFirstSelf: <K, V>(lazyHdl: ptr, key: K) => Opt<V>;
 
   size: (eagerHdl: string) => number;
 

--- a/skstore/ts/src/prv/skstore_types.ts
+++ b/skstore/ts/src/prv/skstore_types.ts
@@ -64,11 +64,19 @@ export interface Context {
     call: (key: K, params: P) => Promise<AValue<V, M>>,
   ) => string;
 
-  get: <K, V>(eagerHdl: string, key: K) => V;
   getFromTable: <K, R>(table: string, key: K, index?: string) => R[];
-  maybeGet: <K, V>(eagerHdl: string, key: K) => Opt<V>;
-  getLazy: <K, V>(lazyHdl: string, key: K) => V;
-  getSelf: <K, V>(lazyHdl: ptr, key: K) => V;
+
+  get: <K, V>(eagerHdl: string, key: K) => V[];
+  getSingle: <K, V>(eagerHdl: string, key: K) => V;
+  maybeGetSingle: <K, V>(eagerHdl: string, key: K) => Opt<V>;
+
+  getLazy: <K, V>(eagerHdl: string, key: K) => V[];
+  getSingleLazy: <K, V>(eagerHdl: string, key: K) => V;
+  maybeGetSingleLazy: <K, V>(eagerHdl: string, key: K) => Opt<V>;
+
+  getSelf: <K, V>(lazyHdl: ptr, key: K) => V[];
+  getSingleSelf: <K, V>(lazyHdl: ptr, key: K) => V;
+  maybeGetSingleSelf: <K, V>(lazyHdl: ptr, key: K) => Opt<V>;
 
   size: (eagerHdl: string) => number;
 
@@ -131,14 +139,19 @@ export interface FromWasm {
     accInit: ptr,
   ): ptr;
 
-  SKIP_SKStore_get(ctx: ptr, getterHdl: ptr, key: ptr): ptr;
   SKIP_SKStore_getFromTable(ctx: ptr, table: ptr, key: ptr, index: ptr): ptr;
 
+  SKIP_SKStore_getArray(ctx: ptr, getterHdl: ptr, key: ptr): ptr;
+  SKIP_SKStore_get(ctx: ptr, getterHdl: ptr, key: ptr): ptr;
   SKIP_SKStore_maybeGet(ctx: ptr, getterHdl: ptr, key: ptr): ptr;
 
+  SKIP_SKStore_getArrayLazy(ctx: ptr, lazyId: ptr, key: ptr): ptr;
   SKIP_SKStore_getLazy(ctx: ptr, lazyId: ptr, key: ptr): ptr;
+  SKIP_SKStore_maybeGetLazy(ctx: ptr, lazyId: ptr, key: ptr): ptr;
 
+  SKIP_SKStore_getArraySelf(ctx: ptr, selfHdl: ptr, key: ptr): ptr;
   SKIP_SKStore_getSelf(ctx: ptr, selfHdl: ptr, key: ptr): ptr;
+  SKIP_SKStore_maybeGetSelf(ctx: ptr, selfHdl: ptr, key: ptr): ptr;
 
   SKIP_SKStore_size(ctx: ptr, eagerHdl: ptr): number;
 

--- a/skstore/ts/src/skstore_api.ts
+++ b/skstore/ts/src/skstore_api.ts
@@ -235,14 +235,28 @@ export interface NonEmptyIterator<T> {
 
 /**
  * A _Lazy_ Handle on a reactive collection, whose values are computed only when queried
- * using `get`
  */
 export interface LHandle<K extends TJSON, V extends TJSON> {
   /**
-   * Get (and potentially compute) a value of a lazy reactive collection
+   * Get (and potentially compute) all values mapped to by some key of a lazy reactive
+   * collection.
    * @throws {Error} when the key does not exist
    */
-  get(key: K): V;
+  get(key: K): V[];
+
+  /**
+   * Get (and potentially compute) a value of a lazy reactive collection.
+   * If multiple values are mapped to by the key, any of them can be returned
+   * @throws {Error} when the key does not exist
+   */
+  getSingle(key: K): V;
+
+  /**
+   * Get (and potentially compute) a value of a lazy reactive collection, if one exists.
+   * If multiple values are mapped to by the key, any of them can be returned.
+   * @throws {Error} when the key does not exist
+   */
+  maybeGetSingle(key: K): Opt<V>;
 }
 
 export interface ALHandle<K extends TJSON, V extends TJSON, M extends TJSON>
@@ -254,15 +268,24 @@ export interface ALHandle<K extends TJSON, V extends TJSON, M extends TJSON>
  */
 export interface EHandle<K extends TJSON, V extends TJSON> {
   /**
-   * Get a value of an eager reactive collection
+   * Get (and potentially compute) all values mapped to by some key of a lazy reactive
+   * collection.
    * @throws {Error} when the key does not exist
    */
-  get(key: K): V;
+  get(key: K): V[];
+
   /**
-   * Get a value of an eager reactive collection, if it exists
+   * Get a value of an eager reactive collection.
+   * If multiple values are mapped to by the key, any of them can be returned.
+   * @throws {Error} when the key does not exist
+   */
+  getSingle(key: K): V;
+  /**
+   * Get a value of an eager reactive collection, if one exists.
+   * If multiple values are mapped to by the key, any of them can be returned.
    * @returns the value for this `key`, or null if no such value exists
    */
-  maybeGet(key: K): Opt<V>;
+  maybeGetSingle(key: K): Opt<V>;
 
   /**
    *  Create a new eager reactive collection by mapping some computation over this one

--- a/skstore/ts/src/skstore_api.ts
+++ b/skstore/ts/src/skstore_api.ts
@@ -245,17 +245,16 @@ export interface LHandle<K extends TJSON, V extends TJSON> {
 
   /**
    * Get (and potentially compute) a value of a lazy reactive collection.
-   * If multiple values are mapped to by the key, any of them can be returned
-   * @throws {Error} when the key does not exist
+   * @throws {Error} when either zero or multiple such values exist
    */
-  getFirst(key: K): V;
+  getOne(key: K): V;
 
   /**
    * Get (and potentially compute) a value of a lazy reactive collection, if one exists.
    * If multiple values are mapped to by the key, any of them can be returned.
    * @returns the value for this `key`, or null if no such value exists
    */
-  maybeGetFirst(key: K): Opt<V>;
+  maybeGetOne(key: K): Opt<V>;
 }
 
 export interface ALHandle<K extends TJSON, V extends TJSON, M extends TJSON>
@@ -274,16 +273,15 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
 
   /**
    * Get a value of an eager reactive collection.
-   * If multiple values are mapped to by the key, any of them can be returned.
-   * @throws {Error} when the key does not exist
+   * @throws {Error} when either zero or multiple such values exist
    */
-  getFirst(key: K): V;
+  getOne(key: K): V;
   /**
    * Get a value of an eager reactive collection, if one exists.
    * If multiple values are mapped to by the key, any of them can be returned.
    * @returns the value for this `key`, or null if no such value exists
    */
-  maybeGetFirst(key: K): Opt<V>;
+  maybeGetOne(key: K): Opt<V>;
 
   /**
    *  Create a new eager reactive collection by mapping some computation over this one

--- a/skstore/ts/src/skstore_api.ts
+++ b/skstore/ts/src/skstore_api.ts
@@ -242,21 +242,21 @@ export interface LHandle<K extends TJSON, V extends TJSON> {
    * collection.
    * @throws {Error} when the key does not exist
    */
-  get(key: K): V[];
+  getArray(key: K): V[];
 
   /**
    * Get (and potentially compute) a value of a lazy reactive collection.
    * If multiple values are mapped to by the key, any of them can be returned
    * @throws {Error} when the key does not exist
    */
-  getSingle(key: K): V;
+  getFirst(key: K): V;
 
   /**
    * Get (and potentially compute) a value of a lazy reactive collection, if one exists.
    * If multiple values are mapped to by the key, any of them can be returned.
    * @throws {Error} when the key does not exist
    */
-  maybeGetSingle(key: K): Opt<V>;
+  maybeGetFirst(key: K): Opt<V>;
 }
 
 export interface ALHandle<K extends TJSON, V extends TJSON, M extends TJSON>
@@ -272,20 +272,20 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
    * collection.
    * @throws {Error} when the key does not exist
    */
-  get(key: K): V[];
+  getArray(key: K): V[];
 
   /**
    * Get a value of an eager reactive collection.
    * If multiple values are mapped to by the key, any of them can be returned.
    * @throws {Error} when the key does not exist
    */
-  getSingle(key: K): V;
+  getFirst(key: K): V;
   /**
    * Get a value of an eager reactive collection, if one exists.
    * If multiple values are mapped to by the key, any of them can be returned.
    * @returns the value for this `key`, or null if no such value exists
    */
-  maybeGetSingle(key: K): Opt<V>;
+  maybeGetFirst(key: K): Opt<V>;
 
   /**
    *  Create a new eager reactive collection by mapping some computation over this one

--- a/skstore/ts/src/skstore_api.ts
+++ b/skstore/ts/src/skstore_api.ts
@@ -240,7 +240,6 @@ export interface LHandle<K extends TJSON, V extends TJSON> {
   /**
    * Get (and potentially compute) all values mapped to by some key of a lazy reactive
    * collection.
-   * @throws {Error} when the key does not exist
    */
   getArray(key: K): V[];
 
@@ -254,7 +253,7 @@ export interface LHandle<K extends TJSON, V extends TJSON> {
   /**
    * Get (and potentially compute) a value of a lazy reactive collection, if one exists.
    * If multiple values are mapped to by the key, any of them can be returned.
-   * @throws {Error} when the key does not exist
+   * @returns the value for this `key`, or null if no such value exists
    */
   maybeGetFirst(key: K): Opt<V>;
 }
@@ -270,7 +269,6 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
   /**
    * Get (and potentially compute) all values mapped to by some key of a lazy reactive
    * collection.
-   * @throws {Error} when the key does not exist
    */
   getArray(key: K): V[];
 

--- a/skstore/ts/tests/tests.ts
+++ b/skstore/ts/tests/tests.ts
@@ -148,7 +148,7 @@ function testMap3Init(
     TestParseInt,
   );
   const eager3 = eager1
-    .map<number, number, typeof TestAdd>(TestAdd, eager2)
+    .map1<number, number, typeof TestAdd>(TestAdd, eager2)
     .map<number, number, typeof TestSum>(TestSum);
   eager3.mapTo(output, TestToOutput);
 }

--- a/skstore/ts/tests/tests.ts
+++ b/skstore/ts/tests/tests.ts
@@ -85,7 +85,7 @@ class TestAdd implements Mapper<number, number, number, number> {
     it: NonEmptyIterator<number>,
   ): Iterable<[number, number]> {
     const v = it.first();
-    const ev = this.other.maybeGet(key);
+    const ev = this.other.maybeGetSingle(key);
     return Array([key, v + (ev ?? 0)]);
   }
 }
@@ -162,7 +162,7 @@ class TestLazyAdd implements LazyCompute<number, number> {
   constructor(private other: EHandle<number, number>) {}
 
   compute(selfHdl: LHandle<number, number>, key: number): number | null {
-    const v = this.other.maybeGet(key);
+    const v = this.other.maybeGetSingle(key);
     return (v ?? 0) + 2;
   }
 }
@@ -174,7 +174,7 @@ class TestSub implements Mapper<number, number, number, number> {
     key: number,
     it: NonEmptyIterator<number>,
   ): Iterable<[number, number]> {
-    return Array([key, this.other.get(key) - it.first()]);
+    return Array([key, this.other.getSingle(key) - it.first()]);
   }
 }
 
@@ -393,7 +393,7 @@ class TestLazyWithAsync
   constructor(private other: EHandle<number, number>) {}
 
   params(key: [number, number]) {
-    const v2 = this.other.maybeGet(key[0]);
+    const v2 = this.other.maybeGetSingle(key[0]);
     return v2 ?? 0;
   }
 
@@ -411,7 +411,7 @@ class TestCheckResult implements Mapper<number, number, number, string> {
     key: number,
     it: NonEmptyIterator<number>,
   ): Iterable<[number, string]> {
-    const result = this.asyncLazy.get([key, it.first()]);
+    const result = this.asyncLazy.getSingle([key, it.first()]);
     let value: [number, string];
     if (result.status == "loading") {
       value = [key, "loading"];

--- a/skstore/ts/tests/tests.ts
+++ b/skstore/ts/tests/tests.ts
@@ -162,7 +162,7 @@ class TestLazyAdd implements LazyCompute<number, number> {
   constructor(private other: EHandle<number, number>) {}
 
   compute(selfHdl: LHandle<number, number>, key: number): number | null {
-    const v = this.other.maybeGetSingle(key);
+    const v = this.other.maybeGetFirst(key);
     return (v ?? 0) + 2;
   }
 }
@@ -174,7 +174,7 @@ class TestSub implements Mapper<number, number, number, number> {
     key: number,
     it: NonEmptyIterator<number>,
   ): Iterable<[number, number]> {
-    return Array([key, this.other.getSingle(key) - it.first()]);
+    return Array([key, this.other.getFirst(key) - it.first()]);
   }
 }
 
@@ -393,7 +393,7 @@ class TestLazyWithAsync
   constructor(private other: EHandle<number, number>) {}
 
   params(key: [number, number]) {
-    const v2 = this.other.maybeGetSingle(key[0]);
+    const v2 = this.other.maybeGetFirst(key[0]);
     return v2 ?? 0;
   }
 
@@ -411,7 +411,7 @@ class TestCheckResult implements Mapper<number, number, number, string> {
     key: number,
     it: NonEmptyIterator<number>,
   ): Iterable<[number, string]> {
-    const result = this.asyncLazy.getSingle([key, it.first()]);
+    const result = this.asyncLazy.getFirst([key, it.first()]);
     let value: [number, string];
     if (result.status == "loading") {
       value = [key, "loading"];

--- a/skstore/ts/tests/tests.ts
+++ b/skstore/ts/tests/tests.ts
@@ -217,7 +217,7 @@ class TestLazyAdd implements LazyCompute<number, number> {
   constructor(private other: EHandle<number, number>) {}
 
   compute(selfHdl: LHandle<number, number>, key: number): number | null {
-    const v = this.other.maybeGetFirst(key);
+    const v = this.other.maybeGetOne(key);
     return (v ?? 0) + 2;
   }
 }
@@ -229,7 +229,7 @@ class TestSub implements Mapper<number, number, number, number> {
     key: number,
     it: NonEmptyIterator<number>,
   ): Iterable<[number, number]> {
-    return Array([key, this.other.getFirst(key) - it.first()]);
+    return Array([key, this.other.getOne(key) - it.first()]);
   }
 }
 
@@ -448,7 +448,7 @@ class TestLazyWithAsync
   constructor(private other: EHandle<number, number>) {}
 
   params(key: [number, number]) {
-    const v2 = this.other.maybeGetFirst(key[0]);
+    const v2 = this.other.maybeGetOne(key[0]);
     return v2 ?? 0;
   }
 
@@ -466,7 +466,7 @@ class TestCheckResult implements Mapper<number, number, number, string> {
     key: number,
     it: NonEmptyIterator<number>,
   ): Iterable<[number, string]> {
-    const result = this.asyncLazy.getFirst([key, it.first()]);
+    const result = this.asyncLazy.getOne([key, it.first()]);
     let value: [number, string];
     if (result.status == "loading") {
       value = [key, "loading"];


### PR DESCRIPTION
Previously, JS handles on SKStore collections had inconsistent/potentially-confusing "get" operations: eager handles had `get : K -> V`  and `maybeGet : K -> ?V`, and lazy handles had just `get : K -> V`.

These suffice for cases where there's at most one value per key, but are specialized versions of the generic `get` operation which can return multiple values (as in e.g. `getArray` or `getIter` in the skip implementation).

So, I've exposed more operations to the JS runtime and renamed things consistently, offering `get : K -> V[]`, `getSingle : K -> V`, and `maybeGetSingle : K -> ?V` on all JS handles.  Open to suggestion on renamings -- I settled on this to make as clear as possible that `get` is the generic/natural way of accessing collections and `getSingle`/`maybeGetSingle` are specialized cases.