### PR TITLE
Add a `ValueMapper` interface for structure-preserving maps

### DIFF
--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -84,7 +84,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     const mapperObj = new mapper(...params);
     Object.freeze(mapperObj);
     if (!mapperObj.constructor.name) {
-      throw new Error("The class must have a name.");
+      throw new Error("Mapper classes must be defined at top-level.");
     }
     const eagerHdl = this.context.map(
       this.eagerHdl,
@@ -253,7 +253,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     const mapperObj = new mapper(...params);
     Object.freeze(mapperObj);
     if (!mapperObj.constructor.name) {
-      throw new Error("The class must have a name.");
+      throw new Error("Mapper classes must be defined at top-level.");
     }
     const eagerHdl = this.context.mapReduce(
       this.eagerHdl,
@@ -506,7 +506,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     const mapperObj = new mapper(...params);
     Object.freeze(mapperObj);
     if (!mapperObj.constructor.name) {
-      throw new Error("The class must have a name.");
+      throw new Error("Mapper classes must be defined at top-level.");
     }
     this.context.mapToSkdb(
       this.eagerHdl,
@@ -758,7 +758,7 @@ export class TableHandleImpl<R extends TJSON[]> implements TableHandle<R> {
     const mapperObj = new mapper(...params);
     Object.freeze(mapperObj);
     if (!mapperObj.constructor.name) {
-      throw new Error("The class must have a name.");
+      throw new Error("Mapper classes must be defined at top-level.");
     }
     const name = this.getName();
     const skname = name + "_" + mapperObj.constructor.name;

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -6,6 +6,8 @@ import type {
   EHandle,
   LHandle,
   Mapper,
+  ValueMapper,
+  EntryMapper,
   OutputMapper,
   TableHandle,
   SKStore,
@@ -13,7 +15,6 @@ import type {
   Mapping,
   MirrorSchema,
   ColumnSchema,
-  EntryMapper,
   Table,
   Loadable,
   JSONObject,
@@ -22,6 +23,7 @@ import type {
   EMParameters,
   MParameters,
   OMParameters,
+  VMParameters,
   LazyCompute,
   LParameters,
   AsyncLazyCompute,
@@ -237,6 +239,164 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p9: P9,
   ): EHandle<K2, V2> {
     return this.mapN(mapper, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+  }
+
+  mapValuesN<
+    V2 extends TJSON,
+    C extends new (...params: Param[]) => ValueMapper<V, V2>,
+  >(mapper: C, ...params: VMParameters<V, V2, C>): EHandle<K, V2> {
+    params.forEach(check);
+    const mapperObj = new mapper(...params);
+    Object.freeze(mapperObj);
+    if (!mapperObj.constructor.name) {
+      throw new Error("Mapper classes must be named.");
+    }
+    const eagerHdl = this.context.map(
+      this.eagerHdl,
+      mapperObj.constructor.name,
+      (key: K, it: NonEmptyIterator<V>) =>
+        it.toArray().map((v) => [key, mapperObj.mapValue(v)]),
+    );
+    return this.derive<K, V2>(eagerHdl);
+  }
+
+  mapValues<V2 extends TJSON>(
+    mapper: new () => ValueMapper<V, V2>,
+  ): EHandle<K, V2> {
+    return this.mapValuesN(mapper);
+  }
+
+  mapValues1<V2 extends TJSON, P1>(
+    mapper: new (p1: P1) => ValueMapper<V, V2>,
+    p1: P1,
+  ): EHandle<K, V2> {
+    return this.mapValuesN(mapper, p1);
+  }
+
+  mapValues2<V2 extends TJSON, P1, P2>(
+    mapper: new (p1: P1, p2: P2) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+  ): EHandle<K, V2> {
+    return this.mapValuesN(mapper, p1, p2);
+  }
+
+  mapValues3<V2 extends TJSON, P1, P2, P3>(
+    mapper: new (p1: P1, p2: P2, p3: P3) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+  ): EHandle<K, V2> {
+    return this.mapValuesN(mapper, p1, p2, p3);
+  }
+
+  mapValues4<V2 extends TJSON, P1, P2, P3, P4>(
+    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ): EHandle<K, V2> {
+    return this.mapValuesN(mapper, p1, p2, p3, p4);
+  }
+
+  mapValues5<V2 extends TJSON, P1, P2, P3, P4, P5>(
+    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ): EHandle<K, V2> {
+    return this.mapValuesN(mapper, p1, p2, p3, p4, p5);
+  }
+
+  mapValues6<V2 extends TJSON, P1, P2, P3, P4, P5, P6>(
+    mapper: new (
+      p1: P1,
+      p2: P2,
+      p3: P3,
+      p4: P4,
+      p5: P5,
+      p6: P6,
+    ) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ): EHandle<K, V2> {
+    return this.mapValuesN(mapper, p1, p2, p3, p4, p5, p6);
+  }
+
+  mapValues7<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7>(
+    mapper: new (
+      p1: P1,
+      p2: P2,
+      p3: P3,
+      p4: P4,
+      p5: P5,
+      p6: P6,
+      p7: P7,
+    ) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ): EHandle<K, V2> {
+    return this.mapValuesN(mapper, p1, p2, p3, p4, p5, p6, p7);
+  }
+
+  mapValues8<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8>(
+    mapper: new (
+      p1: P1,
+      p2: P2,
+      p3: P3,
+      p4: P4,
+      p5: P5,
+      p6: P6,
+      p7: P7,
+      p8: P8,
+    ) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): EHandle<K, V2> {
+    return this.mapValuesN(mapper, p1, p2, p3, p4, p5, p6, p7, p8);
+  }
+
+  mapValues9<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8, P9>(
+    mapper: new (
+      p1: P1,
+      p2: P2,
+      p3: P3,
+      p4: P4,
+      p5: P5,
+      p6: P6,
+      p7: P7,
+      p8: P8,
+      p9: P9,
+    ) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): EHandle<K, V2> {
+    return this.mapValuesN(mapper, p1, p2, p3, p4, p5, p6, p7, p8, p9);
   }
 
   mapReduceN<

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -242,9 +242,9 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
   }
 
   mapValuesN<
-    V2 extends TJSON,
-    C extends new (...params: Param[]) => ValueMapper<V, V2>,
-  >(mapper: C, ...params: VMParameters<V, V2, C>): EHandle<K, V2> {
+    W extends TJSON,
+    C extends new (...params: Param[]) => ValueMapper<V, W>,
+  >(mapper: C, ...params: VMParameters<V, W, C>): EHandle<K, W> {
     params.forEach(check);
     const mapperObj = new mapper(...params);
     Object.freeze(mapperObj);
@@ -257,61 +257,61 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
       (key: K, it: NonEmptyIterator<V>) =>
         it.toArray().map((v) => [key, mapperObj.mapValue(v)]),
     );
-    return this.derive<K, V2>(eagerHdl);
+    return this.derive<K, W>(eagerHdl);
   }
 
-  mapValues<V2 extends TJSON>(
-    mapper: new () => ValueMapper<V, V2>,
-  ): EHandle<K, V2> {
+  mapValues<W extends TJSON>(
+    mapper: new () => ValueMapper<V, W>,
+  ): EHandle<K, W> {
     return this.mapValuesN(mapper);
   }
 
-  mapValues1<V2 extends TJSON, P1>(
-    mapper: new (p1: P1) => ValueMapper<V, V2>,
+  mapValues1<W extends TJSON, P1>(
+    mapper: new (p1: P1) => ValueMapper<V, W>,
     p1: P1,
-  ): EHandle<K, V2> {
+  ): EHandle<K, W> {
     return this.mapValuesN(mapper, p1);
   }
 
-  mapValues2<V2 extends TJSON, P1, P2>(
-    mapper: new (p1: P1, p2: P2) => ValueMapper<V, V2>,
+  mapValues2<W extends TJSON, P1, P2>(
+    mapper: new (p1: P1, p2: P2) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
-  ): EHandle<K, V2> {
+  ): EHandle<K, W> {
     return this.mapValuesN(mapper, p1, p2);
   }
 
-  mapValues3<V2 extends TJSON, P1, P2, P3>(
-    mapper: new (p1: P1, p2: P2, p3: P3) => ValueMapper<V, V2>,
+  mapValues3<W extends TJSON, P1, P2, P3>(
+    mapper: new (p1: P1, p2: P2, p3: P3) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
-  ): EHandle<K, V2> {
+  ): EHandle<K, W> {
     return this.mapValuesN(mapper, p1, p2, p3);
   }
 
-  mapValues4<V2 extends TJSON, P1, P2, P3, P4>(
-    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4) => ValueMapper<V, V2>,
+  mapValues4<W extends TJSON, P1, P2, P3, P4>(
+    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
     p4: P4,
-  ): EHandle<K, V2> {
+  ): EHandle<K, W> {
     return this.mapValuesN(mapper, p1, p2, p3, p4);
   }
 
-  mapValues5<V2 extends TJSON, P1, P2, P3, P4, P5>(
-    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => ValueMapper<V, V2>,
+  mapValues5<W extends TJSON, P1, P2, P3, P4, P5>(
+    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
     p4: P4,
     p5: P5,
-  ): EHandle<K, V2> {
+  ): EHandle<K, W> {
     return this.mapValuesN(mapper, p1, p2, p3, p4, p5);
   }
 
-  mapValues6<V2 extends TJSON, P1, P2, P3, P4, P5, P6>(
+  mapValues6<W extends TJSON, P1, P2, P3, P4, P5, P6>(
     mapper: new (
       p1: P1,
       p2: P2,
@@ -319,18 +319,18 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
       p4: P4,
       p5: P5,
       p6: P6,
-    ) => ValueMapper<V, V2>,
+    ) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
     p4: P4,
     p5: P5,
     p6: P6,
-  ): EHandle<K, V2> {
+  ): EHandle<K, W> {
     return this.mapValuesN(mapper, p1, p2, p3, p4, p5, p6);
   }
 
-  mapValues7<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7>(
+  mapValues7<W extends TJSON, P1, P2, P3, P4, P5, P6, P7>(
     mapper: new (
       p1: P1,
       p2: P2,
@@ -339,7 +339,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
       p5: P5,
       p6: P6,
       p7: P7,
-    ) => ValueMapper<V, V2>,
+    ) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
@@ -347,11 +347,11 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p5: P5,
     p6: P6,
     p7: P7,
-  ): EHandle<K, V2> {
+  ): EHandle<K, W> {
     return this.mapValuesN(mapper, p1, p2, p3, p4, p5, p6, p7);
   }
 
-  mapValues8<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8>(
+  mapValues8<W extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8>(
     mapper: new (
       p1: P1,
       p2: P2,
@@ -361,7 +361,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
       p6: P6,
       p7: P7,
       p8: P8,
-    ) => ValueMapper<V, V2>,
+    ) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
@@ -370,11 +370,11 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p6: P6,
     p7: P7,
     p8: P8,
-  ): EHandle<K, V2> {
+  ): EHandle<K, W> {
     return this.mapValuesN(mapper, p1, p2, p3, p4, p5, p6, p7, p8);
   }
 
-  mapValues9<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8, P9>(
+  mapValues9<W extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8, P9>(
     mapper: new (
       p1: P1,
       p2: P2,
@@ -385,7 +385,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
       p7: P7,
       p8: P8,
       p9: P9,
-    ) => ValueMapper<V, V2>,
+    ) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
@@ -395,7 +395,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p7: P7,
     p8: P8,
     p9: P9,
-  ): EHandle<K, V2> {
+  ): EHandle<K, W> {
     return this.mapValuesN(mapper, p1, p2, p3, p4, p5, p6, p7, p8, p9);
   }
 

--- a/skstore/ts/src/skstore_api.ts
+++ b/skstore/ts/src/skstore_api.ts
@@ -443,53 +443,53 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
    * @returns {EHandle} An eager handle on the resulting output collection
    */
   mapValuesN<
-    V2 extends TJSON,
-    C extends new (...params: Param[]) => ValueMapper<V, V2>,
+    W extends TJSON,
+    C extends new (...params: Param[]) => ValueMapper<V, W>,
   >(
     mapper: C,
-    ...params: VMParameters<V, V2, C>
-  ): EHandle<K, V2>;
+    ...params: VMParameters<V, W, C>
+  ): EHandle<K, W>;
 
-  mapValues<V2 extends TJSON>(
-    mapper: new () => ValueMapper<V, V2>,
-  ): EHandle<K, V2>;
+  mapValues<W extends TJSON>(
+    mapper: new () => ValueMapper<V, W>,
+  ): EHandle<K, W>;
 
-  mapValues1<V2 extends TJSON, P1>(
-    mapper: new (p1: P1) => ValueMapper<V, V2>,
+  mapValues1<W extends TJSON, P1>(
+    mapper: new (p1: P1) => ValueMapper<V, W>,
     p1: P1,
-  ): EHandle<K, V2>;
+  ): EHandle<K, W>;
 
-  mapValues2<V2 extends TJSON, P1, P2>(
-    mapper: new (p1: P1, p2: P2) => ValueMapper<V, V2>,
+  mapValues2<W extends TJSON, P1, P2>(
+    mapper: new (p1: P1, p2: P2) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
-  ): EHandle<K, V2>;
+  ): EHandle<K, W>;
 
-  mapValues3<V2 extends TJSON, P1, P2, P3>(
-    mapper: new (p1: P1, p2: P2, p3: P3) => ValueMapper<V, V2>,
+  mapValues3<W extends TJSON, P1, P2, P3>(
+    mapper: new (p1: P1, p2: P2, p3: P3) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
-  ): EHandle<K, V2>;
+  ): EHandle<K, W>;
 
-  mapValues4<V2 extends TJSON, P1, P2, P3, P4>(
-    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4) => ValueMapper<V, V2>,
+  mapValues4<W extends TJSON, P1, P2, P3, P4>(
+    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
     p4: P4,
-  ): EHandle<K, V2>;
+  ): EHandle<K, W>;
 
-  mapValues5<V2 extends TJSON, P1, P2, P3, P4, P5>(
-    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => ValueMapper<V, V2>,
+  mapValues5<W extends TJSON, P1, P2, P3, P4, P5>(
+    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
     p4: P4,
     p5: P5,
-  ): EHandle<K, V2>;
+  ): EHandle<K, W>;
 
-  mapValues6<V2 extends TJSON, P1, P2, P3, P4, P5, P6>(
+  mapValues6<W extends TJSON, P1, P2, P3, P4, P5, P6>(
     mapper: new (
       p1: P1,
       p2: P2,
@@ -497,16 +497,16 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
       p4: P4,
       p5: P5,
       p6: P6,
-    ) => ValueMapper<V, V2>,
+    ) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
     p4: P4,
     p5: P5,
     p6: P6,
-  ): EHandle<K, V2>;
+  ): EHandle<K, W>;
 
-  mapValues7<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7>(
+  mapValues7<W extends TJSON, P1, P2, P3, P4, P5, P6, P7>(
     mapper: new (
       p1: P1,
       p2: P2,
@@ -515,7 +515,7 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
       p5: P5,
       p6: P6,
       p7: P7,
-    ) => ValueMapper<V, V2>,
+    ) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
@@ -523,9 +523,9 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
     p5: P5,
     p6: P6,
     p7: P7,
-  ): EHandle<K, V2>;
+  ): EHandle<K, W>;
 
-  mapValues8<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8>(
+  mapValues8<W extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8>(
     mapper: new (
       p1: P1,
       p2: P2,
@@ -535,7 +535,7 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
       p6: P6,
       p7: P7,
       p8: P8,
-    ) => ValueMapper<V, V2>,
+    ) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
@@ -544,9 +544,9 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
     p6: P6,
     p7: P7,
     p8: P8,
-  ): EHandle<K, V2>;
+  ): EHandle<K, W>;
 
-  mapValues9<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8, P9>(
+  mapValues9<W extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8, P9>(
     mapper: new (
       p1: P1,
       p2: P2,
@@ -557,7 +557,7 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
       p7: P7,
       p8: P8,
       p9: P9,
-    ) => ValueMapper<V, V2>,
+    ) => ValueMapper<V, W>,
     p1: P1,
     p2: P2,
     p3: P3,
@@ -567,7 +567,7 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
     p7: P7,
     p8: P8,
     p9: P9,
-  ): EHandle<K, V2>;
+  ): EHandle<K, W>;
 
   /**
    * Create a new eager reactive collection by mapping some computation `mapper` over this

--- a/skstore/ts/src/skstore_api.ts
+++ b/skstore/ts/src/skstore_api.ts
@@ -165,10 +165,24 @@ export type MParameters<
 > = C extends new (...params: infer P) => Mapper<K1, V1, K2, V2> ? P : never;
 
 /**
- * The handle entry mapper function to write data into table
- * @param key - the mapped handle entry key
- * @param {NonEmptyIterator} it - an iterator on values avalable for a key
- * @returns {R} the table entry corresponding to eager map key value pair
+ * A specialized form of `Mapper` which re-uses the input collection's key structure
+ * in the output collection and thus doesn't need to consider keys.
+ */
+export interface ValueMapper<V1 extends TJSON, V2 extends TJSON> {
+  mapValue: (value: V1) => V2;
+}
+
+export type VMParameters<
+  V1 extends TJSON,
+  V2 extends TJSON,
+  C extends new (...params: Param[]) => ValueMapper<V1, V2>,
+> = C extends new (...params: infer P) => ValueMapper<V1, V2> ? P : never;
+
+/**
+ * The type of a reactive function mapping a collection into an output table
+ * @param key - a key of the input collection
+ * @param {NonEmptyIterator} it - an iterator on values avalable for said key
+ * @returns {R} a table row corresponding to the input key
  */
 export interface OutputMapper<
   R extends TJSON,
@@ -284,7 +298,7 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
   maybeGetOne(key: K): Opt<V>;
 
   /**
-   *  Create a new eager reactive collection by mapping some computation over this one
+   * Create a new eager reactive collection by mapping some computation over this one
    * @param {Mapper} mapper - function to apply to each element of this collection
    * @returns {EHandle} An eager handle on the resulting output collection
    */
@@ -421,6 +435,139 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
     p8: P8,
     p9: P9,
   ): EHandle<K2, V2>;
+
+  /**
+   * Create a new eager reactive collection by mapping over the _values_ of this one,
+   * keeping the same keys.
+   * @param {ValueMapper} mapper - function to apply to each _value_ of this collection
+   * @returns {EHandle} An eager handle on the resulting output collection
+   */
+  mapValuesN<
+    V2 extends TJSON,
+    C extends new (...params: Param[]) => ValueMapper<V, V2>,
+  >(
+    mapper: C,
+    ...params: VMParameters<V, V2, C>
+  ): EHandle<K, V2>;
+
+  mapValues<V2 extends TJSON>(
+    mapper: new () => ValueMapper<V, V2>,
+  ): EHandle<K, V2>;
+
+  mapValues1<V2 extends TJSON, P1>(
+    mapper: new (p1: P1) => ValueMapper<V, V2>,
+    p1: P1,
+  ): EHandle<K, V2>;
+
+  mapValues2<V2 extends TJSON, P1, P2>(
+    mapper: new (p1: P1, p2: P2) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+  ): EHandle<K, V2>;
+
+  mapValues3<V2 extends TJSON, P1, P2, P3>(
+    mapper: new (p1: P1, p2: P2, p3: P3) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+  ): EHandle<K, V2>;
+
+  mapValues4<V2 extends TJSON, P1, P2, P3, P4>(
+    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ): EHandle<K, V2>;
+
+  mapValues5<V2 extends TJSON, P1, P2, P3, P4, P5>(
+    mapper: new (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ): EHandle<K, V2>;
+
+  mapValues6<V2 extends TJSON, P1, P2, P3, P4, P5, P6>(
+    mapper: new (
+      p1: P1,
+      p2: P2,
+      p3: P3,
+      p4: P4,
+      p5: P5,
+      p6: P6,
+    ) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ): EHandle<K, V2>;
+
+  mapValues7<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7>(
+    mapper: new (
+      p1: P1,
+      p2: P2,
+      p3: P3,
+      p4: P4,
+      p5: P5,
+      p6: P6,
+      p7: P7,
+    ) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ): EHandle<K, V2>;
+
+  mapValues8<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8>(
+    mapper: new (
+      p1: P1,
+      p2: P2,
+      p3: P3,
+      p4: P4,
+      p5: P5,
+      p6: P6,
+      p7: P7,
+      p8: P8,
+    ) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): EHandle<K, V2>;
+
+  mapValues9<V2 extends TJSON, P1, P2, P3, P4, P5, P6, P7, P8, P9>(
+    mapper: new (
+      p1: P1,
+      p2: P2,
+      p3: P3,
+      p4: P4,
+      p5: P5,
+      p6: P6,
+      p7: P7,
+      p8: P8,
+      p9: P9,
+    ) => ValueMapper<V, V2>,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): EHandle<K, V2>;
 
   /**
    * Create a new eager reactive collection by mapping some computation `mapper` over this
@@ -1065,9 +1212,10 @@ export type ALParameters<
 
 export interface SKStore {
   /**
-   * Creates a lazy reactive map
-   * @param compute - the lazy function to compute entries of the lazy map
-   * @returns {LHandle} The the resulting lazy reactive map handle
+   * Creates a lazy reactive collection.
+   * @param compute - the function to compute entries of the lazy collection
+   * @param params - any additional parameters to the lazy computation
+   * @returns {LHandle} The resulting lazy reactive map handle
    */
   lazyN<
     K extends TJSON,

--- a/skstore/ts/tests/tests.ts
+++ b/skstore/ts/tests/tests.ts
@@ -173,6 +173,35 @@ async function testMap3Run(
   ]);
 }
 
+class SquareValues implements ValueMapper<number, number> {
+  mapValue(v) {
+    return v * v;
+  }
+}
+
+function testMapValuesInit(
+  _skstore: SKStore,
+  input: TableHandle<[number, number]>,
+  output: TableHandle<[number, number]>,
+) {
+  input.map(TestFromIntInt).mapValues(SquareValues).mapTo(output, TestToOutput);
+}
+
+async function testMapValuesRun(input: Table<TJSON[]>, output: Table<TJSON[]>) {
+  input.insert([
+    [1, 1],
+    [2, 2],
+    [5, 5],
+    [10, 10],
+  ]);
+  check("testMapValues", output.select({}, ["value"]), [
+    { value: 1 },
+    { value: 4 },
+    { value: 25 },
+    { value: 100 },
+  ]);
+}
+
 //// testSize
 
 class TestSizeGetter implements TableMapper<[number], number, number> {
@@ -560,6 +589,15 @@ export const tests: Test[] = [
     ],
     init: testMap3Init,
     run: testMap3Run,
+  },
+  {
+    name: "testMapValues",
+    schema: [
+      schema("input", [integer("id", true, true), integer("value")]),
+      schema("output", [integer("id", true, true), integer("value")]),
+    ],
+    init: testMapValuesInit,
+    run: testMapValuesRun,
   },
   {
     name: "testSize",


### PR DESCRIPTION
`ValueMapper` is a specialized form of `Mapper` which re-uses the input collection's key structure in the output collection and thus doesn't need to consider keys.

For cases where users just want to map values and preserve the key structure, this will simplify and cut down on boilerplate -- instead of defining the fully-general mapper `(K1, NonEmptyIterator<V1>) => Iterable<[K2, V2]>`, they can just write the `(V1) => V2` transformation directly.