### PR TITLE
[RFC] Stronger type for ptr

### DIFF
--- a/prelude/ts/src/sk_internal_types.ts
+++ b/prelude/ts/src/sk_internal_types.ts
@@ -2,9 +2,7 @@ declare const opaque: unique symbol;
 export type Opaque<Value, Tag> = Value & { [opaque]: Tag };
 
 declare const t: unique symbol;
-export type T<V = unknown> = { [t]: V };
-
-export type Any = T;
+export type T<V> = { [t]: V };
 
 declare const raw: unique symbol;
 export type Raw = T<typeof raw>;
@@ -33,19 +31,23 @@ export type Obstack = T<typeof obstack>;
 declare const p: unique symbol;
 
 declare const array: unique symbol;
-export type Array<Ty extends T> = T<typeof array> & {
+export type Array<Ty extends T<any>> = T<typeof array> & {
   [p]: (_: Ty) => Ty;
 };
 
 declare const vector: unique symbol;
-export type Vector<Ty extends T> = T<typeof vector> & { [p]: (_: Ty) => Ty };
+export type Vector<Ty extends T<any>> = T<typeof vector> & {
+  [p]: (_: Ty) => Ty;
+};
 
 declare const pair: unique symbol;
-export type Pair<Ty1 extends T, Ty2 extends T> = T<typeof pair> & {
+export type Pair<Ty1 extends T<any>, Ty2 extends T<any>> = T<typeof pair> & {
   [p]: [Ty1, Ty2];
 };
 
 declare const function_: unique symbol;
-export type Function<Ty1 extends T, Ty2 extends T> = T<typeof function_> & {
+export type Function<Ty1 extends T<any>, Ty2 extends T<any>> = T<
+  typeof function_
+> & {
   [p]: (_: Ty1) => Ty2;
 };

--- a/prelude/ts/src/sk_internal_types.ts
+++ b/prelude/ts/src/sk_internal_types.ts
@@ -2,7 +2,7 @@ declare const opaque: unique symbol;
 export type Opaque<Value, Tag> = Value & { [opaque]: Tag };
 
 declare const t: unique symbol;
-export type T<V = any> = { [t]: V };
+export type T<V = unknown> = { [t]: V };
 
 export type Any = T;
 

--- a/prelude/ts/src/sk_internal_types.ts
+++ b/prelude/ts/src/sk_internal_types.ts
@@ -6,6 +6,9 @@ export type T<V = any> = { [t]: V };
 
 export type Any = T;
 
+declare const raw: unique symbol;
+export type Raw = T<typeof raw>;
+
 declare const void_: unique symbol;
 export type Void = T<typeof void_>;
 

--- a/prelude/ts/src/sk_internal_types.ts
+++ b/prelude/ts/src/sk_internal_types.ts
@@ -5,3 +5,28 @@ declare const t: unique symbol;
 export type T<V = any> = { [t]: V };
 
 export type Any = T;
+
+declare const byte: unique symbol;
+export type Byte = T<typeof byte>;
+
+declare const uint32: unique symbol;
+export type UInt32 = T<typeof uint32>;
+
+declare const float: unique symbol;
+export type Float = T<typeof float>;
+
+declare const str: unique symbol;
+export type String = T<typeof str>;
+
+declare const exception: unique symbol;
+export type Exception = T<typeof exception>;
+
+declare const obstack: unique symbol;
+export type Obstack = T<typeof obstack>;
+
+declare const p: unique symbol;
+
+declare const array: unique symbol;
+export type Array<Ty extends T> = T<typeof array> & {
+  [p]: (_: Ty) => Ty;
+};

--- a/prelude/ts/src/sk_internal_types.ts
+++ b/prelude/ts/src/sk_internal_types.ts
@@ -1,5 +1,7 @@
 declare const opaque: unique symbol;
 export type Opaque<Value, Tag> = Value & { [opaque]: Tag };
 
-declare const ptr: unique symbol;
-export type Ptr = typeof ptr;
+declare const t: unique symbol;
+export type T<V = any> = { [t]: V };
+
+export type Any = T;

--- a/prelude/ts/src/sk_internal_types.ts
+++ b/prelude/ts/src/sk_internal_types.ts
@@ -37,6 +37,14 @@ export type Array<Ty extends T> = T<typeof array> & {
   [p]: (_: Ty) => Ty;
 };
 
+declare const vector: unique symbol;
+export type Vector<Ty extends T> = T<typeof vector> & { [p]: (_: Ty) => Ty };
+
+declare const pair: unique symbol;
+export type Pair<Ty1 extends T, Ty2 extends T> = T<typeof pair> & {
+  [p]: [Ty1, Ty2];
+};
+
 declare const function_: unique symbol;
 export type Function<Ty1 extends T, Ty2 extends T> = T<typeof function_> & {
   [p]: (_: Ty1) => Ty2;

--- a/prelude/ts/src/sk_internal_types.ts
+++ b/prelude/ts/src/sk_internal_types.ts
@@ -1,0 +1,5 @@
+declare const opaque: unique symbol;
+export type Opaque<Value, Tag> = Value & { [opaque]: Tag };
+
+declare const ptr: unique symbol;
+export type Ptr = typeof ptr;

--- a/prelude/ts/src/sk_internal_types.ts
+++ b/prelude/ts/src/sk_internal_types.ts
@@ -6,6 +6,9 @@ export type T<V = any> = { [t]: V };
 
 export type Any = T;
 
+declare const void_: unique symbol;
+export type Void = T<typeof void_>;
+
 declare const byte: unique symbol;
 export type Byte = T<typeof byte>;
 
@@ -29,4 +32,9 @@ declare const p: unique symbol;
 declare const array: unique symbol;
 export type Array<Ty extends T> = T<typeof array> & {
   [p]: (_: Ty) => Ty;
+};
+
+declare const function_: unique symbol;
+export type Function<Ty1 extends T, Ty2 extends T> = T<typeof function_> & {
+  [p]: (_: Ty1) => Ty2;
 };

--- a/prelude/ts/src/sk_runtime.ts
+++ b/prelude/ts/src/sk_runtime.ts
@@ -197,16 +197,20 @@ class Manager implements ToWasmManager {
     toWasm._ZdlPv = () => {
       throw new Error("_ZdlPv");
     };
-    toWasm.abort = (err: ptr) => {
+    toWasm.abort = (err: ptr<Internal.T<unknown>>) => {
       throw new Error("Abort " + err);
     };
-    toWasm.abortOnCannotGrowMemory = (err: ptr) => {
+    toWasm.abortOnCannotGrowMemory = (err: ptr<Internal.T<unknown>>) => {
       throw new Error("Abort on cannot grow memory " + err);
     };
-    toWasm.__setErrNo = (err: ptr) => {
+    toWasm.__setErrNo = (err: ptr<Internal.T<unknown>>) => {
       throw new Error("ErrNo " + err);
     };
-    toWasm.__cxa_throw = (exn: ptr, infi: ptr, dest: ptr) => {
+    toWasm.__cxa_throw = (
+      exn: ptr<Internal.T<unknown>>,
+      infi: ptr<Internal.T<unknown>>,
+      dest: ptr<Internal.T<unknown>>,
+    ) => {
       throw new Error("Not managed exception");
     };
     toWasm.js_throw = (excPtr: ptr<Internal.Exception>, rethrow: int) =>
@@ -283,10 +287,14 @@ interface ToWasm {
   _ZNSt9exceptionD2Ev: () => void;
   _ZNKSt9exception4whatEv: () => void;
   _ZdlPv: () => void;
-  abort: (err: ptr) => void;
-  abortOnCannotGrowMemory: (err: ptr) => void;
-  __setErrNo: (err: ptr) => void;
-  __cxa_throw: (exn: ptr, infi: ptr, dest: ptr) => void;
+  abort: (err: ptr<Internal.T<unknown>>) => void;
+  abortOnCannotGrowMemory: (err: ptr<Internal.T<unknown>>) => void;
+  __setErrNo: (err: ptr<Internal.T<unknown>>) => void;
+  __cxa_throw: (
+    exn: ptr<Internal.T<unknown>>,
+    infi: ptr<Internal.T<unknown>>,
+    dest: ptr<Internal.T<unknown>>,
+  ) => void;
   js_throw: (excPtr: ptr<Internal.Exception>, rethrow: int) => void;
   js_replace_exn: (
     oldex: ptr<Internal.Exception>,

--- a/prelude/ts/src/sk_runtime.ts
+++ b/prelude/ts/src/sk_runtime.ts
@@ -31,7 +31,10 @@ class LinksImpl implements Links {
   SKIP_print_raw!: (strPtr: ptr<Internal.String>) => void;
   SKIP_print_char!: (code: int) => void;
   SKIP_print_string!: (strPtr: ptr<Internal.String>) => void;
-  SKIP_etry!: (f: ptr, exn_handler: ptr) => ptr;
+  SKIP_etry!: <Ret>(
+    f: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+    exn_handler: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+  ) => ptr<Internal.T<Ret>>;
   js_throw!: (excPtr: ptr<Internal.Exception>, rethrow: int) => void;
   js_replace_exn!: (
     oldex: ptr<Internal.Exception>,
@@ -241,8 +244,10 @@ class Manager implements ToWasmManager {
       links.SKIP_print_char(strPtr);
     toWasm.SKIP_print_string = (strPtr: ptr<Internal.String>) =>
       links.SKIP_print_string(strPtr);
-    toWasm.SKIP_etry = (f: ptr, exn_handler: ptr) =>
-      links.SKIP_etry(f, exn_handler);
+    toWasm.SKIP_etry = <Ret>(
+      f: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+      exn_handler: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+    ): ptr<Internal.T<Ret>> => links.SKIP_etry(f, exn_handler);
     toWasm.SKIP_delete_external_exception = (actor: int) =>
       links.SKIP_delete_external_exception(actor);
     toWasm.SKIP_external_exception_message = (actor: int) =>
@@ -309,7 +314,10 @@ interface ToWasm {
   SKIP_print_raw: (strPtr: ptr<Internal.String>) => void;
   SKIP_print_char: (strPtr: ptr<Internal.String>) => void;
   SKIP_print_string: (strPtr: ptr<Internal.String>) => void;
-  SKIP_etry: (f: ptr, exn_handler: ptr) => ptr;
+  SKIP_etry: <Ret>(
+    f: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+    exn_handler: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+  ) => ptr<Internal.T<Ret>>;
   SKIP_delete_external_exception: (exc: int) => void;
   SKIP_external_exception_message: (exc: int) => ptr<Internal.String>;
   SKIP_js_time_ms_lo: () => int;

--- a/prelude/ts/src/sk_runtime.ts
+++ b/prelude/ts/src/sk_runtime.ts
@@ -3,11 +3,13 @@ import type {
   float,
   ptr,
   Links,
+  Opt,
   Utils,
   ToWasmManager,
   Environment,
 } from "./sk_types.js";
 import { Stream } from "./sk_types.js";
+import type * as Internal from "./sk_internal_types.js";
 
 class LinksImpl implements Links {
   env: Environment | undefined;
@@ -22,22 +24,28 @@ class LinksImpl implements Links {
   SKIP_read_to_end_fill!: () => int;
   SKIP_read_line_get!: (index: int) => int;
 
-  SKIP_print_error!: (strPtr: ptr) => void;
-  SKIP_print_error_raw!: (strPtr: ptr) => void;
-  SKIP_print_debug!: (strPtr: ptr) => void;
-  SKIP_print_debug_raw!: (strPtr: ptr) => void;
-  SKIP_print_raw!: (strPtr: ptr) => void;
+  SKIP_print_error!: (strPtr: ptr<Internal.String>) => void;
+  SKIP_print_error_raw!: (strPtr: ptr<Internal.String>) => void;
+  SKIP_print_debug!: (strPtr: ptr<Internal.String>) => void;
+  SKIP_print_debug_raw!: (strPtr: ptr<Internal.String>) => void;
+  SKIP_print_raw!: (strPtr: ptr<Internal.String>) => void;
   SKIP_print_char!: (code: int) => void;
-  SKIP_print_string!: (strPtr: ptr) => void;
+  SKIP_print_string!: (strPtr: ptr<Internal.String>) => void;
   SKIP_etry!: (f: ptr, exn_handler: ptr) => ptr;
-  js_throw!: (strPtr: ptr, rethrow: int) => void;
-  js_replace_exn!: (oldex: ptr, newex: ptr) => void;
+  js_throw!: (excPtr: ptr<Internal.Exception>, rethrow: int) => void;
+  js_replace_exn!: (
+    oldex: ptr<Internal.Exception>,
+    newex: ptr<Internal.Exception>,
+  ) => void;
   SKIP_throw_cruntime!: (code: int) => void;
   SKIP_JS_timeStamp!: () => float;
 
   SKIP_delete_external_exception!: (exc: int) => void;
-  SKIP_external_exception_message!: (exc: int) => ptr;
-  SKIP_FileSystem_appendTextFile!: (path: ptr, contents: ptr) => void;
+  SKIP_external_exception_message!: (exc: int) => ptr<Internal.String>;
+  SKIP_FileSystem_appendTextFile!: (
+    path: ptr<Internal.String>,
+    contents: ptr<Internal.String>,
+  ) => void;
   SKIP_js_time_ms_lo!: () => int;
   SKIP_js_time_ms_hi!: () => int;
 
@@ -49,39 +57,45 @@ class LinksImpl implements Links {
   };
 
   SKIP_js_get_argc!: () => int;
-  SKIP_js_get_argn!: (index: int) => ptr;
+  SKIP_js_get_argn!: (index: int) => ptr<Internal.String>;
   SKIP_js_get_envc!: () => int;
-  SKIP_js_get_envn!: (index: int) => ptr;
-  SKIP_setenv!: (skName: ptr, skvalue: ptr) => void;
-  SKIP_getenv!: (skName: ptr) => ptr | null;
-  SKIP_unsetenv!: (skName: ptr) => void;
+  SKIP_js_get_envn!: (index: int) => ptr<Internal.String>;
+  SKIP_setenv!: (
+    skName: ptr<Internal.String>,
+    skvalue: ptr<Internal.String>,
+  ) => void;
+  SKIP_getenv!: (skName: ptr<Internal.String>) => Opt<ptr<Internal.String>>;
+  SKIP_unsetenv!: (skName: ptr<Internal.String>) => void;
 
   SKIP_glock() {}
   SKIP_gunlock() {}
 
   complete = (utils: Utils, exports: object) => {
     this.SKIP_etry = utils.etry;
-    this.SKIP_print_error = (msg: ptr) => {
+    this.SKIP_print_error = (msg: ptr<Internal.String>) => {
       utils.sklog(msg, Stream.ERR, true);
     };
-    this.SKIP_print_error_raw = (msg: ptr) => {
+    this.SKIP_print_error_raw = (msg: ptr<Internal.String>) => {
       utils.sklog(msg, Stream.ERR);
     };
-    this.SKIP_print_debug = (msg: ptr) => {
+    this.SKIP_print_debug = (msg: ptr<Internal.String>) => {
       utils.sklog(msg, Stream.DEBUG, true);
     };
-    this.SKIP_print_debug_raw = (msg: ptr) => {
+    this.SKIP_print_debug_raw = (msg: ptr<Internal.String>) => {
       utils.sklog(msg, Stream.DEBUG);
     };
-    this.SKIP_print_raw = (msg: ptr) => {
+    this.SKIP_print_raw = (msg: ptr<Internal.String>) => {
       utils.sklog(msg, Stream.OUT);
     };
-    this.SKIP_print_string = (msg: ptr) => {
+    this.SKIP_print_string = (msg: ptr<Internal.String>) => {
       utils.sklog(msg, Stream.OUT, true);
     };
-    this.js_throw = (exc: ptr, rethrow: int) => utils.ethrow(exc, rethrow != 0);
-    this.js_replace_exn = (oldex: ptr, newex: ptr) =>
-      utils.replace_exn(oldex, newex);
+    this.js_throw = (exc: ptr<Internal.Exception>, rethrow: int) =>
+      utils.ethrow(exc, rethrow != 0);
+    this.js_replace_exn = (
+      oldex: ptr<Internal.Exception>,
+      newex: ptr<Internal.Exception>,
+    ) => utils.replace_exn(oldex, newex);
     this.SKIP_throw_cruntime = utils.exit;
     this.SKIP_print_char = (c: int) => {
       var str = String.fromCharCode(c);
@@ -123,7 +137,10 @@ class LinksImpl implements Links {
     this.SKIP_read_line_get = (i: int) => {
       return this.lineBuffer[i];
     };
-    this.SKIP_FileSystem_appendTextFile = (path: ptr, contents: ptr) => {
+    this.SKIP_FileSystem_appendTextFile = (
+      path: ptr<Internal.String>,
+      contents: ptr<Internal.String>,
+    ) => {
       let strPath = utils.importString(path);
       let strContents = utils.importString(contents);
       if (this.env) {
@@ -131,21 +148,24 @@ class LinksImpl implements Links {
       }
     };
 
-    this.SKIP_setenv = (skName: ptr, skValue: ptr) => {
+    this.SKIP_setenv = (
+      skName: ptr<Internal.String>,
+      skValue: ptr<Internal.String>,
+    ) => {
       if (this.env) {
         this.env
           .sys()
           .setenv(utils.importString(skName), utils.importString(skValue));
       }
     };
-    this.SKIP_getenv = (skName: ptr) => {
+    this.SKIP_getenv = (skName: ptr<Internal.String>) => {
       if (this.env) {
         let value = this.env.sys().getenv(utils.importString(skName));
         return value ? utils.exportString(value) : null;
       }
       return null;
     };
-    this.SKIP_unsetenv = (skName: ptr) => {
+    this.SKIP_unsetenv = (skName: ptr<Internal.String>) => {
       if (this.env) {
         this.env.sys().unsetenv(utils.importString(skName));
       }
@@ -186,10 +206,12 @@ class Manager implements ToWasmManager {
     toWasm.__cxa_throw = (exn: ptr, infi: ptr, dest: ptr) => {
       throw new Error("Not managed exception");
     };
-    toWasm.js_throw = (strPtr: ptr, rethrow: int) =>
-      links.js_throw(strPtr, rethrow);
-    toWasm.js_replace_exn = (oldex: ptr, newex: ptr) =>
-      links.js_replace_exn(oldex, newex);
+    toWasm.js_throw = (excPtr: ptr<Internal.Exception>, rethrow: int) =>
+      links.js_throw(excPtr, rethrow);
+    toWasm.js_replace_exn = (
+      oldex: ptr<Internal.Exception>,
+      newex: ptr<Internal.Exception>,
+    ) => links.js_replace_exn(oldex, newex);
     toWasm.SKIP_throw_cruntime = (code: int) => links.SKIP_throw_cruntime(code);
     toWasm.cos = Math.cos;
     toWasm.sin = Math.sin;
@@ -205,15 +227,20 @@ class Manager implements ToWasmManager {
     toWasm.SKIP_Math_log10 = Math.log10;
     toWasm.SKIP_Math_exp = Math.exp;
     toWasm.SKIP_JS_timeStamp = () => links.SKIP_JS_timeStamp();
-    toWasm.SKIP_print_error = (strPtr: ptr) => links.SKIP_print_error(strPtr);
-    toWasm.SKIP_print_error_raw = (strPtr: ptr) =>
+    toWasm.SKIP_print_error = (strPtr: ptr<Internal.String>) =>
+      links.SKIP_print_error(strPtr);
+    toWasm.SKIP_print_error_raw = (strPtr: ptr<Internal.String>) =>
       links.SKIP_print_error_raw(strPtr);
-    toWasm.SKIP_print_debug = (strPtr: ptr) => links.SKIP_print_debug(strPtr);
-    toWasm.SKIP_print_debug_raw = (strPtr: ptr) =>
+    toWasm.SKIP_print_debug = (strPtr: ptr<Internal.String>) =>
+      links.SKIP_print_debug(strPtr);
+    toWasm.SKIP_print_debug_raw = (strPtr: ptr<Internal.String>) =>
       links.SKIP_print_debug_raw(strPtr);
-    toWasm.SKIP_print_raw = (strPtr: ptr) => links.SKIP_print_raw(strPtr);
-    toWasm.SKIP_print_char = (strPtr: ptr) => links.SKIP_print_char(strPtr);
-    toWasm.SKIP_print_string = (strPtr: ptr) => links.SKIP_print_string(strPtr);
+    toWasm.SKIP_print_raw = (strPtr: ptr<Internal.String>) =>
+      links.SKIP_print_raw(strPtr);
+    toWasm.SKIP_print_char = (strPtr: ptr<Internal.String>) =>
+      links.SKIP_print_char(strPtr);
+    toWasm.SKIP_print_string = (strPtr: ptr<Internal.String>) =>
+      links.SKIP_print_string(strPtr);
     toWasm.SKIP_etry = (f: ptr, exn_handler: ptr) =>
       links.SKIP_etry(f, exn_handler);
     toWasm.SKIP_delete_external_exception = (actor: int) =>
@@ -227,15 +254,21 @@ class Manager implements ToWasmManager {
     toWasm.SKIP_js_get_argn = (index: int) => links.SKIP_js_get_argn(index);
     toWasm.SKIP_js_get_envc = () => links.SKIP_js_get_envc();
     toWasm.SKIP_js_get_envn = (index: int) => links.SKIP_js_get_envn(index);
-    toWasm.SKIP_FileSystem_appendTextFile = (path: ptr, contents: ptr) =>
-      links.SKIP_FileSystem_appendTextFile(path, contents);
+    toWasm.SKIP_FileSystem_appendTextFile = (
+      path: ptr<Internal.String>,
+      contents: ptr<Internal.String>,
+    ) => links.SKIP_FileSystem_appendTextFile(path, contents);
     toWasm.SKIP_read_line_fill = () => links.SKIP_read_line_fill();
     toWasm.SKIP_read_to_end_fill = () => links.SKIP_read_to_end_fill();
     toWasm.SKIP_read_line_get = (index: int) => links.SKIP_read_line_get(index);
-    toWasm.SKIP_setenv = (skName: ptr, skValue: ptr) =>
-      links.SKIP_setenv(skName, skValue);
-    toWasm.SKIP_getenv = (skName: ptr) => links.SKIP_getenv(skName);
-    toWasm.SKIP_unsetenv = (skName: ptr) => links.SKIP_unsetenv(skName);
+    toWasm.SKIP_setenv = (
+      skName: ptr<Internal.String>,
+      skValue: ptr<Internal.String>,
+    ) => links.SKIP_setenv(skName, skValue);
+    toWasm.SKIP_getenv = (skName: ptr<Internal.String>) =>
+      links.SKIP_getenv(skName);
+    toWasm.SKIP_unsetenv = (skName: ptr<Internal.String>) =>
+      links.SKIP_unsetenv(skName);
     return links;
   };
 }
@@ -249,8 +282,11 @@ interface ToWasm {
   abortOnCannotGrowMemory: (err: ptr) => void;
   __setErrNo: (err: ptr) => void;
   __cxa_throw: (exn: ptr, infi: ptr, dest: ptr) => void;
-  js_throw: (strPtr: ptr, rethrow: int) => void;
-  js_replace_exn: (oldex: ptr, newex: ptr) => void;
+  js_throw: (excPtr: ptr<Internal.Exception>, rethrow: int) => void;
+  js_replace_exn: (
+    oldex: ptr<Internal.Exception>,
+    newex: ptr<Internal.Exception>,
+  ) => void;
   SKIP_throw_cruntime: (code: int) => void;
   SKIP_JS_timeStamp: () => float;
   cos: (v: float) => float;
@@ -266,30 +302,36 @@ interface ToWasm {
   SKIP_Math_asin: (v: float) => float;
   SKIP_Math_log10: (v: float) => float;
   SKIP_Math_exp: (v: float) => float;
-  SKIP_print_error: (strPtr: ptr) => void;
-  SKIP_print_error_raw: (strPtr: ptr) => void;
-  SKIP_print_debug: (strPtr: ptr) => void;
-  SKIP_print_debug_raw: (strPtr: ptr) => void;
-  SKIP_print_raw: (strPtr: ptr) => void;
-  SKIP_print_char: (strPtr: ptr) => void;
-  SKIP_print_string: (strPtr: ptr) => void;
+  SKIP_print_error: (strPtr: ptr<Internal.String>) => void;
+  SKIP_print_error_raw: (strPtr: ptr<Internal.String>) => void;
+  SKIP_print_debug: (strPtr: ptr<Internal.String>) => void;
+  SKIP_print_debug_raw: (strPtr: ptr<Internal.String>) => void;
+  SKIP_print_raw: (strPtr: ptr<Internal.String>) => void;
+  SKIP_print_char: (strPtr: ptr<Internal.String>) => void;
+  SKIP_print_string: (strPtr: ptr<Internal.String>) => void;
   SKIP_etry: (f: ptr, exn_handler: ptr) => ptr;
   SKIP_delete_external_exception: (exc: int) => void;
-  SKIP_external_exception_message: (exc: int) => ptr;
+  SKIP_external_exception_message: (exc: int) => ptr<Internal.String>;
   SKIP_js_time_ms_lo: () => int;
   SKIP_js_time_ms_hi: () => int;
   SKIP_js_get_entropy: () => int;
   SKIP_js_get_argc: () => int;
-  SKIP_js_get_argn: (index: int) => ptr;
+  SKIP_js_get_argn: (index: int) => ptr<Internal.String>;
   SKIP_js_get_envc: () => int;
-  SKIP_js_get_envn: (index: int) => ptr;
-  SKIP_FileSystem_appendTextFile: (path: ptr, contents: ptr) => void;
+  SKIP_js_get_envn: (index: int) => ptr<Internal.String>;
+  SKIP_FileSystem_appendTextFile: (
+    path: ptr<Internal.String>,
+    contents: ptr<Internal.String>,
+  ) => void;
   SKIP_read_line_fill: () => int;
   SKIP_read_to_end_fill: () => int;
   SKIP_read_line_get: (index: int) => int;
-  SKIP_setenv: (skName: ptr, skvalue: ptr) => void;
-  SKIP_getenv: (skName: ptr) => ptr | null;
-  SKIP_unsetenv: (skName: ptr) => void;
+  SKIP_setenv: (
+    skName: ptr<Internal.String>,
+    skvalue: ptr<Internal.String>,
+  ) => void;
+  SKIP_getenv: (skName: ptr<Internal.String>) => Opt<ptr<Internal.String>>;
+  SKIP_unsetenv: (skName: ptr<Internal.String>) => void;
 }
 
 /* @sk runtime */

--- a/prelude/ts/src/sk_runtime.ts
+++ b/prelude/ts/src/sk_runtime.ts
@@ -20,7 +20,7 @@ class LinksImpl implements Links {
 
   SKIP_read_line_fill!: () => int;
   SKIP_read_to_end_fill!: () => int;
-  SKIP_read_line_get!: (index: int) => ptr;
+  SKIP_read_line_get!: (index: int) => int;
 
   SKIP_print_error!: (strPtr: ptr) => void;
   SKIP_print_error_raw!: (strPtr: ptr) => void;
@@ -31,7 +31,7 @@ class LinksImpl implements Links {
   SKIP_print_string!: (strPtr: ptr) => void;
   SKIP_etry!: (f: ptr, exn_handler: ptr) => ptr;
   js_throw!: (strPtr: ptr, rethrow: int) => void;
-  js_replace_exn!: (oldex: ptr, newex: int) => void;
+  js_replace_exn!: (oldex: ptr, newex: ptr) => void;
   SKIP_throw_cruntime!: (code: int) => void;
   SKIP_JS_timeStamp!: () => float;
 
@@ -188,7 +188,7 @@ class Manager implements ToWasmManager {
     };
     toWasm.js_throw = (strPtr: ptr, rethrow: int) =>
       links.js_throw(strPtr, rethrow);
-    toWasm.js_replace_exn = (oldex: ptr, newex: int) =>
+    toWasm.js_replace_exn = (oldex: ptr, newex: ptr) =>
       links.js_replace_exn(oldex, newex);
     toWasm.SKIP_throw_cruntime = (code: int) => links.SKIP_throw_cruntime(code);
     toWasm.cos = Math.cos;
@@ -250,7 +250,7 @@ interface ToWasm {
   __setErrNo: (err: ptr) => void;
   __cxa_throw: (exn: ptr, infi: ptr, dest: ptr) => void;
   js_throw: (strPtr: ptr, rethrow: int) => void;
-  js_replace_exn: (oldex: ptr, newex: int) => void;
+  js_replace_exn: (oldex: ptr, newex: ptr) => void;
   SKIP_throw_cruntime: (code: int) => void;
   SKIP_JS_timeStamp: () => float;
   cos: (v: float) => float;
@@ -286,7 +286,7 @@ interface ToWasm {
   SKIP_FileSystem_appendTextFile: (path: ptr, contents: ptr) => void;
   SKIP_read_line_fill: () => int;
   SKIP_read_to_end_fill: () => int;
-  SKIP_read_line_get: (index: int) => ptr;
+  SKIP_read_line_get: (index: int) => int;
   SKIP_setenv: (skName: ptr, skvalue: ptr) => void;
   SKIP_getenv: (skName: ptr) => ptr | null;
   SKIP_unsetenv: (skName: ptr) => void;

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -179,21 +179,23 @@ export interface Memory {
 
 interface Exported {
   SKIP_throw_EndOfFile: () => void;
-  SKIP_String_byteSize: (strPtr: ptr) => int;
+  SKIP_String_byteSize: (strPtr: ptr<Internal.String>) => int;
   SKIP_Obstack_alloc: (size: int) => ptr;
-  SKIP_new_Obstack: () => ptr;
-  SKIP_destroy_Obstack: (pos: ptr) => void;
-  sk_string_create: (addr: ptr, size: int) => ptr;
-  SKIP_createByteArray: (size: int) => ptr;
-  SKIP_createFloatArray: (size: int) => ptr;
-  SKIP_createUInt32Array: (size: int) => ptr;
-  SKIP_getArraySize: (skArray: ptr) => int;
+  SKIP_new_Obstack: () => ptr<Internal.Obstack>;
+  SKIP_destroy_Obstack: (pos: ptr<Internal.Obstack>) => void;
+  sk_string_create: (addr: ptr, size: int) => ptr<Internal.String>;
+  SKIP_createByteArray: (size: int) => ptr<Internal.Array<Internal.Byte>>;
+  SKIP_createFloatArray: (size: int) => ptr<Internal.Array<Internal.Float>>;
+  SKIP_createUInt32Array: (size: int) => ptr<Internal.Array<Internal.UInt32>>;
+  SKIP_getArraySize: <Ty>(skArray: ptr<Internal.Array<Internal.T<Ty>>>) => int;
   SKIP_call0: (fnc: ptr) => ptr;
   SKIP_skfs_init: (size: int) => void;
   SKIP_initializeSkip: () => void;
   SKIP_skfs_end_of_init: () => void;
   SKIP_callWithException: (fnc: ptr, exc: int) => ptr;
-  SKIP_getExceptionMessage: (skExc: ptr) => ptr;
+  SKIP_getExceptionMessage: (
+    skExc: ptr<Internal.Exception>,
+  ) => ptr<Internal.String>;
   SKIP_get_persistent_size: () => int;
   SKIP_get_version: () => number;
   skip_main: () => void;
@@ -230,7 +232,7 @@ export class Utils {
   private stddebug: Array<string>;
   private mainFn?: string;
   private exception?: Error;
-  private stacks: Map<ptr, string>;
+  private stacks: Map<ptr<Internal.Exception>, string>;
 
   exit = (code: int) => {
     let message =
@@ -263,7 +265,11 @@ export class Utils {
       this.stdout.push(str);
     }
   };
-  sklog = (strPtr: ptr, kind?: Stream, newLine: boolean = false) => {
+  sklog = (
+    strPtr: ptr<Internal.String>,
+    kind?: Stream,
+    newLine: boolean = false,
+  ) => {
     let str = this.importString(strPtr);
     this.log(str, kind, newLine);
   };
@@ -357,18 +363,18 @@ export class Utils {
     return this.stdout.join("");
   };
 
-  importOptString = (strPtr: ptr) => {
+  importOptString = (strPtr: ptr<Internal.String>) => {
     if (strPtr > 0) {
       return this.importString(strPtr);
     }
     return null;
   };
-  importString = (strPtr: ptr) => {
+  importString = (strPtr: ptr<Internal.String>) => {
     let size = this.exports.SKIP_String_byteSize(strPtr);
     let utf8 = new Uint8Array(this.exports.memory.buffer, strPtr, size);
     return this.env.decodeUTF8(utf8);
   };
-  exportString: (s: string) => ptr = (s: string) => {
+  exportString = (s: string): ptr<Internal.String> => {
     var data = new Uint8Array(this.exports.memory.buffer);
     // @ts-ignore
     var i = 0,
@@ -404,7 +410,10 @@ export class Utils {
     }
     return this.exports.sk_string_create(addr, i);
   };
-  importBytes = (skArray: ptr, sizeof: int = 1) => {
+  importBytes = (
+    skArray: ptr<Internal.Array<Internal.Byte>>,
+    sizeof: int = 1,
+  ) => {
     let size = this.exports.SKIP_getArraySize(skArray) * sizeof;
     let skData = new Uint8Array(this.exports.memory.buffer, skArray, size);
     let copy = new Uint8Array(size);
@@ -435,7 +444,7 @@ export class Utils {
     );
     data.set(view);
   };
-  importUInt32s = (skArray: ptr) => {
+  importUInt32s = (skArray: ptr<Internal.Array<Internal.UInt32>>) => {
     let size = this.exports.SKIP_getArraySize(skArray);
     let skData = new Uint32Array(this.exports.memory.buffer, skArray, size);
     let copy = new Uint32Array(size);
@@ -452,7 +461,7 @@ export class Utils {
     skData.set(array);
     return skArray;
   }
-  importFloats = (skArray: ptr) => {
+  importFloats = (skArray: ptr<Internal.Array<Internal.Float>>) => {
     let size = this.exports.SKIP_getArraySize(skArray);
     let skData = new Float64Array(this.exports.memory.buffer, skArray, size);
     let copy = new Float64Array(size);
@@ -507,7 +516,7 @@ export class Utils {
       }
     }
   };
-  ethrow = (skExc: ptr, rethrow: boolean) => {
+  ethrow = (skExc: ptr<Internal.Exception>, rethrow: boolean) => {
     if (this.env && this.env.onException) this.env.onException();
     if (rethrow && this.exception) {
       throw this.exception;
@@ -536,7 +545,7 @@ export class Utils {
       throw err;
     }
   };
-  replace_exn(oldex: ptr, newex: ptr) {
+  replace_exn(oldex: ptr<Internal.Exception>, newex: ptr<Internal.Exception>) {
     const stack = this.stacks.get(oldex);
     if (stack) {
       this.stacks.delete(oldex);
@@ -563,7 +572,7 @@ export class Utils {
     }
   };
 
-  getErrorObject: (skExc: ptr) => ErrorObject = (skExc: ptr) => {
+  getErrorObject = (skExc: ptr<Internal.Exception>): ErrorObject => {
     if (skExc == null || skExc == 0) {
       return { message: "SKStore Internal error" };
     }

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -1,6 +1,8 @@
+import type * as Internal from "./sk_internal_types.js";
+
 export type float = number;
 export type int = number;
-export type ptr = number;
+export type ptr = Internal.Opaque<number, Internal.Ptr>;
 export type ErrorObject = {
   message: string;
   stack?: string[];

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -2,7 +2,8 @@ import type * as Internal from "./sk_internal_types.js";
 
 export type float = number;
 export type int = number;
-export type ptr = Internal.Opaque<number, Internal.Ptr>;
+export type ptr<InternalType extends Internal.T = Internal.Any> =
+  Internal.Opaque<number, InternalType>;
 export type ErrorObject = {
   message: string;
   stack?: string[];

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -2,8 +2,10 @@ import type * as Internal from "./sk_internal_types.js";
 
 export type float = number;
 export type int = number;
-export type ptr<InternalType extends Internal.T = Internal.Any> =
-  Internal.Opaque<number, InternalType>;
+export type ptr<InternalType extends Internal.T<any>> = Internal.Opaque<
+  number,
+  InternalType
+>;
 export type ErrorObject = {
   message: string;
   stack?: string[];
@@ -428,7 +430,7 @@ export class Utils {
     copy.set(skData);
     return copy;
   };
-  importBytes2 = (skBytes: ptr, size: int = 1) => {
+  importBytes2 = (skBytes: ptr<Internal.T<any>>, size: int = 1) => {
     let skData = new Uint8Array(this.exports.memory.buffer, skBytes, size);
     let copy = new Uint8Array(size);
     copy.set(skData);
@@ -444,7 +446,7 @@ export class Utils {
     data.set(view);
     return skArray;
   };
-  exportBytes2 = (view: Uint8Array, skBytes: ptr) => {
+  exportBytes2 = (view: Uint8Array, skBytes: ptr<Internal.T<any>>) => {
     let data = new Uint8Array(
       this.exports.memory.buffer,
       skBytes,
@@ -500,7 +502,7 @@ export class Utils {
       exception ? exception.id : 0,
     );
   };
-  getBytesFromBuffer = (dataPtr: ptr, length: int) => {
+  getBytesFromBuffer = (dataPtr: ptr<Internal.T<any>>, length: int) => {
     return new Uint8ClampedArray(this.exports.memory.buffer, dataPtr, length);
   };
   init = () => {

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -190,7 +190,6 @@ interface Exported {
   SKIP_initializeSkip: () => void;
   SKIP_skfs_end_of_init: () => void;
   SKIP_callWithException: (fnc: ptr, exc: int) => ptr;
-  SKIP_getExceptionId: (exn: ptr) => ptr;
   SKIP_getExceptionMessage: (skExc: ptr) => ptr;
   SKIP_get_persistent_size: () => int;
   SKIP_get_version: () => number;

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -180,10 +180,13 @@ export interface Memory {
 interface Exported {
   SKIP_throw_EndOfFile: () => void;
   SKIP_String_byteSize: (strPtr: ptr<Internal.String>) => int;
-  SKIP_Obstack_alloc: (size: int) => ptr;
+  SKIP_Obstack_alloc: (size: int) => ptr<Internal.Raw>;
   SKIP_new_Obstack: () => ptr<Internal.Obstack>;
   SKIP_destroy_Obstack: (pos: ptr<Internal.Obstack>) => void;
-  sk_string_create: (addr: ptr, size: int) => ptr<Internal.String>;
+  sk_string_create: (
+    addr: ptr<Internal.Raw>,
+    size: int,
+  ) => ptr<Internal.String>;
   SKIP_createByteArray: (size: int) => ptr<Internal.Array<Internal.Byte>>;
   SKIP_createFloatArray: (size: int) => ptr<Internal.Array<Internal.Float>>;
   SKIP_createUInt32Array: (size: int) => ptr<Internal.Array<Internal.UInt32>>;

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -188,11 +188,16 @@ interface Exported {
   SKIP_createFloatArray: (size: int) => ptr<Internal.Array<Internal.Float>>;
   SKIP_createUInt32Array: (size: int) => ptr<Internal.Array<Internal.UInt32>>;
   SKIP_getArraySize: <Ty>(skArray: ptr<Internal.Array<Internal.T<Ty>>>) => int;
-  SKIP_call0: (fnc: ptr) => ptr;
+  SKIP_call0: <Ret>(
+    fnc: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+  ) => ptr<Internal.T<Ret>>;
   SKIP_skfs_init: (size: int) => void;
   SKIP_initializeSkip: () => void;
   SKIP_skfs_end_of_init: () => void;
-  SKIP_callWithException: (fnc: ptr, exc: int) => ptr;
+  SKIP_callWithException: <Ret>(
+    fnc: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+    exc: int,
+  ) => ptr<Internal.T<Ret>>;
   SKIP_getExceptionMessage: (
     skExc: ptr<Internal.Exception>,
   ) => ptr<Internal.String>;
@@ -478,10 +483,15 @@ export class Utils {
     skData.set(array);
     return skArray;
   }
-  call = (fnId: ptr) => {
+  call = <Ret>(
+    fnId: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+  ): ptr<Internal.T<Ret>> => {
     return this.exports.SKIP_call0(fnId);
   };
-  callWithException = (fnId: ptr, exception: Exception | null) => {
+  callWithException = <Ret>(
+    fnId: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+    exception: Exception | null,
+  ): ptr<Internal.T<Ret>> => {
     return this.exports.SKIP_callWithException(
       fnId,
       exception ? exception.id : 0,
@@ -497,7 +507,10 @@ export class Utils {
     this.exports.SKIP_initializeSkip();
     this.exports.SKIP_skfs_end_of_init();
   };
-  etry = (f: ptr, exn_handler: ptr) => {
+  etry = <Ret>(
+    f: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+    exn_handler: ptr<Internal.Function<Internal.Void, Internal.T<Ret>>>,
+  ): ptr<Internal.T<Ret>> => {
     let err: Error | null = null;
     try {
       return this.call(f);

--- a/skdate/ts/src/package.json
+++ b/skdate/ts/src/package.json
@@ -1,3 +1,6 @@
 {
-  "type": "module"
+  "type": "module",
+  "devDependencies": {
+    "@types/node": "^22.5.1"
+  }
 }

--- a/skdate/ts/src/sk_date.ts
+++ b/skdate/ts/src/sk_date.ts
@@ -1,18 +1,27 @@
 // sknpm: Cannot be multiline for package sources
 // prettier-ignore
 import type { int, ptr, Environment, Links, ToWasmManager, Utils } from "#std/sk_types.js";
+import type * as Internal from "#std/sk_internal_types.js";
 
 interface ToWasm {
   SKIP_localetimezone: (year: int, month: int, day: int) => int;
-  SKIP_localetimezonename: (year: int, month: int, day: int) => ptr;
-  SKIP_locale: (code: int, value: int) => ptr;
+  SKIP_localetimezonename: (
+    year: int,
+    month: int,
+    day: int,
+  ) => ptr<Internal.String>;
+  SKIP_locale: (code: int, value: int) => ptr<Internal.String>;
   SKIP_JS_currenttimemillis: () => number;
 }
 
 class LinksImpl implements Links {
   SKIP_localetimezone!: (year: int, month: int, day: int) => int;
-  SKIP_localetimezonename!: (year: int, month: int, day: int) => ptr;
-  SKIP_locale!: (code: int, value: int) => ptr;
+  SKIP_localetimezonename!: (
+    year: int,
+    month: int,
+    day: int,
+  ) => ptr<Internal.String>;
+  SKIP_locale!: (code: int, value: int) => ptr<Internal.String>;
 
   constructor() {}
 

--- a/skstore/ts/src/prv/skstore_impl.ts
+++ b/skstore/ts/src/prv/skstore_impl.ts
@@ -1,6 +1,7 @@
 // prettier-ignore
 import { type ptr, type Opt } from "#std/sk_types.js";
 import type { Context } from "./skstore_types.js";
+import type * as Internal from "./skstore_internal_types.js";
 import type {
   Accumulator,
   EHandle,
@@ -177,9 +178,9 @@ export class LSelfImpl<K extends TJSON, V extends TJSON>
   implements LHandle<K, V>
 {
   protected context: Context;
-  protected lazyHdl: ptr;
+  protected lazyHdl: ptr<Internal.LHandle>;
 
-  constructor(context: Context, lazyHdl: ptr) {
+  constructor(context: Context, lazyHdl: ptr<Internal.LHandle>) {
     this.context = context;
     this.lazyHdl = lazyHdl;
     Object.defineProperty(this, "__sk_frozen", {

--- a/skstore/ts/src/prv/skstore_internal_types.ts
+++ b/skstore/ts/src/prv/skstore_internal_types.ts
@@ -39,17 +39,17 @@ export type JSONID = T<typeof jsonid>;
 declare const p: unique symbol;
 
 declare const lhandle: unique symbol;
-export type LHandle<K extends T = JSONID, V extends T = JSONFile> = T<
+export type LHandle<K extends T<any> = JSONID, V extends T<any> = JSONFile> = T<
   typeof lhandle
 > & { [p]: (_: V) => K };
 
 declare const nonemptyiterator: unique symbol;
-export type NonEmptyIterator<Ty extends T = JSONFile> = T<
+export type NonEmptyIterator<Ty extends T<any> = JSONFile> = T<
   typeof nonemptyiterator
 > & { [p]: Ty };
 
 declare const twriter: unique symbol;
-export type TWriter<K extends T = JSONID, V extends T = JSONFile> = T<
+export type TWriter<K extends T<any> = JSONID, V extends T<any> = JSONFile> = T<
   typeof twriter
 > & { [p]: [K, V] };
 

--- a/skstore/ts/src/prv/skstore_internal_types.ts
+++ b/skstore/ts/src/prv/skstore_internal_types.ts
@@ -1,4 +1,4 @@
-import type { T, Pair, String, Vector } from "#std/sk_internal_types.js";
+import type { T } from "#std/sk_internal_types.js";
 export type * from "#std/sk_internal_types.js";
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -52,6 +52,3 @@ declare const twriter: unique symbol;
 export type TWriter<K extends T<any> = JSONID, V extends T<any> = JSONFile> = T<
   typeof twriter
 > & { [p]: [K, V] };
-
-export type VectorCJSON = Vector<CJSON>;
-export type VectorPairStringCJSON = Vector<Pair<String, CJSON>>;

--- a/skstore/ts/src/prv/skstore_internal_types.ts
+++ b/skstore/ts/src/prv/skstore_internal_types.ts
@@ -1,0 +1,57 @@
+import type { T, Pair, String, Vector } from "#std/sk_internal_types.js";
+export type * from "#std/sk_internal_types.js";
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+declare const cjnull: unique symbol;
+export type CJNull = CJSON<typeof cjnull>;
+
+declare const cjbool: unique symbol;
+export type CJBool = CJSON<typeof cjbool>;
+
+declare const cjint: unique symbol;
+export type CJInt = CJSON<typeof cjint>;
+
+declare const cjfloat: unique symbol;
+export type CJFloat = CJSON<typeof cjfloat>;
+
+declare const cjstring: unique symbol;
+export type CJString = CJSON<typeof cjstring>;
+
+declare const cjarray: unique symbol;
+export type CJArray = CJSON<typeof cjarray>;
+
+declare const cjobject: unique symbol;
+export type CJObject = CJSON<typeof cjobject>;
+
+declare const cjson: unique symbol;
+export type CJSON<Sub = any> = T<typeof cjson> & { sub: Sub };
+
+declare const context: unique symbol;
+export type Context = T<typeof context>;
+
+declare const jsonfile: unique symbol;
+export type JSONFile = T<typeof jsonfile>;
+
+declare const jsonid: unique symbol;
+export type JSONID = T<typeof jsonid>;
+
+declare const p: unique symbol;
+
+declare const lhandle: unique symbol;
+export type LHandle<K extends T = JSONID, V extends T = JSONFile> = T<
+  typeof lhandle
+> & { [p]: (_: V) => K };
+
+declare const nonemptyiterator: unique symbol;
+export type NonEmptyIterator<Ty extends T = JSONFile> = T<
+  typeof nonemptyiterator
+> & { [p]: Ty };
+
+declare const twriter: unique symbol;
+export type TWriter<K extends T = JSONID, V extends T = JSONFile> = T<
+  typeof twriter
+> & { [p]: [K, V] };
+
+export type VectorCJSON = Vector<CJSON>;
+export type VectorPairStringCJSON = Vector<Pair<String, CJSON>>;

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -16,6 +16,7 @@ import type {
   FromWasm,
   CtxMapping,
 } from "./skstore_types.js";
+import type * as Internal from "./skstore_internal_types.js";
 import { LSelfImpl, SKStoreFactoryImpl } from "./skstore_impl.js";
 // prettier-ignore
 import type { SKDBShared } from "#skdb/skdb_types.js";
@@ -221,7 +222,7 @@ export class ContextImpl implements Context {
     ) as Opt<V>;
   };
 
-  getArraySelf = <K, V>(lazyHdl: ptr, key: K) => {
+  getArraySelf = <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getArraySelf(
         this.pointer(),
@@ -230,7 +231,7 @@ export class ContextImpl implements Context {
       ),
     ) as V[];
   };
-  getOneSelf = <K, V>(lazyHdl: ptr, key: K) => {
+  getOneSelf = <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_getSelf(
         this.pointer(),
@@ -239,7 +240,7 @@ export class ContextImpl implements Context {
       ),
     ) as V;
   };
-  maybeGetOneSelf = <K, V>(lazyHdl: ptr, key: K) => {
+  maybeGetOneSelf = <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_maybeGetSelf(
         this.pointer(),
@@ -331,9 +332,13 @@ export class ContextImpl implements Context {
 class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
   private skjson: SKJSON;
   private exports: FromWasm;
-  private pointer: ptr;
+  private pointer: ptr<Internal.NonEmptyIterator>;
 
-  constructor(skjson: SKJSON, exports: FromWasm, pointer: ptr) {
+  constructor(
+    skjson: SKJSON,
+    exports: FromWasm,
+    pointer: ptr<Internal.NonEmptyIterator>,
+  ) {
     this.skjson = skjson;
     this.exports = exports;
     this.pointer = pointer;
@@ -383,9 +388,13 @@ class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
 class WriterImpl<K, T> {
   private skjson: SKJSON;
   private exports: FromWasm;
-  private pointer: ptr;
+  private pointer: ptr<Internal.TWriter>;
 
-  constructor(skjson: SKJSON, exports: FromWasm, pointer: ptr) {
+  constructor(
+    skjson: SKJSON,
+    exports: FromWasm,
+    pointer: ptr<Internal.TWriter>,
+  ) {
     this.skjson = skjson;
     this.exports = exports;
     this.pointer = pointer;
@@ -412,50 +421,71 @@ interface ToWasm {
   // Context
   SKIP_SKStore_applyMapFun(
     fn: int,
-    context: ptr,
-    writer: ptr,
-    key: ptr,
-    it: ptr,
+    context: ptr<Internal.Context>,
+    writer: ptr<Internal.TWriter>,
+    key: ptr<Internal.CJSON>,
+    it: ptr<Internal.NonEmptyIterator>,
   ): void;
   SKIP_SKStore_applyMapTableFun(
     fn: int,
-    context: ptr,
-    writer: ptr,
-    row: ptr,
+    context: ptr<Internal.Context>,
+    writer: ptr<Internal.TWriter>,
+    row: ptr<Internal.CJArray>,
     occ: int,
   ): void;
-  SKIP_SKStore_applyConvertToRowFun(fn: int, key: ptr, it: ptr): ptr;
-  SKIP_SKStore_init(context: ptr): void;
-  SKIP_SKStore_applyLazyFun(fn: int, context: ptr, self: ptr, key: ptr): ptr;
-  SKIP_SKStore_applyParamsFun(fn: int, context: ptr, key: ptr): ptr;
+  SKIP_SKStore_applyConvertToRowFun(
+    fn: int,
+    key: ptr<Internal.CJSON>,
+    it: ptr<Internal.NonEmptyIterator>,
+  ): ptr<Internal.CJSON>;
+  SKIP_SKStore_init(context: ptr<Internal.Context>): void;
+  SKIP_SKStore_applyLazyFun(
+    fn: int,
+    context: ptr<Internal.Context>,
+    self: ptr<Internal.LHandle>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
+  SKIP_SKStore_applyParamsFun(
+    fn: int,
+    context: ptr<Internal.Context>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
   SKIP_SKStore_applyLazyAsyncFun(
     fn: int,
-    callId: ptr,
-    name: ptr,
-    key: ptr,
-    param: ptr,
+    callId: ptr<Internal.String>,
+    name: ptr<Internal.String>,
+    key: ptr<Internal.CJSON>,
+    param: ptr<Internal.CJSON>,
   ): void;
 
   // Accumulator
-  SKIP_SKStore_applyAccumulate(fn: int, acc: ptr, value: ptr): ptr;
-  SKIP_SKStore_applyDismiss(fn: int, acc: ptr, value: ptr): Opt<ptr>;
+  SKIP_SKStore_applyAccumulate(
+    fn: int,
+    acc: ptr<Internal.CJSON>,
+    value: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
+  SKIP_SKStore_applyDismiss(
+    fn: int,
+    acc: ptr<Internal.CJSON>,
+    value: ptr<Internal.CJSON>,
+  ): Opt<ptr<Internal.CJSON>>;
   // Utils
-  SKIP_SKStore_getErrorHdl(exn: ptr): number;
+  SKIP_SKStore_getErrorHdl(exn: ptr<Internal.Exception>): number;
 }
 
 class Ref {
-  pointers: ptr[] = [];
+  pointers: ptr<Internal.Context>[] = [];
 
-  push(pointer: ptr) {
+  push(pointer: ptr<Internal.Context>) {
     this.pointers.push(pointer);
   }
 
-  get() {
+  get(): Opt<ptr<Internal.Context>> {
     if (this.pointers.length == 0) return null;
     return this.pointers[this.pointers.length - 1];
   }
 
-  pop() {
+  pop(): void {
     this.pointers.pop();
   }
 }
@@ -466,29 +496,56 @@ class LinksImpl implements Links {
   skjson?: SKJSON;
 
   detachHandle!: (fn: int) => void;
-  applyMapFun!: (fn: int, context: ptr, writer: ptr, key: ptr, it: ptr) => void;
+  applyMapFun!: (
+    fn: int,
+    context: ptr<Internal.Context>,
+    writer: ptr<Internal.TWriter>,
+    key: ptr<Internal.CJSON>,
+    it: ptr<Internal.NonEmptyIterator>,
+  ) => void;
   applyMapTableFun!: (
     fn: int,
-    context: ptr,
-    writer: ptr,
-    row: ptr,
+    context: ptr<Internal.Context>,
+    writer: ptr<Internal.TWriter>,
+    row: ptr<Internal.CJArray>,
     occ: int,
   ) => void;
 
-  applyLazyFun!: (fn: int, context: ptr, self: ptr, key: ptr) => ptr;
-  applyParamsFun!: (fn: int, context: ptr, key: ptr) => ptr;
+  applyLazyFun!: (
+    fn: int,
+    context: ptr<Internal.Context>,
+    self: ptr<Internal.LHandle>,
+    key: ptr<Internal.CJSON>,
+  ) => ptr<Internal.CJSON>;
+  applyParamsFun!: (
+    fn: int,
+    context: ptr<Internal.Context>,
+    key: ptr<Internal.CJSON>,
+  ) => ptr<Internal.CJSON>;
   applyLazyAsyncFun!: (
     fn: int,
-    callId: ptr,
-    name: ptr,
-    key: ptr,
-    param: ptr,
+    callId: ptr<Internal.String>,
+    name: ptr<Internal.String>,
+    key: ptr<Internal.CJSON>,
+    param: ptr<Internal.CJSON>,
   ) => void;
-  init!: (context: ptr) => void;
-  applyAccumulate!: (fn: int, acc: ptr, value: ptr) => ptr;
-  applyDismiss!: (fn: int, acc: ptr, value: ptr) => Opt<ptr>;
-  getErrorHdl!: (exn: ptr) => number;
-  applyConvertToRowFun!: (fn: int, key: ptr, it: ptr) => ptr;
+  init!: (context: ptr<Internal.Context>) => void;
+  applyAccumulate!: (
+    fn: int,
+    acc: ptr<Internal.CJSON>,
+    value: ptr<Internal.CJSON>,
+  ) => ptr<Internal.CJSON>;
+  applyDismiss!: (
+    fn: int,
+    acc: ptr<Internal.CJSON>,
+    value: ptr<Internal.CJSON>,
+  ) => Opt<ptr<Internal.CJSON>>;
+  getErrorHdl!: (exn: ptr<Internal.Exception>) => number;
+  applyConvertToRowFun!: (
+    fn: int,
+    key: ptr<Internal.CJSON>,
+    it: ptr<Internal.NonEmptyIterator>,
+  ) => ptr<Internal.CJSON>;
 
   private initFn!: () => void;
 
@@ -507,7 +564,13 @@ class LinksImpl implements Links {
       return this.skjson;
     };
     const ref = new Ref();
-    this.applyMapFun = (fn: int, ctx: ptr, writer: ptr, key: ptr, it: ptr) => {
+    this.applyMapFun = (
+      fn: int,
+      ctx: ptr<Internal.Context>,
+      writer: ptr<Internal.TWriter>,
+      key: ptr<Internal.CJSON>,
+      it: ptr<Internal.NonEmptyIterator>,
+    ) => {
       ref.push(ctx);
       const jsu = skjson();
       const w = new WriterImpl(jsu, fromWasm, writer);
@@ -531,9 +594,9 @@ class LinksImpl implements Links {
     };
     this.applyMapTableFun = (
       fn: int,
-      ctx: ptr,
-      writer: ptr,
-      row: ptr,
+      ctx: ptr<Internal.Context>,
+      writer: ptr<Internal.TWriter>,
+      row: ptr<Internal.CJArray>,
       occ: int,
     ) => {
       ref.push(ctx);
@@ -547,7 +610,11 @@ class LinksImpl implements Links {
       ref.pop();
     };
 
-    this.applyConvertToRowFun = (fn: int, key: ptr, it: ptr) => {
+    this.applyConvertToRowFun = (
+      fn: int,
+      key: ptr<Internal.CJSON>,
+      it: ptr<Internal.NonEmptyIterator>,
+    ) => {
       const jsu = skjson();
       const res = this.handles.apply(fn, [
         jsu.importJSON(key),
@@ -558,10 +625,10 @@ class LinksImpl implements Links {
 
     this.applyLazyAsyncFun = (
       fn: int,
-      skcall: ptr,
-      skname: ptr,
-      skkey: ptr,
-      skparams: ptr,
+      skcall: ptr<Internal.String>,
+      skname: ptr<Internal.String>,
+      skkey: ptr<Internal.CJSON>,
+      skparams: ptr<Internal.CJSON>,
     ) => {
       const jsu = skjson();
       const callId = jsu.importString(skcall);
@@ -638,7 +705,12 @@ class LinksImpl implements Links {
         });
     };
 
-    this.applyLazyFun = (fn: int, ctx: ptr, hdl: ptr, key: ptr) => {
+    this.applyLazyFun = (
+      fn: int,
+      ctx: ptr<Internal.Context>,
+      hdl: ptr<Internal.LHandle>,
+      key: ptr<Internal.CJSON>,
+    ) => {
       ref.push(ctx);
       const jsu = skjson();
       const context = new ContextImpl(jsu, fromWasm, this.handles, ref);
@@ -652,19 +724,27 @@ class LinksImpl implements Links {
       return res;
     };
 
-    this.applyParamsFun = (fn: int, ctx: ptr, key: ptr) => {
+    this.applyParamsFun = (
+      fn: int,
+      ctx: ptr<Internal.Context>,
+      key: ptr<Internal.CJSON>,
+    ) => {
       ref.push(ctx);
       const jsu = skjson();
       const res = jsu.exportJSON(this.handles.apply(fn, [jsu.importJSON(key)]));
       ref.pop();
       return res;
     };
-    this.init = (context: ptr) => {
+    this.init = (context: ptr<Internal.Context>) => {
       ref.push(context);
       this.initFn();
       ref.pop();
     };
-    this.applyAccumulate = (fn: int, acc: ptr, value: ptr) => {
+    this.applyAccumulate = (
+      fn: int,
+      acc: ptr<Internal.CJSON>,
+      value: ptr<Internal.CJSON>,
+    ) => {
       const jsu = skjson();
       const accumulator = this.handles.get(fn) as Accumulator<any, any>;
       const result = accumulator.accumulate(
@@ -673,7 +753,11 @@ class LinksImpl implements Links {
       );
       return jsu.exportJSON(result);
     };
-    this.applyDismiss = (fn: int, acc: ptr, value: ptr) => {
+    this.applyDismiss = (
+      fn: int,
+      acc: ptr<Internal.CJSON>,
+      value: ptr<Internal.CJSON>,
+    ) => {
       const jsu = skjson();
       const accumulator = this.handles.get(fn) as Accumulator<any, any>;
       const result = accumulator.dismiss(
@@ -685,7 +769,7 @@ class LinksImpl implements Links {
     this.detachHandle = (idx: int) => {
       this.handles.delete(idx);
     };
-    this.getErrorHdl = (exn: ptr) => {
+    this.getErrorHdl = (exn: ptr<Internal.Exception>) => {
       return this.handles.register(utils.getErrorObject(exn));
     };
     const create = (init: () => void) => {
@@ -731,25 +815,28 @@ class Manager implements ToWasmManager {
     };
     toWasm.SKIP_SKStore_applyMapFun = (
       fn: int,
-      context: ptr,
-      writer: ptr,
-      key: ptr,
-      it: ptr,
+      context: ptr<Internal.Context>,
+      writer: ptr<Internal.TWriter>,
+      key: ptr<Internal.CJSON>,
+      it: ptr<Internal.NonEmptyIterator>,
     ) => {
       links.applyMapFun(fn, context, writer, key, it);
     };
     toWasm.SKIP_SKStore_applyMapTableFun = (
       fn: int,
-      context: ptr,
-      writer: ptr,
-      row: ptr,
+      context: ptr<Internal.Context>,
+      writer: ptr<Internal.TWriter>,
+      row: ptr<Internal.CJArray>,
       occ: int,
     ) => {
       links.applyMapTableFun(fn, context, writer, row, occ);
     };
-    toWasm.SKIP_SKStore_applyConvertToRowFun = (fn: int, key: ptr, it: ptr) =>
-      links.applyConvertToRowFun(fn, key, it);
-    toWasm.SKIP_SKStore_init = (context: ptr) => {
+    toWasm.SKIP_SKStore_applyConvertToRowFun = (
+      fn: int,
+      key: ptr<Internal.CJSON>,
+      it: ptr<Internal.NonEmptyIterator>,
+    ) => links.applyConvertToRowFun(fn, key, it);
+    toWasm.SKIP_SKStore_init = (context: ptr<Internal.Context>) => {
       links.init(context);
     };
     toWasm.SKIP_SKStore_applyLazyFun = (fn, context, self, key) =>
@@ -759,18 +846,25 @@ class Manager implements ToWasmManager {
       links.applyParamsFun(fn, context, key);
     toWasm.SKIP_SKStore_applyLazyAsyncFun = (
       fn: int,
-      call: ptr,
-      name: ptr,
-      key: ptr,
-      param: ptr,
+      call: ptr<Internal.String>,
+      name: ptr<Internal.String>,
+      key: ptr<Internal.CJSON>,
+      param: ptr<Internal.CJSON>,
     ) => {
       links.applyLazyAsyncFun(fn, call, name, key, param);
     };
-    toWasm.SKIP_SKStore_applyAccumulate = (fn: int, acc: ptr, value: ptr) =>
-      links.applyAccumulate(fn, acc, value);
-    toWasm.SKIP_SKStore_applyDismiss = (fn: int, acc: ptr, value: ptr) =>
-      links.applyDismiss(fn, acc, value);
-    toWasm.SKIP_SKStore_getErrorHdl = (exn: ptr) => links.getErrorHdl(exn);
+    toWasm.SKIP_SKStore_applyAccumulate = (
+      fn: int,
+      acc: ptr<Internal.CJSON>,
+      value: ptr<Internal.CJSON>,
+    ) => links.applyAccumulate(fn, acc, value);
+    toWasm.SKIP_SKStore_applyDismiss = (
+      fn: int,
+      acc: ptr<Internal.CJSON>,
+      value: ptr<Internal.CJSON>,
+    ) => links.applyDismiss(fn, acc, value);
+    toWasm.SKIP_SKStore_getErrorHdl = (exn: ptr<Internal.Exception>) =>
+      links.getErrorHdl(exn);
     return links;
   };
 }

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -388,7 +388,7 @@ class LinksImpl implements Links {
         return fromWasm.SKIP_SKJSON_endCJArray(arr);
       } else if (typeof value == "object") {
         if (value.__isObjectProxy || value.__isArrayProxy) {
-          return value.__pointer as number;
+          return value.__pointer as ptr;
         } else {
           const obj = fromWasm.SKIP_SKJSON_startCJObject();
           for (const key of Object.keys(value as object)) {

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -284,24 +284,25 @@ function clone<T>(value: T): T {
   }
 }
 
+type PartialCJObj = Internal.Vector<
+  Internal.Pair<Internal.String, Internal.CJSON>
+>;
+type PartialCJArray = Internal.Vector<Internal.CJSON>;
+
 interface FromWasm extends WasmAccess {
-  SKIP_SKJSON_startCJObject: () => ptr<Internal.VectorPairStringCJSON>;
+  SKIP_SKJSON_startCJObject: () => ptr<PartialCJObj>;
   SKIP_SKJSON_addToCJObject: (
-    obj: ptr<Internal.VectorPairStringCJSON>,
+    obj: ptr<PartialCJObj>,
     name: ptr<Internal.String>,
     value: ptr<Internal.CJSON>,
   ) => void;
-  SKIP_SKJSON_endCJObject: (
-    obj: ptr<Internal.VectorPairStringCJSON>,
-  ) => ptr<Internal.CJObject>;
-  SKIP_SKJSON_startCJArray: () => ptr<Internal.VectorCJSON>;
+  SKIP_SKJSON_endCJObject: (obj: ptr<PartialCJObj>) => ptr<Internal.CJObject>;
+  SKIP_SKJSON_startCJArray: () => ptr<PartialCJArray>;
   SKIP_SKJSON_addToCJArray: (
-    arr: ptr<Internal.VectorCJSON>,
+    arr: ptr<PartialCJArray>,
     value: ptr<Internal.CJSON>,
   ) => void;
-  SKIP_SKJSON_endCJArray: (
-    arr: ptr<Internal.VectorCJSON>,
-  ) => ptr<Internal.CJArray>;
+  SKIP_SKJSON_endCJArray: (arr: ptr<PartialCJArray>) => ptr<Internal.CJArray>;
   SKIP_SKJSON_createCJNull: () => ptr<Internal.CJNull>;
   SKIP_SKJSON_createCJInt: (v: int) => ptr<Internal.CJInt>;
   SKIP_SKJSON_createCJFloat: (v: float) => ptr<Internal.CJFloat>;

--- a/skstore/ts/src/prv/skstore_types.ts
+++ b/skstore/ts/src/prv/skstore_types.ts
@@ -1,5 +1,6 @@
 // prettier-ignore
 import type { Opt, Shared, ptr, int, float, Metadata } from "#std/sk_types.js";
+import type * as Internal from "./skstore_internal_types.js";
 import type {
   Accumulator,
   AValue,
@@ -20,11 +21,11 @@ export type CtxMapping<
 };
 
 export interface SKJSON extends Shared {
-  importJSON: (value: ptr, copy?: boolean) => any;
-  exportJSON: <T>(v: T) => ptr;
-  importOptJSON: (value: Opt<ptr>, copy?: boolean) => any;
-  importString: (v: ptr) => string;
-  exportString: (v: string) => ptr;
+  importJSON: (value: ptr<Internal.CJSON>, copy?: boolean) => any;
+  exportJSON: <T>(v: T) => ptr<Internal.CJSON>;
+  importOptJSON: (value: Opt<ptr<Internal.CJSON>>, copy?: boolean) => any;
+  importString: (v: ptr<Internal.String>) => string;
+  exportString: (v: string) => ptr<Internal.String>;
   runWithGC: <T>(fn: () => T) => T;
 }
 
@@ -74,9 +75,9 @@ export interface Context {
   getOneLazy: <K, V>(eagerHdl: string, key: K) => V;
   maybeGetOneLazy: <K, V>(eagerHdl: string, key: K) => Opt<V>;
 
-  getArraySelf: <K, V>(lazyHdl: ptr, key: K) => V[];
-  getOneSelf: <K, V>(lazyHdl: ptr, key: K) => V;
-  maybeGetOneSelf: <K, V>(lazyHdl: ptr, key: K) => Opt<V>;
+  getArraySelf: <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => V[];
+  getOneSelf: <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => V;
+  maybeGetOneSelf: <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => Opt<V>;
 
   size: (eagerHdl: string) => number;
 
@@ -128,65 +129,153 @@ export interface Handles {
 
 export interface FromWasm {
   // Handle
-  SKIP_SKStore_map(ctx: ptr, eagerHdl: ptr, name: ptr, fnPtr: int): ptr;
+  SKIP_SKStore_map(
+    ctx: ptr<Internal.Context>,
+    eagerHdl: ptr<Internal.String>,
+    name: ptr<Internal.String>,
+    fnPtr: int,
+  ): ptr<Internal.String>;
 
   SKIP_SKStore_mapReduce(
-    ctx: ptr,
-    eagerHdl: ptr,
-    name: ptr,
+    ctx: ptr<Internal.Context>,
+    eagerHdl: ptr<Internal.String>,
+    name: ptr<Internal.String>,
     fnPtr: int,
     accumulator: int,
-    accInit: ptr,
-  ): ptr;
+    accInit: ptr<Internal.CJSON>,
+  ): ptr<Internal.String>;
 
-  SKIP_SKStore_getFromTable(ctx: ptr, table: ptr, key: ptr, index: ptr): ptr;
+  SKIP_SKStore_getFromTable(
+    ctx: ptr<Internal.Context>,
+    table: ptr<Internal.String>,
+    key: ptr<Internal.CJSON>,
+    index: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
 
-  SKIP_SKStore_getArray(ctx: ptr, getterHdl: ptr, key: ptr): ptr;
-  SKIP_SKStore_get(ctx: ptr, getterHdl: ptr, key: ptr): ptr;
-  SKIP_SKStore_maybeGet(ctx: ptr, getterHdl: ptr, key: ptr): ptr;
+  SKIP_SKStore_getArray(
+    ctx: ptr<Internal.Context>,
+    getterHdl: ptr<Internal.String>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
+  SKIP_SKStore_get(
+    ctx: ptr<Internal.Context>,
+    getterHdl: ptr<Internal.String>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
+  SKIP_SKStore_maybeGet(
+    ctx: ptr<Internal.Context>,
+    getterHdl: ptr<Internal.String>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
 
-  SKIP_SKStore_getArrayLazy(ctx: ptr, lazyId: ptr, key: ptr): ptr;
-  SKIP_SKStore_getLazy(ctx: ptr, lazyId: ptr, key: ptr): ptr;
-  SKIP_SKStore_maybeGetLazy(ctx: ptr, lazyId: ptr, key: ptr): ptr;
+  SKIP_SKStore_getArrayLazy(
+    ctx: ptr<Internal.Context>,
+    lazyId: ptr<Internal.String>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
+  SKIP_SKStore_getLazy(
+    ctx: ptr<Internal.Context>,
+    lazyId: ptr<Internal.String>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
+  SKIP_SKStore_maybeGetLazy(
+    ctx: ptr<Internal.Context>,
+    lazyId: ptr<Internal.String>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
 
-  SKIP_SKStore_getArraySelf(ctx: ptr, selfHdl: ptr, key: ptr): ptr;
-  SKIP_SKStore_getSelf(ctx: ptr, selfHdl: ptr, key: ptr): ptr;
-  SKIP_SKStore_maybeGetSelf(ctx: ptr, selfHdl: ptr, key: ptr): ptr;
+  SKIP_SKStore_getArraySelf(
+    ctx: ptr<Internal.Context>,
+    selfHdl: ptr<Internal.LHandle>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
+  SKIP_SKStore_getSelf(
+    ctx: ptr<Internal.Context>,
+    selfHdl: ptr<Internal.LHandle>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
+  SKIP_SKStore_maybeGetSelf(
+    ctx: ptr<Internal.Context>,
+    selfHdl: ptr<Internal.LHandle>,
+    key: ptr<Internal.CJSON>,
+  ): ptr<Internal.CJSON>;
 
-  SKIP_SKStore_size(ctx: ptr, eagerHdl: ptr): number;
+  SKIP_SKStore_size(
+    ctx: ptr<Internal.Context>,
+    eagerHdl: ptr<Internal.String>,
+  ): number;
 
-  SKIP_SKStore_toSkdb(ctx: ptr, eagerHdl: ptr, table: ptr, fnPtr: int): void;
+  SKIP_SKStore_toSkdb(
+    ctx: ptr<Internal.Context>,
+    eagerHdl: ptr<Internal.String>,
+    table: ptr<Internal.String>,
+    fnPtr: int,
+  ): void;
 
   // NonEmptyIterator
-  SKIP_SKStore_iteratorNext(it: ptr): Opt<ptr>;
-  SKIP_SKStore_iteratorUniqueValue(it: ptr): Opt<ptr>;
-  SKIP_SKStore_iteratorFirst(it: ptr): ptr;
-  SKIP_SKStore_cloneIterator(it: ptr): ptr;
+  SKIP_SKStore_iteratorNext(
+    it: ptr<Internal.NonEmptyIterator>,
+  ): Opt<ptr<Internal.CJSON>>;
+  SKIP_SKStore_iteratorUniqueValue(
+    it: ptr<Internal.NonEmptyIterator>,
+  ): Opt<ptr<Internal.CJSON>>;
+  SKIP_SKStore_iteratorFirst(
+    it: ptr<Internal.NonEmptyIterator>,
+  ): ptr<Internal.CJSON>;
+  SKIP_SKStore_cloneIterator(
+    it: ptr<Internal.NonEmptyIterator>,
+  ): ptr<Internal.NonEmptyIterator>;
   // Writer
-  SKIP_SKStore_writerSet(writer: ptr, key: ptr, value: ptr): void;
-  SKIP_SKStore_writerSetArray(writer: ptr, key: ptr, values: ptr): void;
+  SKIP_SKStore_writerSet(
+    writer: ptr<Internal.TWriter>,
+    key: ptr<Internal.CJSON>,
+    value: ptr<Internal.CJSON>,
+  ): void;
+  SKIP_SKStore_writerSetArray(
+    writer: ptr<Internal.TWriter>,
+    key: ptr<Internal.CJSON>,
+    values: ptr<Internal.CJArray>,
+  ): void;
 
   // Store
-  SKIP_SKStore_createFor(session: ptr): float;
+  SKIP_SKStore_createFor(session: ptr<Internal.String>): float;
 
   // SKStore
-  SKIP_SKStore_asyncLazy(ctx: ptr, name: ptr, paramsFn: int, lazyFn: int): ptr;
-  SKIP_SKStore_lazy(ctx: ptr, name: ptr, lazyFn: int): ptr;
-  SKIP_SKStore_fromSkdb(ctx: ptr, table: ptr, name: ptr, fnPtr: int): ptr;
-  SKIP_SKStore_multimap(ctx: ptr, name: ptr, mappings: ptr): ptr;
+  SKIP_SKStore_asyncLazy(
+    ctx: ptr<Internal.Context>,
+    name: ptr<Internal.String>,
+    paramsFn: int,
+    lazyFn: int,
+  ): ptr<Internal.String>;
+  SKIP_SKStore_lazy(
+    ctx: ptr<Internal.Context>,
+    name: ptr<Internal.String>,
+    lazyFn: int,
+  ): ptr<Internal.String>;
+  SKIP_SKStore_fromSkdb(
+    ctx: ptr<Internal.Context>,
+    table: ptr<Internal.String>,
+    name: ptr<Internal.String>,
+    fnPtr: int,
+  ): ptr<Internal.String>;
+  SKIP_SKStore_multimap(
+    ctx: ptr<Internal.Context>,
+    name: ptr<Internal.String>,
+    mappings: ptr<Internal.CJArray>,
+  ): ptr<Internal.String>;
   SKIP_SKStore_asyncResult(
-    callId: ptr,
-    name: ptr,
-    key: ptr,
-    param: ptr,
-    value: ptr,
+    callId: ptr<Internal.String>,
+    name: ptr<Internal.String>,
+    key: ptr<Internal.CJSON>,
+    param: ptr<Internal.CJSON>,
+    value: ptr<Internal.CJObject>,
   ): number;
 
   SKIP_SKStore_multimapReduce(
-    ctx: ptr,
-    name: ptr,
-    mappings: ptr,
+    ctx: ptr<Internal.Context>,
+    name: ptr<Internal.String>,
+    mappings: ptr<Internal.CJArray>,
     accumulator: int,
-    accInit: ptr,
-  ): ptr;
+    accInit: ptr<Internal.CJSON>,
+  ): ptr<Internal.String>;
 }

--- a/sql/ts/src/skdb_skdb.ts
+++ b/sql/ts/src/skdb_skdb.ts
@@ -1,6 +1,7 @@
 // sknpm: Cannot be multiline for package sources
 // prettier-ignore
 import type { int, ptr, Environment, Links, ToWasmManager, Utils, Shared } from "#std/sk_types.js";
+import type * as Internal from "#std/sk_internal_types.js";
 import type {
   PagedMemory,
   Page,
@@ -79,13 +80,13 @@ interface ToWasm {
   SKIP_last_tick: (queryID: int) => int;
   SKIP_switch_to: (stream: int) => void;
   SKIP_clear_field_names: () => void;
-  SKIP_push_field_name: (skName: ptr) => void;
+  SKIP_push_field_name: (skName: ptr<Internal.String>) => void;
   SKIP_clear_object: () => void;
   SKIP_push_object_field_null: () => void;
   SKIP_push_object_field_int32: (field: int) => void;
-  SKIP_push_object_field_int64: (field: ptr) => void;
-  SKIP_push_object_field_float: (field: ptr) => void;
-  SKIP_push_object_field_string: (field: ptr) => void;
+  SKIP_push_object_field_int64: (field: ptr<Internal.String>) => void;
+  SKIP_push_object_field_float: (field: ptr<Internal.String>) => void;
+  SKIP_push_object_field_string: (field: ptr<Internal.String>) => void;
   SKIP_push_object: () => void;
   SKIP_js_mark_query: (queryID: int) => void;
   SKIP_js_delete_fun: (queryID: int) => void;
@@ -221,15 +222,18 @@ class LinksImpl implements Links, ToWasm {
 
   SKIP_last_tick!: (queryID: int) => int;
   SKIP_switch_to!: (stream: int) => void;
-  SKIP_call_external_fun!: (funId: int, skParam: ptr) => ptr;
+  SKIP_call_external_fun!: (
+    funId: int,
+    skParam: ptr<Internal.String>,
+  ) => ptr<Internal.String>;
   SKIP_clear_field_names!: () => void;
-  SKIP_push_field_name!: (skName: ptr) => void;
+  SKIP_push_field_name!: (skName: ptr<Internal.String>) => void;
   SKIP_clear_object!: () => void;
   SKIP_push_object_field_null!: () => void;
   SKIP_push_object_field_int32!: (field: int) => void;
-  SKIP_push_object_field_int64!: (field: ptr) => void;
-  SKIP_push_object_field_float!: (field: ptr) => void;
-  SKIP_push_object_field_string!: (field: ptr) => void;
+  SKIP_push_object_field_int64!: (field: ptr<Internal.String>) => void;
+  SKIP_push_object_field_float!: (field: ptr<Internal.String>) => void;
+  SKIP_push_object_field_string!: (field: ptr<Internal.String>) => void;
   SKIP_push_object!: () => void;
   SKIP_js_mark_query!: (queryID: int) => void;
   SKIP_js_delete_fun!: (queryID: int) => void;
@@ -285,7 +289,10 @@ class LinksImpl implements Links, ToWasm {
         }
       }
     };
-    this.SKIP_call_external_fun = (funId: int, skParam: ptr) => {
+    this.SKIP_call_external_fun = (
+      funId: int,
+      skParam: ptr<Internal.String>,
+    ) => {
       let res = this.state.call(funId, JSON.parse(utils.importString(skParam)));
       let strRes = JSON.stringify(res === undefined ? null : res);
       return utils.exportString(strRes);
@@ -299,7 +306,7 @@ class LinksImpl implements Links, ToWasm {
     this.SKIP_clear_field_names = () => {
       this.field_names = new Array();
     };
-    this.SKIP_push_field_name = (skName: ptr) => {
+    this.SKIP_push_field_name = (skName: ptr<Internal.String>) => {
       this.field_names.push(utils.importString(skName));
     };
     this.SKIP_clear_object = () => {
@@ -316,17 +323,17 @@ class LinksImpl implements Links, ToWasm {
       this.object[field_name] = n;
       this.objectIdx++;
     };
-    this.SKIP_push_object_field_int64 = (skV: ptr) => {
+    this.SKIP_push_object_field_int64 = (skV: ptr<Internal.String>) => {
       let field_name: string = this.field_names[this.objectIdx]!;
       this.object[field_name] = parseInt(utils.importString(skV), 10);
       this.objectIdx++;
     };
-    this.SKIP_push_object_field_float = (skV: ptr) => {
+    this.SKIP_push_object_field_float = (skV: ptr<Internal.String>) => {
       let field_name: string = this.field_names[this.objectIdx]!;
       this.object[field_name] = parseFloat(utils.importString(skV));
       this.objectIdx++;
     };
-    this.SKIP_push_object_field_string = (skV: ptr) => {
+    this.SKIP_push_object_field_string = (skV: ptr<Internal.String>) => {
       let field_name: string = this.field_names[this.objectIdx]!;
       this.object[field_name] = utils.importString(skV);
       this.objectIdx++;
@@ -480,7 +487,7 @@ class Manager implements ToWasmManager {
     let toWasm = wasm as ToWasm;
     let links = new LinksImpl(this.environment);
     toWasm.SKIP_clear_field_names = () => links.SKIP_clear_field_names();
-    toWasm.SKIP_push_field_name = (skName: ptr) =>
+    toWasm.SKIP_push_field_name = (skName: ptr<Internal.String>) =>
       links.SKIP_push_field_name(skName);
     toWasm.SKIP_clear_object = () => links.SKIP_clear_object();
     toWasm.SKIP_last_tick = (queryID: int) => links.SKIP_last_tick(queryID);
@@ -489,11 +496,11 @@ class Manager implements ToWasmManager {
       links.SKIP_push_object_field_null();
     toWasm.SKIP_push_object_field_int32 = (field: int) =>
       links.SKIP_push_object_field_int32(field);
-    toWasm.SKIP_push_object_field_int64 = (field: ptr) =>
+    toWasm.SKIP_push_object_field_int64 = (field: ptr<Internal.String>) =>
       links.SKIP_push_object_field_int64(field);
-    toWasm.SKIP_push_object_field_float = (field: ptr) =>
+    toWasm.SKIP_push_object_field_float = (field: ptr<Internal.String>) =>
       links.SKIP_push_object_field_float(field);
-    toWasm.SKIP_push_object_field_string = (field: ptr) =>
+    toWasm.SKIP_push_object_field_string = (field: ptr<Internal.String>) =>
       links.SKIP_push_object_field_string(field);
     toWasm.SKIP_push_object = () => links.SKIP_push_object();
     toWasm.SKIP_js_mark_query = (id: int) => links.SKIP_js_mark_query(id);


### PR DESCRIPTION
In JS, we use `type ptr = number` to represent pointers. Nothing prevents us from mixing `ptr` and `number`.
A first step is to make `ptr` (what Typescript people call) _opaque_ (it corresponds to OCaml `private` types, not abstract types), i.e. it is `number & fake_something` so that we can convert `ptr` to `number` but not the other way around, unless using `as` or `any`, of course...
Under undefined circumstances (pun intended), it guarantees we're not mixing both types.

The second step is to make `ptr` parametric so we know what they refer to in the Skip world (after being compiled to LLVM and Wasm). Again, it avoids mixing things like `ptr<int>` with `ptr<string>`. Like in C, you can always can between pointer, via `void*` (`ptr<any>`).

