### PR TITLE
[JS] default column schemas to non-null, swap argument order

### DIFF
--- a/skstore/ts/examples/sheet.ts
+++ b/skstore/ts/examples/sheet.ts
@@ -13,9 +13,13 @@ import { schema, ctext as text } from "skstore";
 
 export function tablesSchema() {
   console.log("## INPUT");
-  console.log("  cells (sheet TEXT, cell TEXT, value TEXT)");
+  console.log(
+    "  cells (sheet TEXT NOT NULL, cell TEXT NOT NULL, value TEXT NOT NULL)",
+  );
   console.log("## OUTPUT");
-  console.log("  computed (sheet TEXT, cell TEXT, value TEXT)");
+  console.log(
+    "  computed (sheet TEXT NOT NULL, cell TEXT NOT NULL, value TEXT NOT NULL)",
+  );
   console.log("##");
   return [
     schema("cells", [text("sheet"), text("cell"), text("value")]),

--- a/skstore/ts/examples/sum.ts
+++ b/skstore/ts/examples/sum.ts
@@ -12,15 +12,15 @@ import { cinteger as integer, schema } from "skstore";
 
 export function tablesSchema() {
   console.log("## INPUTS");
-  console.log("  input1 (id INTEGER, value INTEGER)");
-  console.log("  input2 (id INTEGER, value INTEGER)");
+  console.log("  input1 (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)");
+  console.log("  input2 (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)");
   console.log("## OUTPUT");
-  console.log("  output (id INTEGER, value INTEGER)");
+  console.log("  output (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)");
   console.log("##");
   return [
-    schema("input1", [integer("id", true), integer("v")]),
-    schema("input2", [integer("id", true), integer("v")]),
-    schema("output", [integer("id", true), integer("v")]),
+    schema("input1", [integer("id", true, true), integer("v")]),
+    schema("input2", [integer("id", true, true), integer("v")]),
+    schema("output", [integer("id", true, true), integer("v")]),
   ];
 }
 

--- a/skstore/ts/src/skstore_utils.ts
+++ b/skstore/ts/src/skstore_utils.ts
@@ -44,52 +44,52 @@ export function schema(name: string, expected: ColumnSchema[]): MirrorSchema {
 
 export function cinteger(
   name: string,
+  notnull: boolean = true,
   primary?: boolean,
-  notnull?: boolean,
 ): ColumnSchema {
   return {
     name,
     type: "INTEGER",
-    primary,
     notnull,
+    primary,
   };
 }
 
 export function ctext(
   name: string,
+  notnull: boolean = true,
   primary?: boolean,
-  notnull?: boolean,
 ): ColumnSchema {
   return {
     name,
     type: "TEXT",
-    primary,
     notnull,
+    primary,
   };
 }
 
 export function cjson(
   name: string,
+  notnull: boolean = true,
   primary?: boolean,
-  notnull?: boolean,
 ): ColumnSchema {
   return {
     name,
     type: "JSON",
-    primary,
     notnull,
+    primary,
   };
 }
 
 export function cfloat(
   name: string,
+  notnull: boolean = true,
   primary?: boolean,
-  notnull?: boolean,
 ): ColumnSchema {
   return {
     name,
     type: "JSON",
-    primary,
     notnull,
+    primary,
   };
 }

--- a/skstore/ts/tests/tests.ts
+++ b/skstore/ts/tests/tests.ts
@@ -535,8 +535,8 @@ export const tests: Test[] = [
   {
     name: "testMap1",
     schema: [
-      schema("input", [integer("id", true), integer("value")]),
-      schema("output", [integer("id", true), integer("value")]),
+      schema("input", [integer("id", true, true), integer("value")]),
+      schema("output", [integer("id", true, true), integer("value")]),
     ],
     init: testMap1Init,
     run: testMap1Run,
@@ -544,9 +544,9 @@ export const tests: Test[] = [
   {
     name: "testMap2",
     schema: [
-      schema("input1", [integer("id", true), text("value")]),
-      schema("input2", [integer("id", true), text("value")]),
-      schema("output", [integer("id", true), integer("value")]),
+      schema("input1", [integer("id", true, true), text("value")]),
+      schema("input2", [integer("id", true, true), text("value")]),
+      schema("output", [integer("id", true, true), integer("value")]),
     ],
     init: testMap2Init,
     run: testMap2Run,
@@ -555,7 +555,7 @@ export const tests: Test[] = [
     name: "testMap3",
     schema: [
       schema("input_no_index", [integer("id"), text("value")]),
-      schema("input_index", [integer("id", true), text("value")]),
+      schema("input_index", [integer("id", true, true), text("value")]),
       schema("output", [integer("id"), integer("value")]),
     ],
     init: testMap3Init,
@@ -564,9 +564,9 @@ export const tests: Test[] = [
   {
     name: "testSize",
     schema: [
-      schema("input", [integer("id", true), integer("value")]),
-      schema("size", [integer("id", true)]),
-      schema("output", [integer("id", true), integer("value")]),
+      schema("input", [integer("id", true, true), integer("value")]),
+      schema("size", [integer("id", true, true)]),
+      schema("output", [integer("id", true, true), integer("value")]),
     ],
     init: testSizeInit,
     run: testSizeRun,
@@ -574,8 +574,8 @@ export const tests: Test[] = [
   {
     name: "testLazy",
     schema: [
-      schema("input", [integer("id", true), integer("value")]),
-      schema("output", [integer("id", true), integer("value")]),
+      schema("input", [integer("id", true, true), integer("value")]),
+      schema("output", [integer("id", true, true), integer("value")]),
     ],
     init: testLazyInit,
     run: testLazyRun,
@@ -583,8 +583,8 @@ export const tests: Test[] = [
   {
     name: "testMapReduce",
     schema: [
-      schema("input", [integer("id", true), integer("v")]),
-      schema("output", [integer("id", true), integer("v")]),
+      schema("input", [integer("id", true, true), integer("v")]),
+      schema("output", [integer("id", true, true), integer("v")]),
     ],
     init: testMapReduceInit,
     run: testMapReduceRun,
@@ -592,8 +592,8 @@ export const tests: Test[] = [
   {
     name: "testMultiMap1",
     schema: [
-      schema("input1", [integer("id", true), integer("value")]),
-      schema("input2", [integer("id", true), integer("value")]),
+      schema("input1", [integer("id", true, true), integer("value")]),
+      schema("input2", [integer("id", true, true), integer("value")]),
       schema("output", [integer("src"), integer("id"), integer("v")]),
     ],
     init: testMultiMap1Init,
@@ -602,9 +602,9 @@ export const tests: Test[] = [
   {
     name: "testMultiMapReduce",
     schema: [
-      schema("input1", [integer("id", true), integer("value")]),
-      schema("input2", [integer("id", true), integer("value")]),
-      schema("output", [integer("id", true), integer("v")]),
+      schema("input1", [integer("id", true, true), integer("value")]),
+      schema("input2", [integer("id", true, true), integer("value")]),
+      schema("output", [integer("id", true, true), integer("v")]),
     ],
     init: testMultiMapReduceInit,
     run: testMultiMapReduceRun,
@@ -612,9 +612,9 @@ export const tests: Test[] = [
   {
     name: "testAsyncLazy",
     schema: [
-      schema("input1", [integer("id", true), integer("value")]),
-      schema("input2", [integer("id", true), integer("value")]),
-      schema("output", [integer("id", true), text("v")]),
+      schema("input1", [integer("id", true, true), integer("value")]),
+      schema("input2", [integer("id", true, true), integer("value")]),
+      schema("output", [integer("id", true, true), text("v")]),
     ],
     init: testAsyncLazyInit,
     run: testAsyncLazyRun,


### PR DESCRIPTION
Some minor tweaks to the column-schema helper functions, namely:

(1) default to non-null: my view is that data columns should be non-null by default and allow for null values only if specified, as in most null-aware type systems (kotlin, rust, etc.)

(2) swap argument order: tables will have at most one primary key column, while they may have many data columns of varying nullability.  Putting the (optional) primary key argument last saves from having to remember it and specify it as false for those data columns.