### PR TITLE
[sknpm] Add modules instead of replacing them

### DIFF
--- a/skmd/ts/src/skmd.ts
+++ b/skmd/ts/src/skmd.ts
@@ -1,6 +1,6 @@
 import { Options, run, type ToWasmManager } from "#std/sk_types";
 
-var modules: (() => Promise<ToWasmManager>)[];
+const modules: (() => Promise<ToWasmManager>)[] = [];
 /*--MODULES--*/
 
 const wasmurl = new URL("./skmd.wasm", import.meta.url);

--- a/sknpm/resources/sk_tests.ts
+++ b/sknpm/resources/sk_tests.ts
@@ -1,6 +1,6 @@
 import { run, type ModuleInit } from "./sk_types.js";
 
-var modules: ModuleInit[];
+const modules: ModuleInit[] = [];
 /*--MODULES--*/
 
 const wasmurl = new URL("./test.wasm", import.meta.url);

--- a/sknpm/src/sknpm.sk
+++ b/sknpm/src/sknpm.sk
@@ -671,7 +671,7 @@ fun copyAndConvertImport(
   };
   strModules = Vector[importLine(runtime)].concat(loaderFiles.map(importLine))
     .concat(moduleFiles.map(importLine))
-    .concat(Vector[`modules = [${modules.join(", ")}];`])
+    .concat(Vector[`modules.push(${modules.join(", ")});`])
     .join("\n");
   res = for (fi in tmplFiles) {
     inner = SKStore.newObstack();

--- a/skstore/ts/src/skstore.ts
+++ b/skstore/ts/src/skstore.ts
@@ -53,7 +53,7 @@ export {
   cjson,
 } from "./skstore_utils.js";
 
-var modules: ModuleInit[];
+const modules: ModuleInit[] = [];
 /*--MODULES--*/
 
 async function wasmUrl(): Promise<URL> {

--- a/sql/ts/src/skdb.ts
+++ b/sql/ts/src/skdb.ts
@@ -10,7 +10,7 @@ export type { Environment } from "#std/sk_types.js";
 export { SKDBTransaction } from "./skdb_util.js";
 import { getWasmUrl } from "./skdb_wasm_locator.js";
 
-var modules: ModuleInit[];
+const modules: ModuleInit[] = [];
 /*--MODULES--*/
 
 export async function createSkdb(

--- a/sql/ts/src/skdb_worker.ts
+++ b/sql/ts/src/skdb_worker.ts
@@ -4,7 +4,7 @@ import { onWorkerMessage } from "#std/sk_worker.js";
 import type { Creator } from "#std/sk_worker.js";
 import type { SKDB } from "./skdb.js";
 
-var modules: ModuleInit[];
+const modules: ModuleInit[] = [];
 /*--MODULES--*/
 
 class DbCreator implements Creator<SKDB> {


### PR DESCRIPTION
The dark magic of `sknpm` replaces the line `/*--MODULES--*/` with several lines of `import` followed by `modules = [...];`, expecting a pre-existing `var modules = [];`.
Linters expect this line to be `const modules = [];` because the array doesn't seem to be changed.
Fine, let's push modules instead of replacing the contents of the array, which was brittle if we didn't start with an empty array.