### PR TITLE
[JS] Add support for mappers returning multiple values per key

### DIFF
--- a/skstore/src/Extern.sk
+++ b/skstore/src/Extern.sk
@@ -96,6 +96,18 @@ fun writerSet(
   writer.set(JSONID(key), JSONFile(value))
 }
 
+@export("SKIP_SKStore_writerSetArray")
+fun writerSetArray(
+  writer: mutable TWriter<JSONID, JSONFile>,
+  key: SKJSON.CJSON,
+  values: SKJSON.CJArray,
+): void {
+  files = values match {
+  | SKJSON.CJArray(xs) -> xs.map(x -> JSONFile(x))
+  };
+  writer.setArray(JSONID(key), files)
+}
+
 @export("SKIP_SKStore_iteratorFirst")
 fun iteratorFirst(values: mutable NonEmptyIterator<JSONFile>): SKJSON.CJSON {
   if (values.isPastFirstValue) {

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -456,17 +456,16 @@ class LinksImpl implements Links {
         jsu.importJSON(key),
         new NonEmptyIteratorImpl(jsu, fromWasm, it),
       ]);
-
-      const bindings = {};
-      for (const v of result) {
-        const t = v as any;
-        bindings[t[0]] ??= [];
-        bindings[t[0]].push(t[1]);
+      const bindings = new Map();
+      for (const datum of result) {
+        const k = datum[0];
+        const v = datum[1];
+        if (bindings.has(k)) bindings.get(k).push(v);
+        else bindings.set(k, [v]);
       }
-      for (const k in bindings) {
-        w.setArray(k, bindings[k]);
+      for (const kv of bindings) {
+        w.setArray(kv[0], kv[1]);
       }
-
       ref.pop();
     };
     this.applyMapTableFun = (

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -339,6 +339,13 @@ class WriterImpl<K, T> {
       this.skjson.exportJSON(value),
     );
   };
+  setArray = (key: K, values: T[]) => {
+    this.exports.SKIP_SKStore_writerSetArray(
+      this.pointer,
+      this.skjson.exportJSON(key),
+      this.skjson.exportJSON(values),
+    );
+  };
 }
 
 interface ToWasm {
@@ -449,10 +456,17 @@ class LinksImpl implements Links {
         jsu.importJSON(key),
         new NonEmptyIteratorImpl(jsu, fromWasm, it),
       ]);
+
+      const bindings = {};
       for (const v of result) {
         const t = v as any;
-        w.set(t[0], t[1]);
+        bindings[t[0]] ??= [];
+        bindings[t[0]].push(t[1]);
       }
+      for (const k in bindings) {
+        w.setArray(k, bindings[k]);
+      }
+
       ref.pop();
     };
     this.applyMapTableFun = (

--- a/skstore/ts/src/prv/skstore_types.ts
+++ b/skstore/ts/src/prv/skstore_types.ts
@@ -150,6 +150,7 @@ export interface FromWasm {
   SKIP_SKStore_iteratorFirst(it: ptr): ptr;
   // Writer
   SKIP_SKStore_writerSet(writer: ptr, key: ptr, value: ptr): void;
+  SKIP_SKStore_writerSetArray(writer: ptr, key: ptr, values: ptr): void;
 
   // Store
   SKIP_SKStore_createFor(session: ptr): float;


### PR DESCRIPTION
Previously, if a mapper returned multiple values bound to the same key then only one was written and the others were silently dropped.  I changed the behaviour here to match my intuition/expectation that they would all be written.

This came up in #285 but is somewhat orthogonal and changes semantics instead of just extending, so submitting separately.