### PR TITLE
Do not replicate generic type parameters in static methods

### DIFF
--- a/prelude/src/skstore/DMap.sk
+++ b/prelude/src/skstore/DMap.sk
@@ -142,7 +142,7 @@ base class DMap<Key: Orderable, Value> {
   | Nil() -> 0
   | Node{height} -> height
 
-  static fun empty<Key: Orderable, Value>(): DMap<Key, Value> {
+  static fun empty(): DMap<Key, Value> {
     Nil()
   }
 

--- a/prelude/src/skstore/Handle.sk
+++ b/prelude/src/skstore/Handle.sk
@@ -310,7 +310,7 @@ class LHandle<K: Key, +V: File>(
   type: File ~> V,
   dirName: DirName,
 ) extends Handle<K, V> {
-  static fun create<V: File>(
+  static fun create(
     typeKey: Key ~> K,
     type: File ~> V,
     context: mutable Context,
@@ -355,7 +355,7 @@ class EHandle<K: Key, V: File>(
   type: File ~> V,
   dirName: DirName,
 ) extends Handle<K, V> {
-  static fun multiMap<K, V, K2: Key, V2: File>(
+  static fun multiMap<K2: Key, V2: File>(
     typeOutputKey: Key ~> K2,
     typeOutput: File ~> V2,
     context: mutable Context,
@@ -412,7 +412,7 @@ class EHandle<K: Key, V: File>(
     EHandle(typeOutputKey, typeOutput, dirName)
   }
 
-  static fun multiMapReduce<K, V, K2: Key, V2: File, V3: File>(
+  static fun multiMapReduce<K2: Key, V2: File, V3: File>(
     typeOutputKey: Key ~> K2,
     typeOutput: File ~> V2,
     context: mutable Context,

--- a/prelude/src/stdlib/collections/persistent/List.sk
+++ b/prelude/src/stdlib/collections/persistent/List.sk
@@ -541,7 +541,7 @@ mutable base class .List<+T>
   | Nil() -> init
 
   // reverse map
-  protected static fun mapRev<T, T2>(
+  protected static fun mapRev<T2>(
     f: T -> T2,
     acc: List<T2>,
     list: readonly List<T>,

--- a/prelude/src/stdlib/collections/persistent/SortedMap.sk
+++ b/prelude/src/stdlib/collections/persistent/SortedMap.sk
@@ -879,7 +879,7 @@ private mutable base class SortedMapIterator<+T, +K: Orderable, +V> final (
   }
 
   // Appends the left path of `node` to the tail of the buffer
-  private static fun extend<K: Orderable, V>(
+  private static fun extend(
     nodes: mutable Vector<Node<K, V>>,
     node: SortedMap<K, V>,
   ): void {


### PR DESCRIPTION
It looks like static methods are generic-class-instantiated like instance methods. Hence there is no need to replicate class type parameters. Or am I missing something?

We should probably disallow hiding class type parameters with method type parameters