### PR TITLE
[sknpm] Do not use docstrings

### DIFF
--- a/prelude/ts/src/sk_posix.ts
+++ b/prelude/ts/src/sk_posix.ts
@@ -154,7 +154,7 @@ class Manager implements ToWasmManager {
   };
 }
 
-/** @sk init */
+/* @sk init */
 export function init(env?: Environment) {
   return Promise.resolve(new Manager(env!));
 }

--- a/prelude/ts/src/sk_runtime.ts
+++ b/prelude/ts/src/sk_runtime.ts
@@ -292,7 +292,7 @@ interface ToWasm {
   SKIP_unsetenv: (skName: ptr) => void;
 }
 
-/** @sk runtime */
+/* @sk runtime */
 export function init(env?: Environment) {
   return Promise.resolve(new Manager(env));
 }

--- a/skdate/ts/src/sk_date.ts
+++ b/skdate/ts/src/sk_date.ts
@@ -94,7 +94,7 @@ class Manager implements ToWasmManager {
   };
 }
 
-/** @sk init */
+/* @sk init */
 export function init(env?: Environment) {
   return Promise.resolve(new Manager());
 }

--- a/sknpm/src/sknpm.sk
+++ b/sknpm/src/sknpm.sk
@@ -610,11 +610,14 @@ fun copyAndConvertImport(
       cLine = line.trim();
       if (cLine == nameLine || cLine == modulesLines || cLine == versionLine) {
         !withTmpl = true;
-      } else if (cLine == "/** @sk init */") {
+      } else if (cLine == "/* @sk init */" || cLine == "/** @sk init */") {
         !withInit = true;
-      } else if (cLine == "/** @sk loader */") {
+      } else if (cLine == "/* @sk loader */" || cLine == "/** @sk loader */") {
         !withLoader = true;
-      } else if (cLine == "/** @sk runtime */") {
+      } else if (
+        cLine == "/* @sk runtime */" ||
+        cLine == "/** @sk runtime */"
+      ) {
         !withRuntime = true;
       } else if (cLine == jsSourceMapping) {
         !line = mjsSourceMapping;

--- a/sknpm/src/ts.sk
+++ b/sknpm/src/ts.sk
@@ -64,7 +64,7 @@ fun tsResource(assets: Array<Asset>): String {
         "  }",
         "}",
         "",
-        "/** @sk init */",
+        "/* @sk init */",
         "export async function init(env: Env) {",
         ` return Promise.all(urls.map(env.fetch)).then(data => new Manager(env, data));`,
         "}",

--- a/skstore/ts/src/prv/skstore_module.ts
+++ b/skstore/ts/src/prv/skstore_module.ts
@@ -775,7 +775,7 @@ class Manager implements ToWasmManager {
   };
 }
 
-/** @sk init */
+/* @sk init */
 export function init(env: Environment) {
   return Promise.resolve(new Manager(env));
 }

--- a/skstore/ts/src/prv/skstore_skjson.ts
+++ b/skstore/ts/src/prv/skstore_skjson.ts
@@ -444,7 +444,7 @@ class Manager implements ToWasmManager {
   };
 }
 
-/** @sk init */
+/* @sk init */
 export function init(env: Environment) {
   return Promise.resolve(new Manager(env));
 }

--- a/sql/ts/src/skdb_skdb.ts
+++ b/sql/ts/src/skdb_skdb.ts
@@ -502,7 +502,7 @@ class Manager implements ToWasmManager {
   };
 }
 
-/** @sk init */
+/* @sk init */
 export function init(env?: Environment) {
   return Promise.resolve(new Manager(env!));
 }


### PR DESCRIPTION
Sknpm relies on some magic lines, I haven't investigated why, but they use the docstring syntax (starting with `/**`) with no reasons.

It doesn't work well with tools relying on docstrings comments. Let's use normal comments instead.

I've left the recognition of the old syntax in sknpm for now because there may be some projects out there using them. They should be converted.