### PR TITLE
Simplify parameters

### DIFF
--- a/skstore/ts/src/skstore_api.ts
+++ b/skstore/ts/src/skstore_api.ts
@@ -132,13 +132,6 @@ export interface EntryMapper<
   mapElement: (entry: R, occ: number) => Iterable<[K, V]>;
 }
 
-export type EMParameters<
-  K extends TJSON,
-  V extends TJSON,
-  R extends TJSON[],
-  C extends new (...params: Param[]) => EntryMapper<R, K, V>,
-> = C extends new (...params: infer P) => EntryMapper<R, K, V> ? P : never;
-
 /**
  * The type of a reactive function mapping over an arbitrary collection.
  * For each key & values in the input collection (of type K1/V1 respectively),
@@ -155,14 +148,6 @@ export interface Mapper<
 > {
   mapElement: (key: K1, it: NonEmptyIterator<V1>) => Iterable<[K2, V2]>;
 }
-
-export type MParameters<
-  K1 extends TJSON,
-  V1 extends TJSON,
-  K2 extends TJSON,
-  V2 extends TJSON,
-  C extends new (...params: Param[]) => Mapper<K1, V1, K2, V2>,
-> = C extends new (...params: infer P) => Mapper<K1, V1, K2, V2> ? P : never;
 
 /**
  * A specialized form of `Mapper` which re-uses the input collection's key structure
@@ -199,13 +184,6 @@ export interface OutputMapper<
 > {
   mapElement: (key: K, it: NonEmptyIterator<V>) => R;
 }
-
-export type OMParameters<
-  R extends TJSON,
-  K extends TJSON,
-  V extends TJSON,
-  C extends new (...params: Param[]) => OutputMapper<R, K, V>,
-> = C extends new (...params: infer P) => OutputMapper<R, K, V> ? P : never;
 
 /**
  * The type of a reactive accumulator (a.k.a. reducer) function, which computes an output
@@ -312,13 +290,9 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
    * @param {Mapper} mapper - function to apply to each element of this collection
    * @returns {EHandle} An eager handle on the resulting output collection
    */
-  mapN<
-    K2 extends TJSON,
-    V2 extends TJSON,
-    C extends new (...params: Param[]) => Mapper<K, V, K2, V2>,
-  >(
-    mapper: C,
-    ...params: MParameters<K, V, K2, V2, C>
+  mapN<K2 extends TJSON, V2 extends TJSON, Params extends Param[]>(
+    mapper: new (...params: Params) => Mapper<K, V, K2, V2>,
+    ...params: Params
   ): EHandle<K2, V2>;
 
   map<K2 extends TJSON, V2 extends TJSON>(
@@ -457,11 +431,11 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
     K2 extends TJSON,
     V2 extends TJSON,
     V3 extends TJSON,
-    C extends new (...params: Param[]) => Mapper<K, V, K2, V2>,
+    Params extends Param[],
   >(
-    mapper: C,
+    mapper: new (...params: Params) => Mapper<K, V, K2, V2>,
     accumulator: Accumulator<V2, V3>,
-    ...params: MParameters<K, V, K2, V2, C>
+    ...params: Params
   ): EHandle<K2, V3>;
 
   mapReduce<K2 extends TJSON, V2 extends TJSON, V3 extends TJSON>(
@@ -672,13 +646,10 @@ export interface EHandle<K extends TJSON, V extends TJSON> {
    * @param {Mapper} mapper - function to apply to each key/value pair in this collection
    *                          to produce a table row
    */
-  mapToN<
-    R extends TJSON[],
-    C extends new (...params: Param[]) => OutputMapper<R, K, V>,
-  >(
+  mapToN<R extends TJSON[], Params extends Param[]>(
     table: TableHandle<R>,
-    mapper: C,
-    ...params: OMParameters<R, K, V, C>
+    mapper: new (...params: Params) => OutputMapper<R, K, V>,
+    ...params: Params
   ): void;
 
   mapTo<R extends TJSON[]>(
@@ -836,13 +807,9 @@ export interface TableHandle<R extends TJSON[]> {
    * Create a new eager reactive collection by mapping over each table entry
    * @returns {EHandle} An eager handle on the resulting collection
    */
-  mapN<
-    K extends TJSON,
-    V extends TJSON,
-    C extends new (...params: Param[]) => EntryMapper<R, K, V>,
-  >(
-    mapper: C,
-    ...params: EMParameters<K, V, R, C>
+  mapN<K extends TJSON, V extends TJSON, Params extends Param[]>(
+    mapper: new (...params: Params) => EntryMapper<R, K, V>,
+    ...params: Params
   ): EHandle<K, V>;
 
   map<K extends TJSON, V extends TJSON>(
@@ -1078,22 +1045,6 @@ export interface AsyncLazyCompute<
   call: (key: K, params: P) => Promise<AValue<V, M>>;
 }
 
-export type LParameters<
-  K extends TJSON,
-  V extends TJSON,
-  C extends new (...params: Param[]) => LazyCompute<K, V>,
-> = C extends new (...params: infer P) => LazyCompute<K, V> ? P : never;
-
-export type ALParameters<
-  K extends TJSON,
-  V extends TJSON,
-  P extends TJSON,
-  M extends TJSON,
-  C extends new (...params: Param[]) => AsyncLazyCompute<K, V, P, M>,
-> = C extends new (...params: infer U) => AsyncLazyCompute<K, V, P, M>
-  ? U
-  : never;
-
 export interface SKStore {
   /**
    * Creates a lazy reactive collection.
@@ -1101,13 +1052,9 @@ export interface SKStore {
    * @param params - any additional parameters to the lazy computation
    * @returns {LHandle} The resulting lazy reactive map handle
    */
-  lazyN<
-    K extends TJSON,
-    V extends TJSON,
-    C extends new (...params: Param[]) => LazyCompute<K, V>,
-  >(
-    compute: C,
-    ...params: LParameters<K, V, C>
+  lazyN<K extends TJSON, V extends TJSON, Params extends Param[]>(
+    compute: new (...params: Params) => LazyCompute<K, V>,
+    ...params: Params
   ): LHandle<K, V>;
 
   lazy<K extends TJSON, V extends TJSON>(
@@ -1272,10 +1219,10 @@ export interface SKStore {
     V extends TJSON,
     P extends TJSON,
     M extends TJSON,
-    C extends new (...params: Param[]) => AsyncLazyCompute<K, V, P, M>,
+    Params extends Param[],
   >(
-    compute: C,
-    ...params: ALParameters<K, V, P, M, C>
+    compute: new (...params: Params) => AsyncLazyCompute<K, V, P, M>,
+    ...params: Params
   ): ALHandle<K, V, M>;
 
   asyncLazy<K extends TJSON, V extends TJSON, P extends TJSON, M extends TJSON>(


### PR DESCRIPTION
Quantify over parameters rather than a constructor.

I'm wondering whether this would be enough to get rid of `map1,2,...`

Only 1 commit, stacked over #293

`make -C skstore check` is happy