### PR TITLE
Lint SkStore

### DIFF
--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -702,7 +702,7 @@ export interface Text {
 export class Raw implements Text {
   text: string;
 
-  constructor(text: string, category?: string) {
+  constructor(text: string, _category?: string) {
     this.text = text;
   }
 

--- a/skstore/ts/examples/package.json
+++ b/skstore/ts/examples/package.json
@@ -1,7 +1,8 @@
 {
   "type": "module",
   "devDependencies": {
-    "@types/node": "^20.14.6"
+    "@types/node": "^20.14.6",
+    "prettier": "3.2.5"
   },
   "dependencies": {
     "commander": "^12.1.0",

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -1,0 +1,9 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+);

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -6,8 +6,14 @@ import stylisticJs from "@stylistic/eslint-plugin-js";
 
 export default tseslint.config(
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
   {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     plugins: {
       "@stylistic/js": stylisticJs,
     },
@@ -40,6 +46,8 @@ export default tseslint.config(
         },
       ],
       "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unsafe-assignment": "warn",
+      "@typescript-eslint/no-unsafe-member-access": "warn",
       "@typescript-eslint/no-empty-object-type": [
         "error",
         { allowInterfaces: "with-single-extends" },
@@ -50,4 +58,5 @@ export default tseslint.config(
       ],
     },
   },
+  { files: ["**/*.js"], ...tseslint.configs.disableTypeChecked },
 );

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -49,6 +49,8 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-assignment": "warn",
       "@typescript-eslint/no-unsafe-member-access": "warn",
       "@typescript-eslint/no-confusing-void-expression": "error",
+      "@typescript-eslint/restrict-plus-operands": "error",
+      "@typescript-eslint/restrict-template-expressions": "warn",
       "@typescript-eslint/no-empty-object-type": [
         "error",
         { allowInterfaces: "with-single-extends" },

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -51,6 +51,7 @@ export default tseslint.config(
       "@typescript-eslint/no-confusing-void-expression": "error",
       "@typescript-eslint/restrict-plus-operands": "error",
       "@typescript-eslint/restrict-template-expressions": "warn",
+      "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
       "@typescript-eslint/no-empty-object-type": [
         "error",
         { allowInterfaces: "with-single-extends" },

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -36,6 +36,10 @@ export default tseslint.config(
         },
       ],
       "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-empty-object-type": [
+        "error",
+        { allowInterfaces: "with-single-extends" },
+      ],
     },
   },
 );

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -6,7 +6,7 @@ import stylisticJs from "@stylistic/eslint-plugin-js";
 
 export default tseslint.config(
   eslint.configs.recommended,
-  ...tseslint.configs.recommendedTypeChecked,
+  ...tseslint.configs.strictTypeChecked,
   {
     languageOptions: {
       parserOptions: {
@@ -53,6 +53,8 @@ export default tseslint.config(
       "@typescript-eslint/restrict-template-expressions": "warn",
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
       "@typescript-eslint/no-unnecessary-condition": "error",
+      "@typescript-eslint/no-unnecessary-type-parameters": "warn",
+      "@typescript-eslint/no-non-null-assertion": "warn",
       "@typescript-eslint/no-empty-object-type": [
         "error",
         { allowInterfaces: "with-single-extends" },

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -7,6 +7,7 @@ import stylisticJs from "@stylistic/eslint-plugin-js";
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
   {
     languageOptions: {
       parserOptions: {
@@ -59,6 +60,9 @@ export default tseslint.config(
         "error",
         { allowInterfaces: "with-single-extends" },
       ],
+      "@typescript-eslint/consistent-type-definitions": "warn",
+      "@typescript-eslint/consistent-indexed-object-style": "off",
+      "@typescript-eslint/no-inferrable-types": "off",
       "@stylistic/js/lines-between-class-members": [
         "error",
         { enforce: [{ prev: "*", next: "method", blankLine: "always" }] },

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -48,6 +48,7 @@ export default tseslint.config(
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unsafe-assignment": "warn",
       "@typescript-eslint/no-unsafe-member-access": "warn",
+      "@typescript-eslint/no-confusing-void-expression": "error",
       "@typescript-eslint/no-empty-object-type": [
         "error",
         { allowInterfaces: "with-single-extends" },

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -6,4 +6,35 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    rules: {
+      "no-unused-vars": [
+        "error",
+        {
+          args: "none",
+          caughtErrors: "all",
+          ignoreRestSiblings: true,
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          reportUsedIgnorePattern: true,
+        },
+      ],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "none",
+          caughtErrors: "all",
+          ignoreRestSiblings: true,
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          reportUsedIgnorePattern: true,
+        },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
 );

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -52,6 +52,7 @@ export default tseslint.config(
       "@typescript-eslint/restrict-plus-operands": "error",
       "@typescript-eslint/restrict-template-expressions": "warn",
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
       "@typescript-eslint/no-empty-object-type": [
         "error",
         { allowInterfaces: "with-single-extends" },

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -8,6 +8,7 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   {
     rules: {
+      "prefer-spread": "warn",
       "no-unused-vars": [
         "error",
         {

--- a/skstore/ts/src/eslint.config.js
+++ b/skstore/ts/src/eslint.config.js
@@ -2,11 +2,15 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
+import stylisticJs from "@stylistic/eslint-plugin-js";
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
+    plugins: {
+      "@stylistic/js": stylisticJs,
+    },
     rules: {
       "prefer-spread": "warn",
       "no-unused-vars": [
@@ -39,6 +43,10 @@ export default tseslint.config(
       "@typescript-eslint/no-empty-object-type": [
         "error",
         { allowInterfaces: "with-single-extends" },
+      ],
+      "@stylistic/js/lines-between-class-members": [
+        "error",
+        { enforce: [{ prev: "*", next: "method", blankLine: "always" }] },
       ],
     },
   },

--- a/skstore/ts/src/package.json
+++ b/skstore/ts/src/package.json
@@ -5,6 +5,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@stylistic/eslint-plugin-js": "^2.6.4",
     "@types/node": "^20.14.9",
     "prettier": "3.2.5",
     "typescript-eslint": "^8.3.0"

--- a/skstore/ts/src/package.json
+++ b/skstore/ts/src/package.json
@@ -1,7 +1,12 @@
 {
   "type": "module",
+  "scripts": {
+    "lint": "eslint ."
+  },
   "devDependencies": {
+    "@eslint/js": "^9.9.1",
     "@types/node": "^20.14.9",
-    "prettier": "3.2.5"
+    "prettier": "3.2.5",
+    "typescript-eslint": "^8.3.0"
   }
 }

--- a/skstore/ts/src/package.json
+++ b/skstore/ts/src/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "devDependencies": {
-    "@types/node": "^20.14.9"
+    "@types/node": "^20.14.9",
+    "prettier": "3.2.5"
   }
 }

--- a/skstore/ts/src/package.json
+++ b/skstore/ts/src/package.json
@@ -7,6 +7,7 @@
     "@eslint/js": "^9.9.1",
     "@stylistic/eslint-plugin-js": "^2.6.4",
     "@types/node": "^20.14.9",
+    "@typescript-eslint/parser": "^8.3.0",
     "prettier": "3.2.5",
     "typescript-eslint": "^8.3.0"
   }

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -978,8 +978,8 @@ export class TableImpl<R extends TJSON[]> implements Table<R> {
     );
   }
 
-  select(select: JSONObject, colmuns?: string[]): JSONObject[] {
-    const query = toSelectQuery(this.getName(), select, colmuns);
+  select(select: JSONObject, columns?: string[]): JSONObject[] {
+    const query = toSelectQuery(this.getName(), select, columns);
     return this.skdb.exec(
       query.query,
       query.params ? toParams(query.params) : undefined,

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -6,7 +6,6 @@ import type {
   EHandle,
   LHandle,
   Mapper,
-  ValueMapper,
   EntryMapper,
   OutputMapper,
   TableHandle,
@@ -39,7 +38,7 @@ type Query = { query: string; params?: JSONObject };
 function assertNoKeysNaN<K extends TJSON, V extends TJSON>(
   kv_pairs: Iterable<[K, V]>,
 ): Iterable<[K, V]> {
-  for (let [k, _v] of kv_pairs) {
+  for (const [k, _v] of kv_pairs) {
     if (Number.isNaN(k)) {
       // NaN is forbidden since it breaks comparison reflexivity, ordering, etc.
       throw new Error("NaN is forbidden as a Skip collection key");
@@ -1042,7 +1041,7 @@ export class SKStoreImpl implements SKStore {
     K2 extends TJSON,
     V2 extends TJSON,
   >(mappings: Mapping<K1, V1, K2, V2>[]): EHandle<K2, V2> {
-    var name = "";
+    let name = "";
     const ctxmapping = mappings.map((mapping) => {
       const params = mapping.params ?? [];
       params.forEach(check);
@@ -1069,7 +1068,7 @@ export class SKStoreImpl implements SKStore {
     mappings: Mapping<K1, V1, K2, V2>[],
     accumulator: Accumulator<V2, V3>,
   ): EHandle<K2, V3> {
-    var name = "";
+    let name = "";
     const ctxmapping = mappings.map((mapping) => {
       const params = mapping.params ?? [];
       params.forEach(check);
@@ -1586,8 +1585,8 @@ export class SKStoreFactoryImpl implements SKStoreFactory {
     tablesSchema: MirrorSchema[],
     connect: boolean = true,
   ): Promise<Table<TJSON[]>[]> => {
-    let context = this.context();
-    let skdb = await this.createSync();
+    const context = this.context();
+    const skdb = await this.createSync();
     const tables = mirror(context, skdb, connect, ...tablesSchema);
     const skstore = new SKStoreImpl(context);
     this.create(() => init(skstore, ...tables));
@@ -1665,8 +1664,8 @@ function create(table: MirrorSchema): Query {
 }
 
 function toValues(entry: TJSON[], prefix: string = ""): Query {
-  let exprs: string[] = [];
-  let params: JSONObject = {};
+  const exprs: string[] = [];
+  const params: JSONObject = {};
   for (let i = 0; i < entry.length; i++) {
     const field = entry[i];
     if (
@@ -1692,8 +1691,8 @@ function toWhere(
   prefix: string = "",
 ): Query {
   if (columns.length != entry.length) throw new Error("Invalid entry type.");
-  let exprs: string[] = [];
-  let params: JSONObject = {};
+  const exprs: string[] = [];
+  const params: JSONObject = {};
   for (let i = 0; i < columns.length; i++) {
     const column = columns[i];
     const field = entry[i];
@@ -1718,8 +1717,8 @@ function toWhere(
 }
 
 function toSets(update: JSONObject, prefix: string = ""): Query {
-  let exprs: string[] = [];
-  let params: JSONObject = {};
+  const exprs: string[] = [];
+  const params: JSONObject = {};
   Object.keys(update).forEach((column: keyof JSONObject) => {
     const field = update[column];
     params[prefix + column] = field;
@@ -1734,8 +1733,8 @@ function toSets(update: JSONObject, prefix: string = ""): Query {
 function toSelectWhere(select: JSONObject, prefix: string = ""): Query {
   const keys = Object.keys(select);
   if (keys.length <= 0) return { query: "true" };
-  let exprs: string[] = [];
-  let params: JSONObject = {};
+  const exprs: string[] = [];
+  const params: JSONObject = {};
   keys.forEach((column: keyof JSONObject) => {
     const field = select[column];
     if (Array.isArray(field)) {
@@ -1759,7 +1758,7 @@ function toSelectWhere(select: JSONObject, prefix: string = ""): Query {
 }
 
 function toParams(params: JSONObject): Params {
-  let res: Record<string, string | number | boolean> = {};
+  const res: Record<string, string | number | boolean> = {};
   Object.keys(params).forEach((key: keyof JSONObject) => {
     const v = params[key];
     if (typeof v == "string") {

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -1654,10 +1654,9 @@ function toMirrorDefinition(table: MirrorSchema): MirrorDefn {
     table: table.name,
     expectedColumns: toColumns(table.expected),
     filterExpr: table.filter ? table.filter.filter : undefined,
-    filterParams:
-      table.filter && table.filter.params
-        ? toParams(table.filter.params)
-        : undefined,
+    filterParams: table.filter?.params
+      ? toParams(table.filter.params)
+      : undefined,
   };
 }
 

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -1653,7 +1653,7 @@ function toMirrorDefinition(table: MirrorSchema): MirrorDefn {
   return {
     table: table.name,
     expectedColumns: toColumns(table.expected),
-    filterExpr: table.filter ? table.filter.filter : undefined,
+    filterExpr: table.filter?.filter,
     filterParams: table.filter?.params
       ? toParams(table.filter.params)
       : undefined,

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -534,7 +534,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     table: TableHandle<R>,
     mapper: new () => OutputMapper<R, K, V>,
   ): void {
-    return this.mapToN(table, mapper);
+    this.mapToN(table, mapper);
   }
 
   mapTo1<R extends TJSON[], P1>(
@@ -542,7 +542,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     mapper: new (p1: P1) => OutputMapper<R, K, V>,
     p1: P1,
   ): void {
-    return this.mapToN(table, mapper, p1);
+    this.mapToN(table, mapper, p1);
   }
 
   mapTo2<R extends TJSON[], P1, P2>(
@@ -551,7 +551,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p1: P1,
     p2: P2,
   ): void {
-    return this.mapToN(table, mapper, p1, p2);
+    this.mapToN(table, mapper, p1, p2);
   }
 
   mapTo3<R extends TJSON[], P1, P2, P3>(
@@ -561,7 +561,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p2: P2,
     p3: P3,
   ): void {
-    return this.mapToN(table, mapper, p1, p2, p3);
+    this.mapToN(table, mapper, p1, p2, p3);
   }
 
   mapTo4<R extends TJSON[], P1, P2, P3, P4>(
@@ -572,7 +572,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p3: P3,
     p4: P4,
   ): void {
-    return this.mapToN(table, mapper, p1, p2, p3, p4);
+    this.mapToN(table, mapper, p1, p2, p3, p4);
   }
 
   mapTo5<R extends TJSON[], P1, P2, P3, P4, P5>(
@@ -590,7 +590,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p4: P4,
     p5: P5,
   ): void {
-    return this.mapToN(table, mapper, p1, p2, p3, p4, p5);
+    this.mapToN(table, mapper, p1, p2, p3, p4, p5);
   }
 
   mapTo6<R extends TJSON[], P1, P2, P3, P4, P5, P6>(
@@ -610,7 +610,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p5: P5,
     p6: P6,
   ): void {
-    return this.mapToN(table, mapper, p1, p2, p3, p4, p5, p6);
+    this.mapToN(table, mapper, p1, p2, p3, p4, p5, p6);
   }
 
   mapTo7<R extends TJSON[], P1, P2, P3, P4, P5, P6, P7>(
@@ -632,7 +632,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p6: P6,
     p7: P7,
   ): void {
-    return this.mapToN(table, mapper, p1, p2, p3, p4, p5, p6, p7);
+    this.mapToN(table, mapper, p1, p2, p3, p4, p5, p6, p7);
   }
 
   mapTo8<R extends TJSON[], P1, P2, P3, P4, P5, P6, P7, P8>(
@@ -656,7 +656,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p7: P7,
     p8: P8,
   ): void {
-    return this.mapToN(table, mapper, p1, p2, p3, p4, p5, p6, p7, p8);
+    this.mapToN(table, mapper, p1, p2, p3, p4, p5, p6, p7, p8);
   }
 
   mapTo9<R extends TJSON[], P1, P2, P3, P4, P5, P6, P7, P8, P9>(
@@ -682,7 +682,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
     p8: P8,
     p9: P9,
   ): void {
-    return this.mapToN(table, mapper, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    this.mapToN(table, mapper, p1, p2, p3, p4, p5, p6, p7, p8, p9);
   }
 }
 
@@ -1595,7 +1595,9 @@ export class SKStoreFactoryImpl implements SKStoreFactory {
     const skdb = await this.createSync();
     const tables = mirror(context, skdb, connect, ...tablesSchema);
     const skstore = new SKStoreImpl(context);
-    this.create(() => init(skstore, ...tables));
+    this.create(() => {
+      init(skstore, ...tables);
+    });
     return tables.map((t) => (t as TableHandleImpl<TJSON[]>).toTable());
   };
 }

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -61,6 +61,7 @@ class EHandleImpl<K extends TJSON, V extends TJSON> implements EHandle<K, V> {
       value: true,
     });
   }
+
   getId(): string {
     return this.eagerHdl;
   }
@@ -731,9 +732,11 @@ export class LSelfImpl<K extends TJSON, V extends TJSON>
   getArray(key: K): V[] {
     return this.context.getArraySelf(this.lazyHdl, key);
   }
+
   getOne(key: K): V {
     return this.context.getOneSelf(this.lazyHdl, key);
   }
+
   maybeGetOne(key: K): Opt<V> {
     return this.context.maybeGetOneSelf(this.lazyHdl, key);
   }

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -1048,6 +1048,7 @@ export class SKStoreImpl implements SKStore {
     const ctxmapping = mappings.map((mapping) => {
       const params = mapping.params ?? [];
       params.forEach(check);
+      /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
       const mapperObj = new mapping.mapper(...params);
       Object.freeze(mapperObj);
       name += mapperObj.constructor.name;
@@ -1075,6 +1076,7 @@ export class SKStoreImpl implements SKStore {
     const ctxmapping = mappings.map((mapping) => {
       const params = mapping.params ?? [];
       params.forEach(check);
+      /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
       const mapperObj = new mapping.mapper(...params);
       Object.freeze(mapperObj);
       name += mapperObj.constructor.name;
@@ -1556,6 +1558,7 @@ export class SKStoreImpl implements SKStore {
         ("__isObjectProxy" in object && object.__isObjectProxy)) &&
       "clone" in object
     ) {
+      /* eslint-disable-next-line @typescript-eslint/no-unsafe-call */
       console.log(object.clone());
     } else {
       console.log(object);
@@ -1611,6 +1614,7 @@ export function mirror(
   ...tables: MirrorSchema[]
 ): TableHandle<TJSON[]>[] {
   if (connect) {
+    /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
     skdb.mirror(...toMirrorDefinitions(...tables));
   } else {
     /*
@@ -1854,7 +1858,7 @@ export function check<T>(value: T): void {
     return;
   } else if (type == "object") {
     const jso = value as any;
-    if ((value as any).__sk_frozen) {
+    if (jso.__sk_frozen) {
       return;
     } else if (Object.isFrozen(jso)) {
       if (Array.isArray(jso)) {
@@ -1862,6 +1866,7 @@ export function check<T>(value: T): void {
           check(jso[i]);
         }
       } else {
+        /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
         for (const key of Object.keys(jso)) {
           check(jso[key]);
         }

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -1677,16 +1677,17 @@ function toValues(entry: TJSON[], prefix: string = ""): Query {
   const params: JSONObject = {};
   for (let i = 0; i < entry.length; i++) {
     const field = entry[i];
+    const prefixedI = `${prefix}${i}`;
     if (
       typeof field == "string" ||
       typeof field == "number" ||
       typeof field == "boolean"
     ) {
-      params[prefix + i] = field;
+      params[prefixedI] = field;
     } else {
-      params[prefix + i] = JSON.stringify(field);
+      params[prefixedI] = JSON.stringify(field);
     }
-    exprs.push(`@${prefix + i}`);
+    exprs.push(`@${prefixedI}`);
   }
   return {
     query: exprs.join(" , "),
@@ -1708,7 +1709,7 @@ function toWhere(
     if (Array.isArray(field)) {
       const inVal: string[] = [];
       for (let idx = 0; idx < field.length; idx++) {
-        const pName = prefix + idx + "_" + column.name;
+        const pName = `${prefix}${idx}_${column.name}`;
         params[pName] = field[idx];
         inVal.push(`@${pName}`);
       }
@@ -1728,10 +1729,11 @@ function toWhere(
 function toSets(update: JSONObject, prefix: string = ""): Query {
   const exprs: string[] = [];
   const params: JSONObject = {};
-  Object.keys(update).forEach((column: keyof JSONObject) => {
+  Object.keys(update).forEach((column: string & keyof JSONObject) => {
     const field = update[column];
-    params[prefix + column] = field;
-    exprs.push(`${column} = @${prefix + column}`);
+    const prefixedColumn = `${prefix}${column}`;
+    params[prefixedColumn] = field;
+    exprs.push(`${column} = @${prefixedColumn}`);
   });
   return {
     query: exprs.join(" , "),
@@ -1744,18 +1746,18 @@ function toSelectWhere(select: JSONObject, prefix: string = ""): Query {
   if (keys.length <= 0) return { query: "true" };
   const exprs: string[] = [];
   const params: JSONObject = {};
-  keys.forEach((column: keyof JSONObject) => {
+  keys.forEach((column: string & keyof JSONObject) => {
     const field = select[column];
     if (Array.isArray(field)) {
       const inVal: string[] = [];
       for (let idx = 0; idx < field.length; idx++) {
-        const pName = prefix + idx + "_" + column;
+        const pName = `${prefix}${idx}_${column}`;
         params[pName] = field[idx];
         inVal.push(`@${pName}`);
       }
       exprs.push(`${column} IN (${inVal.join(", ")})`);
     } else {
-      const pName = prefix + column;
+      const pName = `${prefix}${column}`;
       params[pName] = field;
       exprs.push(`${column} = @${pName}`);
     }
@@ -1768,7 +1770,7 @@ function toSelectWhere(select: JSONObject, prefix: string = ""): Query {
 
 function toParams(params: JSONObject): Params {
   const res: Record<string, string | number | boolean> = {};
-  Object.keys(params).forEach((key: keyof JSONObject) => {
+  Object.keys(params).forEach((key: string & keyof JSONObject) => {
     const v = params[key];
     if (typeof v == "string") {
       res[key] = v;
@@ -1816,7 +1818,7 @@ function toInsertQuery(
 ): Query {
   let params: JSONObject = {};
   const values = entries.map((vs, idx) => {
-    const q = toValues(vs, "v" + idx + "_");
+    const q = toValues(vs, `v${idx}_`);
     params = { ...params, ...q.params };
     return q;
   });

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -576,7 +576,7 @@ class LinksImpl implements Links {
       const register = (value: Result<TJSON, TJSON>) => {
         if (!notify) {
           const skdbApp = this.env.shared.get("SKDB") as SKDBShared;
-          notify = skdbApp?.notify;
+          notify = skdbApp.notify;
         }
         setTimeout(() => {
           const result = jsu.runWithGC(() => {
@@ -599,9 +599,9 @@ class LinksImpl implements Links {
       };
       promise
         .then((value) => {
-          if (value.payload !== null && value.payload !== undefined) {
+          if (value.payload !== undefined) {
             register(
-              value.metadata !== null && value.metadata !== undefined
+              value.metadata !== undefined
                 ? {
                     status: "success",
                     payload: value.payload,
@@ -614,7 +614,7 @@ class LinksImpl implements Links {
             );
           } else {
             register(
-              value.metadata !== null && value.metadata !== undefined
+              value.metadata !== undefined
                 ? {
                     status: "unchanged",
                     metadata: value.metadata,
@@ -661,8 +661,6 @@ class LinksImpl implements Links {
     };
     this.init = (context: ptr) => {
       ref.push(context);
-      if (!this.initFn)
-        throw new Error("SKStore init function must be defined");
       this.initFn();
       ref.pop();
     };

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -32,7 +32,7 @@ class HandlesImpl implements Handles {
 
   register(v: JSON) {
     const freeID = this.freeIDs.pop();
-    const id = freeID === undefined ? this.nextID++ : freeID;
+    const id = freeID ?? this.nextID++;
     this.objects[id] = v;
     return id;
   }

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -625,7 +625,7 @@ class LinksImpl implements Links {
             );
           }
         })
-        .catch((reason: any) => {
+        .catch((reason: unknown) => {
           let msg: string;
           if (reason instanceof Error) {
             msg = reason.message;

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -37,17 +37,18 @@ class HandlesImpl implements Handles {
     return id;
   }
 
-  get(id: int) {
+  get(id: int): any {
     return this.objects[id];
   }
 
-  apply = (id: int, parameters: any[]) => {
+  apply<T>(id: int, parameters: T[]): T {
     const fn = this.objects[id];
+    /* eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
     return fn.apply(null, parameters);
-  };
+  }
 
-  delete(id: int) {
-    const current = this.objects[id];
+  delete(id: int): any {
+    const current: unknown = this.objects[id];
     this.objects[id] = null;
     this.freeIDs.push(id);
     return current;
@@ -339,18 +340,21 @@ class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
   }
 
   next(): Opt<T> {
+    /* eslint-disable-next-line @typescript-eslint/no-unsafe-return */
     return this.skjson.importOptJSON(
       this.exports.SKIP_SKStore_iteratorNext(this.pointer),
     );
   }
 
   first(): T {
+    /* eslint-disable-next-line @typescript-eslint/no-unsafe-return */
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_iteratorFirst(this.pointer),
     );
   }
 
   uniqueValue(): Opt<T> {
+    /* eslint-disable-next-line @typescript-eslint/no-unsafe-return */
     return this.skjson.importOptJSON(
       this.exports.SKIP_SKStore_iteratorUniqueValue(this.pointer),
     );
@@ -515,10 +519,12 @@ class LinksImpl implements Links {
       for (const datum of result) {
         const k = datum[0];
         const v = datum[1];
+        /* eslint-disable-next-line @typescript-eslint/no-unsafe-call */
         if (bindings.has(k)) bindings.get(k).push(v);
         else bindings.set(k, [v]);
       }
       for (const kv of bindings) {
+        /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
         w.setArray(kv[0], kv[1]);
       }
       ref.pop();
@@ -535,7 +541,7 @@ class LinksImpl implements Links {
       const w = new WriterImpl(jsu, fromWasm, writer);
       const result = this.handles.apply(fn, [jsu.importJSON(row), occ]);
       for (const v of result) {
-        const t = v as any;
+        const t = v as [any, any];
         w.set(t[0], t[1]);
       }
       ref.pop();
@@ -562,6 +568,7 @@ class LinksImpl implements Links {
       const name = jsu.importString(skname);
       const key = jsu.importJSON(skkey, true);
       const params = jsu.importJSON(skparams, true);
+      /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
       const promise = this.handles.apply<Promise<AValue<TJSON, TJSON>>>(fn, [
         key,
         params,

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -713,6 +713,7 @@ class LinksImpl implements Links {
 
 class Manager implements ToWasmManager {
   env: Environment;
+
   constructor(env: Environment) {
     this.env = env;
   }

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -42,7 +42,7 @@ class HandlesImpl implements Handles {
   }
 
   apply = (id: int, parameters: any[]) => {
-    let fn = this.objects[id];
+    const fn = this.objects[id];
     return fn.apply(null, parameters);
   };
 
@@ -619,7 +619,7 @@ class LinksImpl implements Links {
           }
         })
         .catch((reason: any) => {
-          var msg: string;
+          let msg: string;
           if (reason instanceof Error) {
             msg = reason.message;
           } else if (typeof reason == "string") {
@@ -683,7 +683,7 @@ class LinksImpl implements Links {
     this.getErrorHdl = (exn: ptr) => {
       return this.handles.register(utils.getErrorObject(exn));
     };
-    let create = (init: () => void) => {
+    const create = (init: () => void) => {
       // Register the init function to have  a named init function
       this.initFn = init;
       // Get a run uuid to build to allow function mapping reload in case of persistence
@@ -718,8 +718,8 @@ class Manager implements ToWasmManager {
   }
 
   prepare = (wasm: object) => {
-    let toWasm = wasm as ToWasm;
-    let links = new LinksImpl(this.env);
+    const toWasm = wasm as ToWasm;
+    const links = new LinksImpl(this.env);
     toWasm.SKIP_SKStore_detachHandle = (fn: int) => links.detachHandle(fn);
     toWasm.SKIP_SKStore_applyMapFun = (
       fn: int,

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -728,24 +728,32 @@ class Manager implements ToWasmManager {
   prepare = (wasm: object) => {
     const toWasm = wasm as ToWasm;
     const links = new LinksImpl(this.env);
-    toWasm.SKIP_SKStore_detachHandle = (fn: int) => links.detachHandle(fn);
+    toWasm.SKIP_SKStore_detachHandle = (fn: int) => {
+      links.detachHandle(fn);
+    };
     toWasm.SKIP_SKStore_applyMapFun = (
       fn: int,
       context: ptr,
       writer: ptr,
       key: ptr,
       it: ptr,
-    ) => links.applyMapFun(fn, context, writer, key, it);
+    ) => {
+      links.applyMapFun(fn, context, writer, key, it);
+    };
     toWasm.SKIP_SKStore_applyMapTableFun = (
       fn: int,
       context: ptr,
       writer: ptr,
       row: ptr,
       occ: int,
-    ) => links.applyMapTableFun(fn, context, writer, row, occ);
+    ) => {
+      links.applyMapTableFun(fn, context, writer, row, occ);
+    };
     toWasm.SKIP_SKStore_applyConvertToRowFun = (fn: int, key: ptr, it: ptr) =>
       links.applyConvertToRowFun(fn, key, it);
-    toWasm.SKIP_SKStore_init = (context: ptr) => links.init(context);
+    toWasm.SKIP_SKStore_init = (context: ptr) => {
+      links.init(context);
+    };
     toWasm.SKIP_SKStore_applyLazyFun = (fn, context, self, key) =>
       links.applyLazyFun(fn, context, self, key);
 
@@ -757,7 +765,9 @@ class Manager implements ToWasmManager {
       name: ptr,
       key: ptr,
       param: ptr,
-    ) => links.applyLazyAsyncFun(fn, call, name, key, param);
+    ) => {
+      links.applyLazyAsyncFun(fn, call, name, key, param);
+    };
     toWasm.SKIP_SKStore_applyAccumulate = (fn: int, acc: ptr, value: ptr) =>
       links.applyAccumulate(fn, acc, value);
     toWasm.SKIP_SKStore_applyDismiss = (fn: int, acc: ptr, value: ptr) =>

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -382,9 +382,9 @@ class LinksImpl implements Links {
         return fromWasm.SKIP_SKJSON_createCJString(utils.exportString(value));
       } else if (Array.isArray(value)) {
         const arr = fromWasm.SKIP_SKJSON_startCJArray();
-        value.forEach((v) =>
-          fromWasm.SKIP_SKJSON_addToCJArray(arr, exportJSON(v)),
-        );
+        value.forEach((v) => {
+          fromWasm.SKIP_SKJSON_addToCJArray(arr, exportJSON(v));
+        });
         return fromWasm.SKIP_SKJSON_endCJArray(arr);
       } else if (typeof value == "object") {
         if (value.__isObjectProxy || value.__isArrayProxy) {
@@ -434,8 +434,12 @@ class Manager implements ToWasmManager {
   prepare = (wasm: object) => {
     const toWasm = wasm as ToWasm;
     const link = new LinksImpl(this.env);
-    toWasm.SKIP_SKJSON_console = (value: ptr) => link.SKJSON_console(value);
-    toWasm.SKIP_SKJSON_error = (value: ptr) => link.SKJSON_error(value);
+    toWasm.SKIP_SKJSON_console = (value: ptr) => {
+      link.SKJSON_console(value);
+    };
+    toWasm.SKIP_SKJSON_error = (value: ptr) => {
+      link.SKJSON_error(value);
+    };
     return link;
   };
 }

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -2,6 +2,7 @@
 import type { int, ptr, float, Links, Utils, ToWasmManager, Environment, Opt, Shared, } from "#std/sk_types.js";
 
 export enum Type {
+  /* eslint-disable no-unused-vars */
   Undefined,
   Null,
   Int,
@@ -10,6 +11,7 @@ export enum Type {
   String,
   Array,
   Object,
+  /* eslint-enable no-unused-vars */
 }
 
 interface WasmAccess {
@@ -83,12 +85,14 @@ function getValue(hdl: WasmHandle): any {
       return hdl.utils.importString(
         hdl.access.SKIP_SKJSON_asString(hdl.pointer),
       );
-    case Type.Array:
+    case Type.Array: {
       const aPtr = hdl.access.SKIP_SKJSON_asArray(hdl.pointer);
       return new Proxy(hdl.derive(aPtr), reactiveArray);
-    case Type.Object:
+    }
+    case Type.Object: {
       const oPtr = hdl.access.SKIP_SKJSON_asObject(hdl.pointer);
       return new Proxy(hdl.derive(oPtr), reactiveObject);
+    }
     case Type.Undefined:
     default:
       return undefined;
@@ -111,12 +115,14 @@ function getValueAt(hdl: WasmHandle, idx: int, array: boolean = false): any {
       return hdl.access.SKIP_SKJSON_asBoolean(skval) ? true : false;
     case Type.String:
       return hdl.utils.importString(hdl.access.SKIP_SKJSON_asString(skval));
-    case Type.Array:
+    case Type.Array: {
       const aPtr = hdl.access.SKIP_SKJSON_asArray(skval);
       return new Proxy(hdl.derive(aPtr), reactiveArray);
-    case Type.Object:
+    }
+    case Type.Object: {
       const oPtr = hdl.access.SKIP_SKJSON_asObject(skval);
       return new Proxy(hdl.derive(oPtr), reactiveObject);
+    }
     case Type.Undefined:
     default:
       return undefined;
@@ -364,7 +370,7 @@ class LinksImpl implements Links {
     };
 
     const exportJSON = (value: any) => {
-      let type = typeof value;
+      const type = typeof value;
       if (value === null || value === undefined) {
         return fromWasm.SKIP_SKJSON_createCJNull();
       } else if (type == "number") {
@@ -374,7 +380,7 @@ class LinksImpl implements Links {
       } else if (type == "string") {
         return fromWasm.SKIP_SKJSON_createCJString(utils.exportString(value));
       } else if (Array.isArray(value)) {
-        let arr = fromWasm.SKIP_SKJSON_startCJArray();
+        const arr = fromWasm.SKIP_SKJSON_startCJArray();
         value.forEach((v) =>
           fromWasm.SKIP_SKJSON_addToCJArray(arr, exportJSON(v)),
         );
@@ -383,8 +389,8 @@ class LinksImpl implements Links {
         if (value.__isObjectProxy || value.__isArrayProxy) {
           return value.__pointer as number;
         } else {
-          let obj = fromWasm.SKIP_SKJSON_startCJObject();
-          for (let key of Object.keys(value)) {
+          const obj = fromWasm.SKIP_SKJSON_startCJObject();
+          for (const key of Object.keys(value)) {
             fromWasm.SKIP_SKJSON_addToCJObject(
               obj,
               utils.exportString(key),

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -295,7 +295,7 @@ class Mapping {
 
   register(v: any) {
     const freeID = this.freeIDs.pop();
-    const id = freeID === undefined ? this.nextID++ : freeID;
+    const id = freeID ?? this.nextID++;
     this.objects[id] = v;
     return id;
   }

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -227,7 +227,7 @@ export const reactiveArray = {
   },
   ownKeys(hdl: WasmHandle) {
     const l = hdl.access.SKIP_SKJSON_arraySize(hdl.pointer);
-    const res = Array.from(Array(l).keys()).map((v) => "" + v);
+    const res = Array.from(Array(l).keys()).map((v) => v.toString());
     return res;
   },
   getOwnPropertyDescriptor(hdl: WasmHandle, prop: string) {

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -425,6 +425,7 @@ class LinksImpl implements Links {
 
 class Manager implements ToWasmManager {
   env: Environment;
+
   constructor(env: Environment) {
     this.env = env;
   }

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -216,7 +216,7 @@ export const reactiveArray = {
   set(_hdl: WasmHandle, _prop: string, _value: any) {
     throw new Error("Reactive array cannot be modified.");
   },
-  has(hdl: WasmHandle, prop: string): boolean {
+  has(_hdl: WasmHandle, prop: string): boolean {
     if (prop === "__isArrayProxy") return true;
     if (prop === "__sk_frozen") return true;
     if (prop === "__pointer") return true;

--- a/skstore/ts/src/skstore.ts
+++ b/skstore/ts/src/skstore.ts
@@ -59,8 +59,10 @@ const modules: ModuleInit[] = [];
 async function wasmUrl(): Promise<URL> {
   //@ts-expect-error  ImportMeta is incomplete
   if (import.meta.env || import.meta.webpack) {
+    /* eslint-disable @typescript-eslint/no-unsafe-return */
     //@ts-expect-error  Cannot find module './skstore.wasm?url' or its corresponding type declarations.
     return await import("./skstore.wasm?url");
+    /* eslint-enable @typescript-eslint/no-unsafe-return */
   }
 
   return new URL("./skstore.wasm", import.meta.url);
@@ -98,7 +100,7 @@ export function freeze<T extends TJSON>(value: T): T {
       }
       return Object.freeze(value) as T;
     } else {
-      const jso = value as any;
+      const jso = value as Record<string, any>;
       Object.defineProperty(value, "__sk_frozen", {
         enumerable: false,
         writable: false,

--- a/skstore/ts/src/skstore.ts
+++ b/skstore/ts/src/skstore.ts
@@ -57,9 +57,9 @@ const modules: ModuleInit[] = [];
 /*--MODULES--*/
 
 async function wasmUrl(): Promise<URL> {
-  //@ts-ignore
+  //@ts-expect-error  ImportMeta is incomplete
   if (import.meta.env || import.meta.webpack) {
-    //@ts-ignore
+    //@ts-expect-error  Cannot find module './skstore.wasm?url' or its corresponding type declarations.
     return await import("./skstore.wasm?url");
   }
 
@@ -71,7 +71,7 @@ export async function createSKStore(
   tables: MirrorSchema[],
   connect: boolean = true,
 ): Promise<Table<TJSON[]>[]> {
-  let data = await runUrl(wasmUrl, modules, [], "SKDB_factory");
+  const data = await runUrl(wasmUrl, modules, [], "SKDB_factory");
   const factory = data.environment.shared.get("SKStore") as SKStoreFactory;
   return factory.runSKStore(init, tables, connect);
 }

--- a/skstore/ts/src/skstore_api.ts
+++ b/skstore/ts/src/skstore_api.ts
@@ -189,7 +189,7 @@ export abstract class ValueMapper<
 /**
  * The type of a reactive function mapping a collection into an output table
  * @param key - a key of the input collection
- * @param {NonEmptyIterator} it - an iterator on values avalable for said key
+ * @param {NonEmptyIterator} it - an iterator on values available for said key
  * @returns {R} a table row corresponding to the input key
  */
 export interface OutputMapper<
@@ -988,21 +988,21 @@ export interface Table<R extends TJSON[]> {
    * Update an entry in the table
    * @param row - the table entry to update
    * @param updates - the column values updates
-   * @throws {Error} when the updates violate an index or other contraint
+   * @throws {Error} when the updates violate an index or other constraint
    */
   update(row: R, updates: JSONObject): void;
   /**
    * Update entries in the table matching some `where` clause
    * @param where - the column values to filter entries
    * @param updates - the column values updates
-   * @throws {Error} when an index contraints is broken
+   * @throws {Error} when an index constraints is broken
    */
   updateWhere(where: JSONObject, updates: JSONObject): void;
   /**
    * Select entries in the table
    * @param where - the column values to filter entries
    * @param columns - the columns to include in the output; include all by default
-   * @throws {Error} when an index contraints is broken
+   * @throws {Error} when an index constraints is broken
    */
   select(where: JSONObject, columns?: string[]): JSONObject[];
   /**
@@ -1221,7 +1221,7 @@ export interface SKStore {
   ): LHandle<K, V>;
 
   /**
-   * Map over each entry of each eager reative map and apply the corresponding mapper function
+   * Map over each entry of each eager reactive map and apply the corresponding mapper function
    * @param {Mapping[]} mappings - the handles to combine
    * @returns {EHandle} The the resulting eager reactive map handle
    */
@@ -1234,7 +1234,7 @@ export interface SKStore {
     mappings: Mapping<K1, V1, K2, V2>[],
   ): EHandle<K2, V2>;
   /**
-   * Map over each entry of each eager reative map and apply the corresponding mapper function
+   * Map over each entry of each eager reactive map and apply the corresponding mapper function
    *  then reduce the when the given accumulator
    * @param {Mapping} mappings - the handles to combine
    * @param {Accumulator} accumulator - reduction manager
@@ -1252,7 +1252,7 @@ export interface SKStore {
   ): EHandle<K2, V3>;
 
   /**
-   * Creates a lazy reactive map attched to a asynch call
+   * Creates a lazy reactive map attached to a async call
    * @param get - the function the gather the values from others reactive maps
    * @param call - the async function to call with gathered values
    * @returns {LHandle} The the resulting lazy reactive map handle

--- a/skstore/ts/src/skstore_api.ts
+++ b/skstore/ts/src/skstore_api.ts
@@ -220,6 +220,7 @@ export interface Accumulator<T extends TJSON, V extends TJSON> {
    * @return the resulting accumulated value
    */
   accumulate(acc: Opt<V>, value: T): V;
+
   /**
    * The computation to perform when an input value is removed
    * @param acc - the current accumulated value
@@ -238,6 +239,7 @@ export interface NonEmptyIterator<T> extends Iterable<T> {
    *   `first` cannot be called after `next`
    */
   next: () => Opt<T>;
+
   /**
    * Returns the first element of the iteration.
    * @throws {Error} when next called before
@@ -984,6 +986,7 @@ export interface Table<R extends TJSON[]> {
    *         violation
    */
   insert(entry: R[], update?: boolean): void;
+
   /**
    * Update an entry in the table
    * @param row - the table entry to update
@@ -991,6 +994,7 @@ export interface Table<R extends TJSON[]> {
    * @throws {Error} when the updates violate an index or other constraint
    */
   update(row: R, updates: JSONObject): void;
+
   /**
    * Update entries in the table matching some `where` clause
    * @param where - the column values to filter entries
@@ -998,6 +1002,7 @@ export interface Table<R extends TJSON[]> {
    * @throws {Error} when an index constraints is broken
    */
   updateWhere(where: JSONObject, updates: JSONObject): void;
+
   /**
    * Select entries in the table
    * @param where - the column values to filter entries
@@ -1005,22 +1010,26 @@ export interface Table<R extends TJSON[]> {
    * @throws {Error} when an index constraints is broken
    */
   select(where: JSONObject, columns?: string[]): JSONObject[];
+
   /**
    * Delete an entry from the table
    * @param entry - the entry to delete
    */
   delete(entry: R): void;
+
   /**
    * Delete entries from the table matching some `where` clause.
    * @param where - the column values to filter entries
    */
   deleteWhere(where: JSONObject): void;
+
   /**
    * Register a callback to be invoked on the `rows` of this table whenever data changes
    * @param update - the callback to invoke when data changes
    * @returns a callback `close` to terminate and clean up the watch
    */
   watch: (update: (rows: JSONObject[]) => void) => { close: () => void };
+
   /**
    * Register a callback to be invoked on the `added` and `removed` rows of this table
    * whenever data changes
@@ -1233,6 +1242,7 @@ export interface SKStore {
   >(
     mappings: Mapping<K1, V1, K2, V2>[],
   ): EHandle<K2, V2>;
+
   /**
    * Map over each entry of each eager reactive map and apply the corresponding mapper function
    *  then reduce the when the given accumulator

--- a/skstore/ts/src/skstore_utils.ts
+++ b/skstore/ts/src/skstore_utils.ts
@@ -7,9 +7,11 @@ import type {
 
 export class Sum implements Accumulator<number, number> {
   default = 0;
+
   accumulate(acc: number, value: number): number {
     return acc + value;
   }
+
   dismiss(acc: number, value: number): Opt<number> {
     return acc - value;
   }
@@ -17,9 +19,11 @@ export class Sum implements Accumulator<number, number> {
 
 export class Min implements Accumulator<number, number> {
   default = null;
+
   accumulate(acc: Opt<number>, value: number): number {
     return acc === null ? value : Math.min(acc, value);
   }
+
   dismiss(acc: number, value: number): Opt<number> {
     return value > acc ? acc : null;
   }
@@ -27,9 +31,11 @@ export class Min implements Accumulator<number, number> {
 
 export class Max implements Accumulator<number, number> {
   default = null;
+
   accumulate(acc: Opt<number>, value: number): number {
     return acc === null ? value : Math.max(acc, value);
   }
+
   dismiss(acc: number, value: number): Opt<number> {
     return value < acc ? acc : null;
   }

--- a/skstore/ts/src/skstore_utils.ts
+++ b/skstore/ts/src/skstore_utils.ts
@@ -51,7 +51,7 @@ export function schema(name: string, expected: ColumnSchema[]): MirrorSchema {
 export function cinteger(
   name: string,
   notnull: boolean = true,
-  primary?: boolean,
+  primary: boolean = false,
 ): ColumnSchema {
   return {
     name,
@@ -64,7 +64,7 @@ export function cinteger(
 export function ctext(
   name: string,
   notnull: boolean = true,
-  primary?: boolean,
+  primary: boolean = false,
 ): ColumnSchema {
   return {
     name,
@@ -77,7 +77,7 @@ export function ctext(
 export function cjson(
   name: string,
   notnull: boolean = true,
-  primary?: boolean,
+  primary: boolean = false,
 ): ColumnSchema {
   return {
     name,
@@ -90,7 +90,7 @@ export function cjson(
 export function cfloat(
   name: string,
   notnull: boolean = true,
-  primary?: boolean,
+  primary: boolean = false,
 ): ColumnSchema {
   return {
     name,

--- a/skstore/ts/src/tsconfig.json
+++ b/skstore/ts/src/tsconfig.json
@@ -9,13 +9,23 @@
     },
     "strictNullChecks": true,
     "module": "node16",
-    "strict": true,
     "verbatimModuleSyntax": true,
     "declaration": true,
     "sourceMap": true,
     "declarationMap": true,
     "moduleResolution": "Node16",
     "incremental": true,
-    "noEmit": true
+    "noEmit": true,
+    "strict": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "exactOptionalPropertyTypes": false,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   }
 }

--- a/skstore/ts/tests/package.json
+++ b/skstore/ts/tests/package.json
@@ -5,6 +5,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@types/node": "^20.14.9"
+    "@types/node": "^20.14.9",
+    "prettier": "3.2.5"
   }
 }

--- a/sql/ts/src/skdb_util.ts
+++ b/sql/ts/src/skdb_util.ts
@@ -3,7 +3,7 @@ import type { SKDB, Params } from "./skdb_types.js";
 /* ***************************************************************************/
 /* The type used to represent callable external functions. */
 /* ***************************************************************************/
-export class SKDBCallable<T1, T2> {
+export class SKDBCallable<_T1, _T2> {
   private id: number;
 
   constructor(id: number) {


### PR DESCRIPTION
Add `ESLint` and enable more strict typechecking rules for `skstore/ts/src`.
Only minor changes, no red flags were found.
A few rules are still disabled because they were too noisy.

To run the linter: `npm run lint`