### PR TITLE
Change directory naming logic to avoid collisions when reusing mappers

### DIFF
--- a/skstore/src/Extern.sk
+++ b/skstore/src/Extern.sk
@@ -1,4 +1,4 @@
-module alias DBUtils = SKDBFormToSKStore;
+module alias DBUtils = SKDBToFromSKStore;
 
 module SKStore;
 

--- a/skstore/src/Skdb.sk
+++ b/skstore/src/Skdb.sk
@@ -1,6 +1,6 @@
 module alias P = SQLParser;
 
-module SKDBFormToSKStore;
+module SKDBToFromSKStore;
 
 class TypeError(msg: String) extends Exception {
   fun getMessage(): String {

--- a/skstore/src/Utils.sk
+++ b/skstore/src/Utils.sk
@@ -40,7 +40,7 @@ fun eagerMap<K: Key, V: File, K2: Key, V2: File>(
     mutable NonEmptyIterator<V>,
   ) ~> void,
 ): EHandle<K2, V2> {
-  dirName = subDirName(context, name);
+  dirName = handle.dirName.sub(name);
   handle.map(keyConv, fileConv, context, dirName, compute);
 }
 
@@ -85,7 +85,7 @@ fun eagerMapReduce<K: Key, V: File, K2: Key, V2: File, V3: File>(
   ) ~> void,
   accumulator: Accumulator<V2, V3>,
 ): EHandle<K2, V3> {
-  dirName = subDirName(context, name);
+  dirName = handle.dirName.sub(name);
   handle.mapReduce(
     keyConv,
     fileConv,

--- a/skstore/ts/tests/tests.ts
+++ b/skstore/ts/tests/tests.ts
@@ -184,7 +184,11 @@ function testMapValuesInit(
   input: TableHandle<[number, number]>,
   output: TableHandle<[number, number]>,
 ) {
-  input.map(TestFromIntInt).mapValues(SquareValues).mapTo(output, TestToOutput);
+  input
+    .map(TestFromIntInt)
+    .mapValues(SquareValues)
+    .mapValues(SquareValues)
+    .mapTo(output, TestToOutput);
 }
 
 async function testMapValuesRun(input: Table<TJSON[]>, output: Table<TJSON[]>) {
@@ -196,9 +200,9 @@ async function testMapValuesRun(input: Table<TJSON[]>, output: Table<TJSON[]>) {
   ]);
   check("testMapValues", output.select({}, ["value"]), [
     { value: 1 },
-    { value: 4 },
-    { value: 25 },
-    { value: 100 },
+    { value: 16 },
+    { value: 625 },
+    { value: 10000 },
   ]);
 }
 


### PR DESCRIPTION
The previous naming logic for eager maps led to directory naming collisions (and thus semantic weirdness) when the same mapper was reused multiple times, either in sequence or interleaved with other mappers.

This PR gives a more structured/inutitive naming scheme to the results of maps, so that mapping `Bar` over a directory with a name like `/sk/foo/` will produce a directory with a name like `/sk/foo/bar/`, then mapping again will produce `/sk/foo/bar/bar/`, etc.