### PR TITLE
SkJSON/skruntime: make CJArray parametric

### DIFF
--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -677,16 +677,7 @@ export class Utils {
     try {
       let res = fn();
       this.exports.SKIP_destroy_Obstack(obsPos);
-      if (
-        res !== null &&
-        typeof res === "object" &&
-        (("__isArrayProxy" in res && res.__isArrayProxy) ||
-          ("__isObjectProxy" in res && res.__isObjectProxy)) &&
-        "clone" in res
-      ) {
-        const clone = res.clone as () => T;
-        return clone();
-      } else return res;
+      return cloneIfProxy(res);
     } catch (ex) {
       this.exports.SKIP_destroy_Obstack(obsPos);
       throw ex;
@@ -958,4 +949,16 @@ export async function runUrl(
     buffer = await env.fetch(url);
   }
   return await start(modules, buffer, env, main);
+}
+
+export function cloneIfProxy<T>(v: T): T {
+  if (
+    v !== null &&
+    typeof v === "object" &&
+    (("__isArrayProxy" in v && v.__isArrayProxy) ||
+      ("__isObjectProxy" in v && v.__isObjectProxy)) &&
+    "clone" in v
+  )
+    return (v.clone as () => T)();
+  return v;
 }

--- a/prelude/ts/src/sk_types.ts
+++ b/prelude/ts/src/sk_types.ts
@@ -951,12 +951,15 @@ export async function runUrl(
   return await start(modules, buffer, env, main);
 }
 
+export const sk_isArrayProxy: unique symbol = Symbol();
+export const sk_isObjectProxy: unique symbol = Symbol();
+
 export function cloneIfProxy<T>(v: T): T {
   if (
     v !== null &&
     typeof v === "object" &&
-    (("__isArrayProxy" in v && v.__isArrayProxy) ||
-      ("__isObjectProxy" in v && v.__isObjectProxy)) &&
+    ((sk_isArrayProxy in v && v[sk_isArrayProxy]) ||
+      (sk_isObjectProxy in v && v[sk_isObjectProxy])) &&
     "clone" in v
   )
     return (v.clone as () => T)();

--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -527,18 +527,22 @@ fun size(context: mutable Context, handleId: String): Float {
 fun input(
   context: mutable Context,
   name: String,
-  values: SKJSON.CJArray<SKJSON.CJSON>,
+  cjvalues: SKJSON.CJArray<SKJSON.CJArray<SKJSON.CJSON>>,
 ): String {
-  makeInput(
-    JSONID::keyType,
-    JSONFile::type,
-    context,
-    name,
-    SKJSON.expectArray(values).map(v -> {
-      a = SKJSON.expectArray(v);
-      (JSONID(a[0]), JSONFile(a[1]))
-    }),
-  )
+  cjvalues match {
+  | SKJSON.CJArray(values) ->
+    makeInput(
+      JSONID::keyType,
+      JSONFile::type,
+      context,
+      name,
+      values.map(v -> {
+        v match {
+        | SKJSON.CJArray(a) -> (JSONID(a[0]), JSONFile(a[1]))
+        }
+      }),
+    )
+  }
 }
 
 @export("SkipRuntime_lazy")

--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -433,7 +433,7 @@ fun getArray(
   context: mutable Context,
   handleId: String,
   key: SKJSON.CJSON,
-): SKJSON.CJSON {
+): SKJSON.CJArray<SKJSON.CJSON> {
   eager = EHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));
   SKJSON.CJArray(eager.getArray(context, JSONID(key)).map(v -> v.value))
 }
@@ -466,7 +466,7 @@ fun getArrayLazy(
   context: mutable Context,
   handleId: String,
   key: SKJSON.CJSON,
-): SKJSON.CJSON {
+): SKJSON.CJArray<SKJSON.CJSON> {
   lazy = LHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));
   getArraySelf(context, lazy, key)
 }
@@ -495,7 +495,7 @@ fun getArraySelf(
   context: mutable Context,
   handle: LHandle<JSONID, JSONFile>,
   key: SKJSON.CJSON,
-): SKJSON.CJSON {
+): SKJSON.CJArray<SKJSON.CJSON> {
   SKJSON.CJArray(handle.getArray(context, JSONID(key)).map(v -> v.value))
 }
 @export("SkipRuntime_getSelf")

--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -26,7 +26,7 @@ native fun applyMapTableFun(
   fn: UInt32,
   context: mutable Context,
   writer: mutable TWriter<JSONID, JSONFile>,
-  key: SKJSON.CJArray,
+  key: SKJSON.CJArray<SKJSON.CJSON>,
   occ: Float,
 ): void;
 
@@ -100,7 +100,7 @@ fun writerSet(
 fun writerSetArray(
   writer: mutable TWriter<JSONID, JSONFile>,
   key: SKJSON.CJSON,
-  values: SKJSON.CJArray,
+  values: SKJSON.CJArray<SKJSON.CJSON>,
 ): void {
   files = values match {
   | SKJSON.CJArray(xs) -> xs.map(x -> JSONFile(x))
@@ -259,7 +259,7 @@ fun mapReduce(
 fun multimap(
   context: mutable Context,
   name: String,
-  mappings: SKJSON.CJArray,
+  mappings: SKJSON.CJArray<SKJSON.CJSON>,
 ): String {
   skmappings = mappings match {
   | SKJSON.CJArray(v) ->
@@ -286,7 +286,7 @@ fun multimap(
 fun multimapReduce(
   context: mutable Context,
   name: String,
-  mappings: SKJSON.CJArray,
+  mappings: SKJSON.CJArray<SKJSON.CJSON>,
   accumulator: UInt32,
   default: SKJSON.CJSON,
 ): String {
@@ -523,7 +523,7 @@ fun size(context: mutable Context, handleId: String): Float {
 fun input(
   context: mutable Context,
   name: String,
-  values: SKJSON.CJArray,
+  values: SKJSON.CJArray<SKJSON.CJSON>,
 ): String {
   makeInput(
     JSONID::keyType,

--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -259,22 +259,24 @@ fun mapReduce(
 fun multimap(
   context: mutable Context,
   name: String,
-  mappings: SKJSON.CJArray<SKJSON.CJSON>,
+  mappings: SKJSON.CJArray<SKJSON.CJArray<SKJSON.CJSON>>,
 ): String {
   skmappings = mappings match {
   | SKJSON.CJArray(v) ->
     v.map(e -> {
-      mapping = SKJSON.expectArray(e);
-      handleId = SKJSON.asString(mapping[0]);
-      eager = EHandle(
-        JSONID::keyType,
-        JSONFile::type,
-        DirName::create(handleId),
-      );
-      mapHandle = FnHandle::make(
-        UInt32::truncate(SKJSON.asFloat(mapping[1]).toInt()),
-      );
-      return (eager, mapHandle.map)
+      e match {
+      | SKJSON.CJArray(mapping) ->
+        handleId = SKJSON.asString(mapping[0]);
+        eager = EHandle(
+          JSONID::keyType,
+          JSONFile::type,
+          DirName::create(handleId),
+        );
+        mapHandle = FnHandle::make(
+          UInt32::truncate(SKJSON.asFloat(mapping[1]).toInt()),
+        );
+        return (eager, mapHandle.map)
+      }
     })
   };
   eagerMultiMap(JSONID::keyType, JSONFile::type, name, context, skmappings)
@@ -286,7 +288,7 @@ fun multimap(
 fun multimapReduce(
   context: mutable Context,
   name: String,
-  mappings: SKJSON.CJArray<SKJSON.CJSON>,
+  mappings: SKJSON.CJArray<SKJSON.CJArray<SKJSON.CJSON>>,
   accumulator: UInt32,
   default: SKJSON.CJSON,
 ): String {
@@ -294,17 +296,19 @@ fun multimapReduce(
   skmappings = mappings match {
   | SKJSON.CJArray(v) ->
     v.map(e -> {
-      mapping = SKJSON.expectArray(e);
-      handleId = SKJSON.asString(mapping[0]);
-      eager = EHandle(
-        JSONID::keyType,
-        JSONFile::type,
-        DirName::create(handleId),
-      );
-      mapHandle = FnHandle::make(
-        UInt32::truncate(SKJSON.asFloat(mapping[1]).toInt()),
-      );
-      return (eager, mapHandle.map)
+      e match {
+      | SKJSON.CJArray(mapping) ->
+        handleId = SKJSON.asString(mapping[0]);
+        eager = EHandle(
+          JSONID::keyType,
+          JSONFile::type,
+          DirName::create(handleId),
+        );
+        mapHandle = FnHandle::make(
+          UInt32::truncate(SKJSON.asFloat(mapping[1]).toInt()),
+        );
+        return (eager, mapHandle.map)
+      }
     })
   };
   eagerMultiMapReduce(

--- a/skipruntime-ts/src/JSON.sk
+++ b/skipruntime-ts/src/JSON.sk
@@ -55,7 +55,7 @@ fun asString(json: CJSON): String {
 }
 
 @export("SKIP_SKJSON_asArray")
-fun asArray(json: CJSON): CJArray {
+fun asArray(json: CJSON): CJArray<CJSON> {
   json match {
   | v @ CJArray _ -> v
   | _ -> invariant_violation("Must be a Array value.")
@@ -109,14 +109,14 @@ fun objectSize(object: CJObject): Float {
 }
 
 @export("SKIP_SKJSON_at")
-fun at(array: CJArray, idx: Float): ?CJSON {
+fun at(array: CJArray<CJSON>, idx: Float): ?CJSON {
   array match {
   | CJArray(values) -> values.maybeGet(idx.toInt())
   }
 }
 
 @export("SKIP_SKJSON_arraySize")
-fun arraySize(array: CJArray): Float {
+fun arraySize(array: CJArray<CJSON>): Float {
   array match {
   | CJArray(values) -> values.size().toFloat()
   }
@@ -153,7 +153,7 @@ fun addToCJArray(array: mutable Vector<CJSON>, value: CJSON): void {
 }
 
 @export("SKIP_SKJSON_endCJArray")
-fun endCJArray(array: mutable Vector<CJSON>): CJArray {
+fun endCJArray(array: mutable Vector<CJSON>): CJArray<CJSON> {
   CJArray(array.toArray())
 }
 

--- a/skipruntime-ts/src/Skdb.sk
+++ b/skipruntime-ts/src/Skdb.sk
@@ -163,7 +163,7 @@ fun convertValue(v: SKJSON.CJSON, ty: P.Type): ?SKDB.CValue {
   };
 }
 
-fun toCJArray(row: SKDB.RowValues): SKJSON.CJArray {
+fun toCJArray(row: SKDB.RowValues): SKJSON.CJArray<SKJSON.CJSON> {
   SKJSON.CJArray(
     row.values.map(cell ->
       cell match {

--- a/skipruntime-ts/ts/src/eslint.config.js
+++ b/skipruntime-ts/ts/src/eslint.config.js
@@ -11,6 +11,9 @@ export default tseslint.config(
   ...tseslint.configs.strictTypeChecked,
   ...tseslint.configs.stylisticTypeChecked,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: "error",
+    },
     languageOptions: {
       parserOptions: {
         projectService: true,

--- a/skipruntime-ts/ts/src/eslint.config.js
+++ b/skipruntime-ts/ts/src/eslint.config.js
@@ -60,6 +60,7 @@ export default tseslint.config(
       "@typescript-eslint/restrict-template-expressions": "warn",
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
       "@typescript-eslint/no-unnecessary-condition": "error",
+      "@typescript-eslint/no-unnecessary-type-arguments": "warn",
       "@typescript-eslint/no-unnecessary-type-parameters": "warn",
       "@typescript-eslint/no-non-null-assertion": "warn",
       "@typescript-eslint/no-empty-object-type": [

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -1,5 +1,5 @@
 // prettier-ignore
-import { type ptr, type Opt } from "#std/sk_types.js";
+import { type ptr, type Opt, cloneIfProxy } from "#std/sk_types.js";
 import type { Context } from "./skipruntime_types.js";
 import type * as Internal from "./skstore_internal_types.js";
 import type {
@@ -450,17 +450,7 @@ export class SKStoreImpl implements SKStore {
   }
 
   log(object: any): void {
-    if (
-      typeof object == "object" &&
-      (("__isArrayProxy" in object && object.__isArrayProxy) ||
-        ("__isObjectProxy" in object && object.__isObjectProxy)) &&
-      "clone" in object
-    ) {
-      /* eslint-disable-next-line @typescript-eslint/no-unsafe-call */
-      console.log(object.clone());
-    } else {
-      console.log(object);
-    }
+    console.log(cloneIfProxy(object));
   }
 }
 

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -1,5 +1,5 @@
 // prettier-ignore
-import type { int, ptr, Links, Utils, ToWasmManager, Environment, Opt, Metadata } from "#std/sk_types.js";
+import type { int, ptr, Links, Utils, ToWasmManager, Environment, Opt, Metadata, ErrorObject } from "#std/sk_types.js";
 import type { SKJSON } from "./skjson.js";
 import type {
   Accumulator,
@@ -11,6 +11,7 @@ import type {
 } from "../skipruntime_api.js";
 
 import type {
+  Handle,
   Handles,
   Context,
   FromWasm,
@@ -31,25 +32,24 @@ class HandlesImpl implements Handles {
     this.env = env;
   }
 
-  register(v: any) {
+  register<T>(v: T): Handle<T> {
     const freeID = this.freeIDs.pop();
     const id = freeID ?? this.nextID++;
     this.objects[id] = v;
-    return id;
+    return id as Handle<T>;
   }
 
-  get(id: int): any {
-    return this.objects[id];
+  get<T>(id: Handle<T>): T {
+    return this.objects[id] as T;
   }
 
-  apply<R, P extends any[] = any[]>(id: int, parameters: P): R {
-    const fn = this.objects[id];
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+  apply<R, P extends any[]>(id: Handle<(..._: P) => R>, parameters: P): R {
+    const fn = this.get(id);
     return fn.apply(null, parameters);
   }
 
-  delete(id: int): any {
-    const current: unknown = this.objects[id];
+  delete<T>(id: Handle<T>): T {
+    const current = this.get(id);
     this.objects[id] = null;
     this.freeIDs.push(id);
     return current;
@@ -417,41 +417,59 @@ class WriterImpl<K, T> {
 }
 
 interface ToWasm {
-  SKIP_SKStore_detachHandle(fn: int): void;
+  SKIP_SKStore_detachHandle<T>(fn: Handle<T>): void;
   // Context
-  SKIP_SKStore_applyMapFun(
-    fn: int,
+  SKIP_SKStore_applyMapFun<
+    K extends TJSON,
+    V extends TJSON,
+    K2 extends TJSON,
+    V2 extends TJSON,
+  >(
+    fn: Handle<(key: K, it: NonEmptyIterator<V>) => Iterable<[K2, V2]>>,
     context: ptr<Internal.Context>,
     writer: ptr<Internal.TWriter>,
     key: ptr<Internal.CJSON>,
     it: ptr<Internal.NonEmptyIterator>,
   ): void;
-  SKIP_SKStore_applyMapTableFun(
-    fn: int,
+  SKIP_SKStore_applyMapTableFun<
+    R extends TJSON,
+    K extends TJSON,
+    V extends TJSON,
+  >(
+    fn: Handle<(row: R, occ: number) => Iterable<[K, V]>>,
     context: ptr<Internal.Context>,
     writer: ptr<Internal.TWriter>,
     row: ptr<Internal.CJArray>,
     occ: int,
   ): void;
-  SKIP_SKStore_applyConvertToRowFun(
-    fn: int,
+  SKIP_SKStore_applyConvertToRowFun<
+    R extends TJSON,
+    K extends TJSON,
+    V extends TJSON,
+  >(
+    fn: Handle<(key: K, it: NonEmptyIterator<V>) => R>,
     key: ptr<Internal.CJSON>,
     it: ptr<Internal.NonEmptyIterator>,
   ): ptr<Internal.CJSON>;
   SKIP_SKStore_init(context: ptr<Internal.Context>): void;
-  SKIP_SKStore_applyLazyFun(
-    fn: int,
+  SKIP_SKStore_applyLazyFun<K extends TJSON, V extends TJSON>(
+    fn: Handle<(selfHdl: LazyCollection<K, V>, key: K) => Opt<V>>,
     context: ptr<Internal.Context>,
     self: ptr<Internal.LHandle>,
     key: ptr<Internal.CJSON>,
   ): ptr<Internal.CJSON>;
-  SKIP_SKStore_applyParamsFun(
-    fn: int,
+  SKIP_SKStore_applyParamsFun<K extends TJSON, P extends TJSON>(
+    fn: Handle<(key: K) => P>,
     context: ptr<Internal.Context>,
     key: ptr<Internal.CJSON>,
   ): ptr<Internal.CJSON>;
-  SKIP_SKStore_applyLazyAsyncFun(
-    fn: int,
+  SKIP_SKStore_applyLazyAsyncFun<
+    K extends TJSON,
+    V extends TJSON,
+    P extends TJSON,
+    M extends TJSON,
+  >(
+    fn: Handle<(key: K, params: P) => Promise<AValue<V, M>>>,
     callId: ptr<Internal.String>,
     name: ptr<Internal.String>,
     key: ptr<Internal.CJSON>,
@@ -459,18 +477,18 @@ interface ToWasm {
   ): void;
 
   // Accumulator
-  SKIP_SKStore_applyAccumulate(
-    fn: int,
+  SKIP_SKStore_applyAccumulate<T extends TJSON, V extends TJSON>(
+    fn: Handle<Accumulator<T, V>>,
     acc: ptr<Internal.CJSON>,
     value: ptr<Internal.CJSON>,
   ): ptr<Internal.CJSON>;
-  SKIP_SKStore_applyDismiss(
-    fn: int,
+  SKIP_SKStore_applyDismiss<T extends TJSON, V extends TJSON>(
+    fn: Handle<Accumulator<T, V>>,
     acc: ptr<Internal.CJSON>,
     value: ptr<Internal.CJSON>,
   ): Opt<ptr<Internal.CJSON>>;
   // Utils
-  SKIP_SKStore_getErrorHdl(exn: ptr<Internal.Exception>): number;
+  SKIP_SKStore_getErrorHdl(exn: ptr<Internal.Exception>): Handle<ErrorObject>;
 }
 
 class Ref {
@@ -495,54 +513,64 @@ class LinksImpl implements Links {
   handles: Handles;
   skjson?: SKJSON;
 
-  detachHandle!: (fn: int) => void;
-  applyMapFun!: (
-    fn: int,
+  detachHandle!: <T>(fn: Handle<T>) => void;
+  applyMapFun!: <
+    K extends TJSON,
+    V extends TJSON,
+    K2 extends TJSON,
+    V2 extends TJSON,
+  >(
+    fn: Handle<(key: K, it: NonEmptyIterator<V>) => Iterable<[K2, V2]>>,
     context: ptr<Internal.Context>,
     writer: ptr<Internal.TWriter>,
     key: ptr<Internal.CJSON>,
     it: ptr<Internal.NonEmptyIterator>,
   ) => void;
-  applyMapTableFun!: (
-    fn: int,
+  applyMapTableFun!: <R extends TJSON, K extends TJSON, V extends TJSON>(
+    fn: Handle<(row: R, occ: number) => Iterable<[K, V]>>,
     context: ptr<Internal.Context>,
     writer: ptr<Internal.TWriter>,
     row: ptr<Internal.CJArray>,
     occ: int,
   ) => void;
 
-  applyLazyFun!: (
-    fn: int,
+  applyLazyFun!: <K extends TJSON, V extends TJSON>(
+    fn: Handle<(selfHdl: LazyCollection<K, V>, key: K) => Opt<V>>,
     context: ptr<Internal.Context>,
     self: ptr<Internal.LHandle>,
     key: ptr<Internal.CJSON>,
   ) => ptr<Internal.CJSON>;
-  applyParamsFun!: (
-    fn: int,
+  applyParamsFun!: <K extends TJSON, P extends TJSON>(
+    fn: Handle<(key: K) => P>,
     context: ptr<Internal.Context>,
     key: ptr<Internal.CJSON>,
   ) => ptr<Internal.CJSON>;
-  applyLazyAsyncFun!: (
-    fn: int,
+  applyLazyAsyncFun!: <
+    K extends TJSON,
+    V extends TJSON,
+    P extends TJSON,
+    M extends TJSON,
+  >(
+    fn: Handle<(key: K, params: P) => Promise<AValue<V, M>>>,
     callId: ptr<Internal.String>,
     name: ptr<Internal.String>,
     key: ptr<Internal.CJSON>,
     param: ptr<Internal.CJSON>,
   ) => void;
   init!: (context: ptr<Internal.Context>) => void;
-  applyAccumulate!: (
-    fn: int,
+  applyAccumulate!: <T extends TJSON, V extends TJSON>(
+    fn: Handle<Accumulator<T, V>>,
     acc: ptr<Internal.CJSON>,
     value: ptr<Internal.CJSON>,
   ) => ptr<Internal.CJSON>;
-  applyDismiss!: (
-    fn: int,
+  applyDismiss!: <T extends TJSON, V extends TJSON>(
+    fn: Handle<Accumulator<T, V>>,
     acc: ptr<Internal.CJSON>,
     value: ptr<Internal.CJSON>,
   ) => Opt<ptr<Internal.CJSON>>;
-  getErrorHdl!: (exn: ptr<Internal.Exception>) => number;
-  applyConvertToRowFun!: (
-    fn: int,
+  getErrorHdl!: (exn: ptr<Internal.Exception>) => Handle<ErrorObject>;
+  applyConvertToRowFun!: <R extends TJSON, K extends TJSON, V extends TJSON>(
+    fn: Handle<(key: K, it: NonEmptyIterator<V>) => R>,
     key: ptr<Internal.CJSON>,
     it: ptr<Internal.NonEmptyIterator>,
   ) => ptr<Internal.CJSON>;
@@ -564,8 +592,13 @@ class LinksImpl implements Links {
       return this.skjson;
     };
     const ref = new Ref();
-    this.applyMapFun = (
-      fn: int,
+    this.applyMapFun = <
+      K1 extends TJSON,
+      V1 extends TJSON,
+      K2 extends TJSON,
+      V2 extends TJSON,
+    >(
+      fn: Handle<(key: K1, it: NonEmptyIterator<V1>) => Iterable<[K2, V2]>>,
       ctx: ptr<Internal.Context>,
       writer: ptr<Internal.TWriter>,
       key: ptr<Internal.CJSON>,
@@ -574,26 +607,28 @@ class LinksImpl implements Links {
       ref.push(ctx);
       const jsu = skjson();
       const w = new WriterImpl(jsu, fromWasm, writer);
-      const result = this.handles.apply<any>(fn, [
+      const result = this.handles.apply(fn, [
         jsu.importJSON(key),
-        new NonEmptyIteratorImpl(jsu, fromWasm, it),
+        new NonEmptyIteratorImpl<V1>(jsu, fromWasm, it),
       ]);
-      const bindings = new Map();
+      const bindings = new Map<K2, V2[]>();
       for (const datum of result) {
         const k = datum[0];
         const v = datum[1];
-        /* eslint-disable-next-line @typescript-eslint/no-unsafe-call */
-        if (bindings.has(k)) bindings.get(k).push(v);
-        else bindings.set(k, [v]);
+        const at_k = bindings.get(k);
+        if (at_k !== undefined) {
+          at_k.push(v);
+        } else {
+          bindings.set(k, [v]);
+        }
       }
       for (const kv of bindings) {
-        /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
         w.setArray(kv[0], kv[1]);
       }
       ref.pop();
     };
-    this.applyMapTableFun = (
-      fn: int,
+    this.applyMapTableFun = <R extends TJSON, K extends TJSON, V extends TJSON>(
+      fn: Handle<(row: R, occ: number) => Iterable<[K, V]>>,
       ctx: ptr<Internal.Context>,
       writer: ptr<Internal.TWriter>,
       row: ptr<Internal.CJArray>,
@@ -602,29 +637,37 @@ class LinksImpl implements Links {
       ref.push(ctx);
       const jsu = skjson();
       const w = new WriterImpl(jsu, fromWasm, writer);
-      const result = this.handles.apply<any>(fn, [jsu.importJSON(row), occ]);
-      for (const v of result) {
-        const t = v as [any, any];
+      const result = this.handles.apply(fn, [jsu.importJSON(row), occ]);
+      for (const t of result) {
         w.set(t[0], t[1]);
       }
       ref.pop();
     };
 
-    this.applyConvertToRowFun = (
-      fn: int,
+    this.applyConvertToRowFun = <
+      R extends TJSON,
+      K extends TJSON,
+      V extends TJSON,
+    >(
+      fn: Handle<(key: K, it: NonEmptyIterator<V>) => R>,
       key: ptr<Internal.CJSON>,
       it: ptr<Internal.NonEmptyIterator>,
     ) => {
       const jsu = skjson();
       const res = this.handles.apply(fn, [
         jsu.importJSON(key),
-        new NonEmptyIteratorImpl(jsu, fromWasm, it),
+        new NonEmptyIteratorImpl<V>(jsu, fromWasm, it),
       ]);
       return jsu.exportJSON(res);
     };
 
-    this.applyLazyAsyncFun = (
-      fn: int,
+    this.applyLazyAsyncFun = <
+      K extends TJSON,
+      V extends TJSON,
+      P extends TJSON,
+      M extends TJSON,
+    >(
+      fn: Handle<(key: K, params: P) => Promise<AValue<V, M>>>,
       skcall: ptr<Internal.String>,
       skname: ptr<Internal.String>,
       skkey: ptr<Internal.CJSON>,
@@ -635,10 +678,7 @@ class LinksImpl implements Links {
       const name = jsu.importString(skname);
       const key = jsu.importJSON(skkey, true);
       const params = jsu.importJSON(skparams, true);
-      const promise = this.handles.apply<Promise<AValue<TJSON, TJSON>>>(fn, [
-        key,
-        params,
-      ]);
+      const promise = this.handles.apply(fn, [key, params]);
       const register = (value: Result<TJSON, TJSON>) => {
         if (!notify) {
           const skdbApp = this.env.shared.get("SKDB") as SKDBShared;
@@ -657,7 +697,7 @@ class LinksImpl implements Links {
             );
           });
           if (result < 0) {
-            throw this.handles.delete(-result);
+            throw this.handles.delete(-result as Handle<unknown>);
           } else if (notify) {
             notify();
           }
@@ -704,8 +744,8 @@ class LinksImpl implements Links {
         });
     };
 
-    this.applyLazyFun = (
-      fn: int,
+    this.applyLazyFun = <K extends TJSON, V extends TJSON>(
+      fn: Handle<(selfHdl: LazyCollection<K, V>, key: K) => Opt<V>>,
       ctx: ptr<Internal.Context>,
       hdl: ptr<Internal.LHandle>,
       key: ptr<Internal.CJSON>,
@@ -715,7 +755,7 @@ class LinksImpl implements Links {
       const context = new ContextImpl(jsu, fromWasm, this.handles, ref);
       const res = jsu.exportJSON(
         this.handles.apply(fn, [
-          new LSelfImpl(context, hdl),
+          new LSelfImpl(context, hdl) as LazyCollection<K, V>,
           jsu.importJSON(key),
         ]),
       );
@@ -723,8 +763,8 @@ class LinksImpl implements Links {
       return res;
     };
 
-    this.applyParamsFun = (
-      fn: int,
+    this.applyParamsFun = <K extends TJSON, P extends TJSON>(
+      fn: Handle<(key: K) => P>,
       ctx: ptr<Internal.Context>,
       key: ptr<Internal.CJSON>,
     ) => {
@@ -739,33 +779,33 @@ class LinksImpl implements Links {
       this.initFn();
       ref.pop();
     };
-    this.applyAccumulate = (
-      fn: int,
+    this.applyAccumulate = <T extends TJSON, V extends TJSON>(
+      fn: Handle<Accumulator<T, V>>,
       acc: ptr<Internal.CJSON>,
       value: ptr<Internal.CJSON>,
     ) => {
       const jsu = skjson();
-      const accumulator = this.handles.get(fn) as Accumulator<any, any>;
+      const accumulator = this.handles.get(fn);
       const result = accumulator.accumulate(
-        jsu.importJSON(acc),
-        jsu.importJSON(value),
+        jsu.importJSON(acc) as Opt<V>,
+        jsu.importJSON(value) as T,
       );
       return jsu.exportJSON(result);
     };
-    this.applyDismiss = (
-      fn: int,
+    this.applyDismiss = <T extends TJSON, V extends TJSON>(
+      fn: Handle<Accumulator<T, V>>,
       acc: ptr<Internal.CJSON>,
       value: ptr<Internal.CJSON>,
     ) => {
       const jsu = skjson();
-      const accumulator = this.handles.get(fn) as Accumulator<any, any>;
+      const accumulator = this.handles.get(fn);
       const result = accumulator.dismiss(
-        jsu.importJSON(acc),
-        jsu.importJSON(value),
+        jsu.importJSON(acc) as V,
+        jsu.importJSON(value) as T,
       );
       return result != null ? jsu.exportJSON(result) : null;
     };
-    this.detachHandle = (idx: int) => {
+    this.detachHandle = <T>(idx: Handle<T>) => {
       this.handles.delete(idx);
     };
     this.getErrorHdl = (exn: ptr<Internal.Exception>) => {
@@ -781,7 +821,7 @@ class LinksImpl implements Links {
         Math.trunc(fromWasm.SkipRuntime_createFor(jsu.exportString(uuid))),
       );
       if (result < 0) {
-        throw this.handles.delete(-result);
+        throw this.handles.delete(-result as Handle<unknown>);
       }
     };
     this.env.shared.set(
@@ -809,11 +849,16 @@ class Manager implements ToWasmManager {
   prepare = (wasm: object) => {
     const toWasm = wasm as ToWasm;
     const links = new LinksImpl(this.env);
-    toWasm.SKIP_SKStore_detachHandle = (fn: int) => {
+    toWasm.SKIP_SKStore_detachHandle = <T>(fn: Handle<T>) => {
       links.detachHandle(fn);
     };
-    toWasm.SKIP_SKStore_applyMapFun = (
-      fn: int,
+    toWasm.SKIP_SKStore_applyMapFun = <
+      K extends TJSON,
+      V extends TJSON,
+      K2 extends TJSON,
+      V2 extends TJSON,
+    >(
+      fn: Handle<(key: K, it: NonEmptyIterator<V>) => Iterable<[K2, V2]>>,
       context: ptr<Internal.Context>,
       writer: ptr<Internal.TWriter>,
       key: ptr<Internal.CJSON>,
@@ -821,8 +866,12 @@ class Manager implements ToWasmManager {
     ) => {
       links.applyMapFun(fn, context, writer, key, it);
     };
-    toWasm.SKIP_SKStore_applyMapTableFun = (
-      fn: int,
+    toWasm.SKIP_SKStore_applyMapTableFun = <
+      R extends TJSON,
+      K extends TJSON,
+      V extends TJSON,
+    >(
+      fn: Handle<(row: R, occ: number) => Iterable<[K, V]>>,
       context: ptr<Internal.Context>,
       writer: ptr<Internal.TWriter>,
       row: ptr<Internal.CJArray>,
@@ -830,21 +879,37 @@ class Manager implements ToWasmManager {
     ) => {
       links.applyMapTableFun(fn, context, writer, row, occ);
     };
-    toWasm.SKIP_SKStore_applyConvertToRowFun = (
-      fn: int,
+    toWasm.SKIP_SKStore_applyConvertToRowFun = <
+      R extends TJSON,
+      K extends TJSON,
+      V extends TJSON,
+    >(
+      fn: Handle<(key: K, it: NonEmptyIterator<V>) => R>,
       key: ptr<Internal.CJSON>,
       it: ptr<Internal.NonEmptyIterator>,
     ) => links.applyConvertToRowFun(fn, key, it);
     toWasm.SKIP_SKStore_init = (context: ptr<Internal.Context>) => {
       links.init(context);
     };
-    toWasm.SKIP_SKStore_applyLazyFun = (fn, context, self, key) =>
-      links.applyLazyFun(fn, context, self, key);
+    toWasm.SKIP_SKStore_applyLazyFun = <K extends TJSON, V extends TJSON>(
+      fn: Handle<(selfHdl: LazyCollection<K, V>, key: K) => Opt<V>>,
+      context: ptr<Internal.Context>,
+      self: ptr<Internal.LHandle>,
+      key: ptr<Internal.CJSON>,
+    ) => links.applyLazyFun(fn, context, self, key);
 
-    toWasm.SKIP_SKStore_applyParamsFun = (fn, context, key) =>
-      links.applyParamsFun(fn, context, key);
-    toWasm.SKIP_SKStore_applyLazyAsyncFun = (
-      fn: int,
+    toWasm.SKIP_SKStore_applyParamsFun = <K extends TJSON, P extends TJSON>(
+      fn: Handle<(key: K) => P>,
+      context: ptr<Internal.Context>,
+      key: ptr<Internal.CJSON>,
+    ) => links.applyParamsFun(fn, context, key);
+    toWasm.SKIP_SKStore_applyLazyAsyncFun = <
+      K extends TJSON,
+      V extends TJSON,
+      P extends TJSON,
+      M extends TJSON,
+    >(
+      fn: Handle<(key: K, params: P) => Promise<AValue<V, M>>>,
       call: ptr<Internal.String>,
       name: ptr<Internal.String>,
       key: ptr<Internal.CJSON>,
@@ -852,13 +917,13 @@ class Manager implements ToWasmManager {
     ) => {
       links.applyLazyAsyncFun(fn, call, name, key, param);
     };
-    toWasm.SKIP_SKStore_applyAccumulate = (
-      fn: int,
+    toWasm.SKIP_SKStore_applyAccumulate = <T extends TJSON, V extends TJSON>(
+      fn: Handle<Accumulator<T, V>>,
       acc: ptr<Internal.CJSON>,
       value: ptr<Internal.CJSON>,
     ) => links.applyAccumulate(fn, acc, value);
-    toWasm.SKIP_SKStore_applyDismiss = (
-      fn: int,
+    toWasm.SKIP_SKStore_applyDismiss = <T extends TJSON, V extends TJSON>(
+      fn: Handle<Accumulator<T, V>>,
       acc: ptr<Internal.CJSON>,
       value: ptr<Internal.CJSON>,
     ) => links.applyDismiss(fn, acc, value);

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -31,7 +31,7 @@ class HandlesImpl implements Handles {
     this.env = env;
   }
 
-  register(v: JSON) {
+  register(v: any) {
     const freeID = this.freeIDs.pop();
     const id = freeID ?? this.nextID++;
     this.objects[id] = v;

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -1,6 +1,6 @@
 // prettier-ignore
 import type { int, ptr, Links, Utils, ToWasmManager, Environment, Opt, Metadata, ErrorObject } from "#std/sk_types.js";
-import type { SKJSON } from "./skjson.js";
+import type { SKJSON, Exportable } from "./skjson.js";
 import type {
   Accumulator,
   NonEmptyIterator,
@@ -152,7 +152,11 @@ export class ContextImpl implements Context {
     return this.skjson.importString(resHdlPtr);
   };
 
-  getFromTable = <K, R>(table: string, key: K, index?: string) => {
+  getFromTable = <K extends TJSON, R>(
+    table: string,
+    key: K,
+    index?: string,
+  ) => {
     return this.skjson.importJSON(
       this.exports.SkipRuntime_getFromTable(
         this.pointer(),
@@ -163,7 +167,7 @@ export class ContextImpl implements Context {
     ) as R[];
   };
 
-  getArray = <K, V>(eagerHdl: string, key: K) => {
+  getArray = <K extends TJSON, V>(eagerHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SkipRuntime_getArray(
         this.pointer(),
@@ -173,7 +177,7 @@ export class ContextImpl implements Context {
     ) as V[];
   };
 
-  getOne = <K, V>(eagerHdl: string, key: K) => {
+  getOne = <K extends TJSON, V>(eagerHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SkipRuntime_get(
         this.pointer(),
@@ -183,7 +187,7 @@ export class ContextImpl implements Context {
     ) as V;
   };
 
-  maybeGetOne = <K, V>(eagerHdl: string, key: K) => {
+  maybeGetOne = <K extends TJSON, V>(eagerHdl: string, key: K) => {
     const res = this.exports.SkipRuntime_maybeGet(
       this.pointer(),
       this.skjson.exportString(eagerHdl),
@@ -192,7 +196,7 @@ export class ContextImpl implements Context {
     return this.skjson.importJSON(res) as Opt<V>;
   };
 
-  getArrayLazy = <K, V>(lazyHdl: string, key: K) => {
+  getArrayLazy = <K extends TJSON, V>(lazyHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SkipRuntime_getArrayLazy(
         this.pointer(),
@@ -202,7 +206,7 @@ export class ContextImpl implements Context {
     ) as V[];
   };
 
-  getOneLazy = <K, V>(lazyHdl: string, key: K) => {
+  getOneLazy = <K extends TJSON, V>(lazyHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SkipRuntime_getLazy(
         this.pointer(),
@@ -212,7 +216,7 @@ export class ContextImpl implements Context {
     ) as V;
   };
 
-  maybeGetOneLazy = <K, V>(lazyHdl: string, key: K) => {
+  maybeGetOneLazy = <K extends TJSON, V>(lazyHdl: string, key: K) => {
     return this.skjson.importJSON(
       this.exports.SkipRuntime_maybeGetLazy(
         this.pointer(),
@@ -222,7 +226,10 @@ export class ContextImpl implements Context {
     ) as Opt<V>;
   };
 
-  getArraySelf = <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => {
+  getArraySelf = <K extends TJSON, V>(
+    lazyHdl: ptr<Internal.LHandle>,
+    key: K,
+  ) => {
     return this.skjson.importJSON(
       this.exports.SkipRuntime_getArraySelf(
         this.pointer(),
@@ -231,7 +238,7 @@ export class ContextImpl implements Context {
       ),
     ) as V[];
   };
-  getOneSelf = <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => {
+  getOneSelf = <K extends TJSON, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => {
     return this.skjson.importJSON(
       this.exports.SkipRuntime_getSelf(
         this.pointer(),
@@ -240,7 +247,10 @@ export class ContextImpl implements Context {
       ),
     ) as V;
   };
-  maybeGetOneSelf = <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => {
+  maybeGetOneSelf = <K extends TJSON, V>(
+    lazyHdl: ptr<Internal.LHandle>,
+    key: K,
+  ) => {
     return this.skjson.importJSON(
       this.exports.SkipRuntime_maybeGetSelf(
         this.pointer(),
@@ -382,7 +392,7 @@ class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
   }
 }
 
-class WriterImpl<K, T> {
+class WriterImpl<K extends TJSON, T extends TJSON> {
   private skjson: SKJSON;
   private exports: FromWasm;
   private pointer: ptr<Internal.TWriter>;
@@ -655,7 +665,7 @@ class LinksImpl implements Links {
         jsu.importJSON(key) as K,
         new NonEmptyIteratorImpl<V>(jsu, fromWasm, it),
       ]);
-      return jsu.exportJSON(res);
+      return jsu.exportJSON(res as Exportable);
     };
 
     this.applyLazyAsyncFun = <

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -1,6 +1,6 @@
 // prettier-ignore
 import type { int, ptr, Links, Utils, ToWasmManager, Environment, Opt, Metadata, ErrorObject } from "#std/sk_types.js";
-import type { SKJSON, Exportable } from "./skjson.js";
+import type { SKJSON } from "./skjson.js";
 import type {
   Accumulator,
   NonEmptyIterator,
@@ -665,7 +665,7 @@ class LinksImpl implements Links {
         jsu.importJSON(key) as K,
         new NonEmptyIteratorImpl<V>(jsu, fromWasm, it),
       ]);
-      return jsu.exportJSON(res as Exportable);
+      return jsu.exportJSON(res);
     };
 
     this.applyLazyAsyncFun = <

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -42,7 +42,7 @@ class HandlesImpl implements Handles {
     return this.objects[id];
   }
 
-  apply<T>(id: int, parameters: T[]): T {
+  apply<R, P extends any[] = any[]>(id: int, parameters: P): R {
     const fn = this.objects[id];
     /* eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
     return fn.apply(null, parameters);
@@ -574,7 +574,7 @@ class LinksImpl implements Links {
       ref.push(ctx);
       const jsu = skjson();
       const w = new WriterImpl(jsu, fromWasm, writer);
-      const result = this.handles.apply(fn, [
+      const result = this.handles.apply<any>(fn, [
         jsu.importJSON(key),
         new NonEmptyIteratorImpl(jsu, fromWasm, it),
       ]);
@@ -602,7 +602,7 @@ class LinksImpl implements Links {
       ref.push(ctx);
       const jsu = skjson();
       const w = new WriterImpl(jsu, fromWasm, writer);
-      const result = this.handles.apply(fn, [jsu.importJSON(row), occ]);
+      const result = this.handles.apply<any>(fn, [jsu.importJSON(row), occ]);
       for (const v of result) {
         const t = v as [any, any];
         w.set(t[0], t[1]);
@@ -635,7 +635,6 @@ class LinksImpl implements Links {
       const name = jsu.importString(skname);
       const key = jsu.importJSON(skkey, true);
       const params = jsu.importJSON(skparams, true);
-      /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
       const promise = this.handles.apply<Promise<AValue<TJSON, TJSON>>>(fn, [
         key,
         params,

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -345,24 +345,21 @@ class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
   }
 
   next(): Opt<T> {
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-return */
     return this.skjson.importOptJSON(
       this.exports.SkipRuntime_iteratorNext(this.pointer),
-    );
+    ) as Opt<T>;
   }
 
   first(): T {
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-return */
     return this.skjson.importJSON(
       this.exports.SkipRuntime_iteratorFirst(this.pointer),
-    );
+    ) as T;
   }
 
   uniqueValue(): Opt<T> {
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-return */
     return this.skjson.importOptJSON(
       this.exports.SkipRuntime_iteratorUniqueValue(this.pointer),
-    );
+    ) as Opt<T>;
   }
 
   toArray: () => T[] = () => {
@@ -608,7 +605,7 @@ class LinksImpl implements Links {
       const jsu = skjson();
       const w = new WriterImpl(jsu, fromWasm, writer);
       const result = this.handles.apply(fn, [
-        jsu.importJSON(key),
+        jsu.importJSON(key) as K1,
         new NonEmptyIteratorImpl<V1>(jsu, fromWasm, it),
       ]);
       const bindings = new Map<K2, V2[]>();
@@ -637,7 +634,7 @@ class LinksImpl implements Links {
       ref.push(ctx);
       const jsu = skjson();
       const w = new WriterImpl(jsu, fromWasm, writer);
-      const result = this.handles.apply(fn, [jsu.importJSON(row), occ]);
+      const result = this.handles.apply(fn, [jsu.importJSON(row) as R, occ]);
       for (const t of result) {
         w.set(t[0], t[1]);
       }
@@ -655,7 +652,7 @@ class LinksImpl implements Links {
     ) => {
       const jsu = skjson();
       const res = this.handles.apply(fn, [
-        jsu.importJSON(key),
+        jsu.importJSON(key) as K,
         new NonEmptyIteratorImpl<V>(jsu, fromWasm, it),
       ]);
       return jsu.exportJSON(res);
@@ -676,8 +673,8 @@ class LinksImpl implements Links {
       const jsu = skjson();
       const callId = jsu.importString(skcall);
       const name = jsu.importString(skname);
-      const key = jsu.importJSON(skkey, true);
-      const params = jsu.importJSON(skparams, true);
+      const key = jsu.importJSON(skkey, true) as K;
+      const params = jsu.importJSON(skparams, true) as P;
       const promise = this.handles.apply(fn, [key, params]);
       const register = (value: Result<TJSON, TJSON>) => {
         if (!notify) {
@@ -756,7 +753,7 @@ class LinksImpl implements Links {
       const res = jsu.exportJSON(
         this.handles.apply(fn, [
           new LSelfImpl(context, hdl) as LazyCollection<K, V>,
-          jsu.importJSON(key),
+          jsu.importJSON(key) as K,
         ]),
       );
       ref.pop();
@@ -770,7 +767,9 @@ class LinksImpl implements Links {
     ) => {
       ref.push(ctx);
       const jsu = skjson();
-      const res = jsu.exportJSON(this.handles.apply(fn, [jsu.importJSON(key)]));
+      const res = jsu.exportJSON(
+        this.handles.apply(fn, [jsu.importJSON(key) as K]),
+      );
       ref.pop();
       return res;
     };

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -177,7 +177,7 @@ export interface FromWasm {
     ctx: ptr<Internal.Context>,
     getterHdl: ptr<Internal.String>,
     key: ptr<Internal.CJSON>,
-  ): ptr<Internal.CJSON>;
+  ): ptr<Internal.CJArray<Internal.CJSON>>;
   SkipRuntime_get(
     ctx: ptr<Internal.Context>,
     getterHdl: ptr<Internal.String>,
@@ -193,7 +193,7 @@ export interface FromWasm {
     ctx: ptr<Internal.Context>,
     lazyId: ptr<Internal.String>,
     key: ptr<Internal.CJSON>,
-  ): ptr<Internal.CJSON>;
+  ): ptr<Internal.CJArray<Internal.CJSON>>;
   SkipRuntime_getLazy(
     ctx: ptr<Internal.Context>,
     lazyId: ptr<Internal.String>,
@@ -209,7 +209,7 @@ export interface FromWasm {
     ctx: ptr<Internal.Context>,
     selfHdl: ptr<Internal.LHandle>,
     key: ptr<Internal.CJSON>,
-  ): ptr<Internal.CJSON>;
+  ): ptr<Internal.CJArray<Internal.CJSON>>;
   SkipRuntime_getSelf(
     ctx: ptr<Internal.Context>,
     selfHdl: ptr<Internal.LHandle>,

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -119,27 +119,39 @@ export interface Context {
   notify?: () => void;
 }
 
+export type Handle<T> = Internal.Opaque<int, { handle_for: T }>;
+
 export interface Handles {
-  register(v: any): int;
-  get(id: int): any;
-  apply<R, P extends any[] = any[]>(id: int, parameters: P): R;
-  delete(id: int): any;
+  register<T>(v: T): Handle<T>;
+  get<T>(id: Handle<T>): T;
+  apply<R, P extends any[]>(id: Handle<(..._: P) => R>, parameters: P): R;
+  delete<T>(id: Handle<T>): T;
   name(metadata: Metadata): string;
 }
 
 export interface FromWasm {
-  SkipRuntime_map(
+  SkipRuntime_map<
+    K extends TJSON,
+    V extends TJSON,
+    K2 extends TJSON,
+    V2 extends TJSON,
+  >(
     ctx: ptr<Internal.Context>,
     eagerCollectionId: ptr<Internal.String>,
     name: ptr<Internal.String>,
-    fnPtr: int,
+    fnPtr: Handle<(key: K, it: NonEmptyIterator<V>) => Iterable<[K2, V2]>>,
   ): ptr<Internal.String>;
 
-  SkipRuntime_mapReduce(
+  SkipRuntime_mapReduce<
+    K extends TJSON,
+    V extends TJSON,
+    K2 extends TJSON,
+    V2 extends TJSON,
+  >(
     ctx: ptr<Internal.Context>,
     eagerCollectionId: ptr<Internal.String>,
     name: ptr<Internal.String>,
-    fnPtr: int,
+    fnPtr: Handle<(key: K, it: NonEmptyIterator<V>) => Iterable<[K2, V2]>>,
     accumulator: int,
     accInit: ptr<Internal.CJSON>,
   ): ptr<Internal.String>;
@@ -204,11 +216,11 @@ export interface FromWasm {
     eagerCollectionId: ptr<Internal.String>,
   ): number;
 
-  SkipRuntime_toSkdb(
+  SkipRuntime_toSkdb<R, K, V>(
     ctx: ptr<Internal.Context>,
     eagerCollectionId: ptr<Internal.String>,
     table: ptr<Internal.String>,
-    fnPtr: int,
+    fnPtr: Handle<(key: K, it: NonEmptyIterator<V>) => R>,
   ): void;
 
   // NonEmptyIterator
@@ -240,22 +252,22 @@ export interface FromWasm {
   SkipRuntime_createFor(session: ptr<Internal.String>): float;
 
   // SKStore
-  SkipRuntime_asyncLazy(
+  SkipRuntime_asyncLazy<K extends TJSON, V extends TJSON, P extends TJSON>(
     ctx: ptr<Internal.Context>,
     name: ptr<Internal.String>,
-    paramsFn: int,
-    lazyFn: int,
+    paramsFn: Handle<(key: K) => P>,
+    lazyFn: Handle<(key: K, params: P) => Promise<V>>,
   ): ptr<Internal.String>;
-  SkipRuntime_lazy(
+  SkipRuntime_lazy<K extends TJSON, V extends TJSON>(
     ctx: ptr<Internal.Context>,
     name: ptr<Internal.String>,
-    lazyFn: int,
+    lazyFn: Handle<(selfHdl: LazyCollection<K, V>, key: K) => Opt<V>>,
   ): ptr<Internal.String>;
-  SkipRuntime_fromSkdb(
+  SkipRuntime_fromSkdb<R extends TJSON, K extends TJSON, V extends TJSON>(
     ctx: ptr<Internal.Context>,
     table: ptr<Internal.String>,
     name: ptr<Internal.String>,
-    fnPtr: int,
+    fnPtr: Handle<(entry: R, occ: number) => Iterable<[K, V]>>,
   ): ptr<Internal.String>;
   SkipRuntime_multimap(
     ctx: ptr<Internal.Context>,
@@ -270,11 +282,11 @@ export interface FromWasm {
     value: ptr<Internal.CJObject>,
   ): number;
 
-  SkipRuntime_multimapReduce(
+  SkipRuntime_multimapReduce<V2 extends TJSON, V3 extends TJSON>(
     ctx: ptr<Internal.Context>,
     name: ptr<Internal.String>,
     mappings: ptr<Internal.CJArray>,
-    accumulator: int,
+    accumulator: Handle<Accumulator<V2, V3>>,
     accInit: ptr<Internal.CJSON>,
   ): ptr<Internal.String>;
 }

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -122,7 +122,7 @@ export interface Context {
 export interface Handles {
   register(v: any): int;
   get(id: int): any;
-  apply<T>(id: int, parameters: T[]): T;
+  apply<R, P extends any[] = any[]>(id: int, parameters: P): R;
   delete(id: int): any;
   name(metadata: Metadata): string;
 }

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -65,19 +65,29 @@ export interface Context {
     call: (key: K, params: P) => Promise<AValue<V, M>>,
   ) => string;
 
-  getFromTable: <K, R>(table: string, key: K, index?: string) => R[];
+  getFromTable: <K extends TJSON, R>(
+    table: string,
+    key: K,
+    index?: string,
+  ) => R[];
 
-  getArray: <K, V>(collection: string, key: K) => V[];
-  getOne: <K, V>(collection: string, key: K) => V;
-  maybeGetOne: <K, V>(collection: string, key: K) => Opt<V>;
+  getArray: <K extends TJSON, V>(collection: string, key: K) => V[];
+  getOne: <K extends TJSON, V>(collection: string, key: K) => V;
+  maybeGetOne: <K extends TJSON, V>(collection: string, key: K) => Opt<V>;
 
-  getArrayLazy: <K, V>(collection: string, key: K) => V[];
-  getOneLazy: <K, V>(collection: string, key: K) => V;
-  maybeGetOneLazy: <K, V>(collection: string, key: K) => Opt<V>;
+  getArrayLazy: <K extends TJSON, V>(collection: string, key: K) => V[];
+  getOneLazy: <K extends TJSON, V>(collection: string, key: K) => V;
+  maybeGetOneLazy: <K extends TJSON, V>(collection: string, key: K) => Opt<V>;
 
-  getArraySelf: <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => V[];
-  getOneSelf: <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => V;
-  maybeGetOneSelf: <K, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => Opt<V>;
+  getArraySelf: <K extends TJSON, V>(
+    lazyHdl: ptr<Internal.LHandle>,
+    key: K,
+  ) => V[];
+  getOneSelf: <K extends TJSON, V>(lazyHdl: ptr<Internal.LHandle>, key: K) => V;
+  maybeGetOneSelf: <K extends TJSON, V>(
+    lazyHdl: ptr<Internal.LHandle>,
+    key: K,
+  ) => Opt<V>;
 
   size: (collection: string) => number;
 

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -282,7 +282,9 @@ export interface FromWasm {
   SkipRuntime_multimap(
     ctx: ptr<Internal.Context>,
     name: ptr<Internal.String>,
-    mappings: ptr<Internal.CJArray>,
+    mappings: ptr<
+      Internal.CJArray<Internal.CJArray<Internal.CJString | Internal.CJInt>>
+    >,
   ): ptr<Internal.String>;
   SkipRuntime_asyncResult(
     callId: ptr<Internal.String>,
@@ -295,7 +297,9 @@ export interface FromWasm {
   SkipRuntime_multimapReduce<V2 extends TJSON, V3 extends TJSON>(
     ctx: ptr<Internal.Context>,
     name: ptr<Internal.String>,
-    mappings: ptr<Internal.CJArray>,
+    mappings: ptr<
+      Internal.CJArray<Internal.CJArray<Internal.CJString | Internal.CJInt>>
+    >,
     accumulator: Handle<Accumulator<V2, V3>>,
     accInit: ptr<Internal.CJSON>,
   ): ptr<Internal.String>;

--- a/skipruntime-ts/ts/src/internals/skjson.ts
+++ b/skipruntime-ts/ts/src/internals/skjson.ts
@@ -34,10 +34,10 @@ interface WasmAccess {
     json: ptr<Internal.CJObject>,
     idx: int,
   ) => Opt<ptr<Internal.CJSON>>;
-  SKIP_SKJSON_at: (
-    json: ptr<Internal.CJArray>,
+  SKIP_SKJSON_at: <T extends Internal.CJSON>(
+    json: ptr<Internal.CJArray<T>>,
     idx: int,
-  ) => Opt<ptr<Internal.CJSON>>;
+  ) => Opt<ptr<T>>;
 
   SKIP_SKJSON_objectSize: (json: ptr<Internal.CJObject>) => int;
   SKIP_SKJSON_arraySize: (json: ptr<Internal.CJArray>) => int;
@@ -129,8 +129,8 @@ function getFieldAt<T extends Internal.CJObject>(
   return interpretPointer(hdl, hdl.access.SKIP_SKJSON_get(hdl.pointer, idx));
 }
 
-function getItemAt<T extends Internal.CJArray>(
-  hdl: WasmHandle<T>,
+function getItemAt<T extends Internal.CJSON>(
+  hdl: WasmHandle<Internal.CJArray<T>>,
   idx: int,
 ): Exportable {
   return interpretPointer(hdl, hdl.access.SKIP_SKJSON_at(hdl.pointer, idx));
@@ -328,7 +328,7 @@ function clone<T>(value: T): T {
 type PartialCJObj = Internal.Vector<
   Internal.Pair<Internal.String, Internal.CJSON>
 >;
-type PartialCJArray = Internal.Vector<Internal.CJSON>;
+type PartialCJArray<T extends Internal.CJSON> = Internal.Vector<T>;
 
 interface FromWasm extends WasmAccess {
   SKIP_SKJSON_startCJObject: () => ptr<PartialCJObj>;
@@ -338,12 +338,16 @@ interface FromWasm extends WasmAccess {
     value: ptr<Internal.CJSON>,
   ) => void;
   SKIP_SKJSON_endCJObject: (obj: ptr<PartialCJObj>) => ptr<Internal.CJObject>;
-  SKIP_SKJSON_startCJArray: () => ptr<PartialCJArray>;
-  SKIP_SKJSON_addToCJArray: (
-    arr: ptr<PartialCJArray>,
-    value: ptr<Internal.CJSON>,
+  SKIP_SKJSON_startCJArray: <T extends Internal.CJSON>() => ptr<
+    PartialCJArray<T>
+  >;
+  SKIP_SKJSON_addToCJArray: <T extends Internal.CJSON>(
+    arr: ptr<PartialCJArray<T>>,
+    value: ptr<T>,
   ) => void;
-  SKIP_SKJSON_endCJArray: (arr: ptr<PartialCJArray>) => ptr<Internal.CJArray>;
+  SKIP_SKJSON_endCJArray: <T extends Internal.CJSON>(
+    arr: ptr<PartialCJArray<T>>,
+  ) => ptr<Internal.CJArray<T>>;
   SKIP_SKJSON_createCJNull: () => ptr<Internal.CJNull>;
   SKIP_SKJSON_createCJInt: (v: int) => ptr<Internal.CJInt>;
   SKIP_SKJSON_createCJFloat: (v: float) => ptr<Internal.CJFloat>;

--- a/skipruntime-ts/ts/src/internals/skjson.ts
+++ b/skipruntime-ts/ts/src/internals/skjson.ts
@@ -1,7 +1,7 @@
 // prettier-ignore
 import type { int, ptr, float, Links, Utils,  ToWasmManager, Environment, Opt, Shared, } from "#std/sk_types.js";
 import { sk_isArrayProxy, sk_isObjectProxy } from "#std/sk_types.js";
-import type { TJSON } from "skipruntime_api.js";
+import type { JSONObject, TJSON } from "skipruntime_api.js";
 import type * as Internal from "./skstore_internal_types.js";
 
 export enum Type {
@@ -403,7 +403,16 @@ export type Exportable =
 
 export interface SKJSON extends Shared {
   importJSON: (value: ptr<Internal.CJSON>, copy?: boolean) => Exportable;
-  exportJSON: (v: Exportable) => ptr<Internal.CJSON>;
+  exportJSON(v: null | undefined): ptr<Internal.CJNull>;
+  exportJSON(v: number): ptr<Internal.CJFloat>;
+  exportJSON(v: boolean): ptr<Internal.CJBool>;
+  exportJSON(v: string): ptr<Internal.CJString>;
+  exportJSON(v: any[]): ptr<Internal.CJArray>;
+  exportJSON(v: JSONObject): ptr<Internal.CJObject>;
+  exportJSON<T extends Internal.CJSON>(
+    v: (ObjectProxy<object> | ArrayProxy<any>) & { __pointer: ptr<T> },
+  ): ptr<T>;
+  exportJSON(v: TJSON | null): ptr<Internal.CJSON>;
   importOptJSON: (
     value: Opt<ptr<Internal.CJSON>>,
     copy?: boolean,

--- a/skipruntime-ts/ts/src/internals/skjson.ts
+++ b/skipruntime-ts/ts/src/internals/skjson.ts
@@ -299,26 +299,18 @@ function clone<T>(value: T): T {
     if (Array.isArray(value)) {
       return value.map(clone) as T;
     } else if (isArrayProxy(value)) {
-      const res: any[] = [];
-      const length: number = value.length;
-      for (let i = 0; i < length; i++) {
-        res.push(clone(value[i]));
-      }
-      return res as T;
+      return Array.from({ length: value.length }, (_, i) =>
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        clone(value[i]),
+      ) as T;
     } else if (isObjectProxy(value)) {
-      const res: any = {};
-      for (const key of value.keys) {
-        res[key] = clone(value[key]);
-      }
-      return res as T;
+      return Object.fromEntries(
+        value.keys.map((k) => [k, clone(value[k])]),
+      ) as T;
     } else {
-      const aValue = value as any;
-      const res: any = {};
-      const keys = Object.keys(aValue as object);
-      for (const key of keys) {
-        res[key] = clone(aValue[key]);
-      }
-      return res as T;
+      return Object.fromEntries(
+        Object.entries(value).map(([k, v]): [string, any] => [k, clone(v)]),
+      ) as T;
     }
   } else {
     return value;
@@ -433,7 +425,7 @@ class LinksImpl implements Links {
     const fromWasm = exports as FromWasm;
     const importJSON = (valuePtr: ptr<Internal.CJSON>, copy?: boolean): any => {
       const value = getValue(new WasmHandle(utils, valuePtr, fromWasm));
-      return copy ? (value !== null ? clone(value) : value) : value;
+      return copy && value !== null ? clone(value) : value;
     };
 
     const exportJSON = (value: any): ptr<Internal.CJSON> => {

--- a/skipruntime-ts/ts/src/internals/skjson.ts
+++ b/skipruntime-ts/ts/src/internals/skjson.ts
@@ -33,11 +33,11 @@ interface WasmAccess {
   SKIP_SKJSON_get: (
     json: ptr<Internal.CJObject>,
     idx: int,
-  ) => ptr<Internal.CJSON>; // Should be Opt<...>
+  ) => Opt<ptr<Internal.CJSON>>;
   SKIP_SKJSON_at: (
     json: ptr<Internal.CJArray>,
     idx: int,
-  ) => ptr<Internal.CJSON>; // Should be Opt<...>
+  ) => Opt<ptr<Internal.CJSON>>;
 
   SKIP_SKJSON_objectSize: (json: ptr<Internal.CJObject>) => int;
   SKIP_SKJSON_arraySize: (json: ptr<Internal.CJArray>) => int;
@@ -83,9 +83,9 @@ class WasmHandle<T extends Internal.CJSON> {
 
 function interpretPointer<T extends Internal.CJSON>(
   hdl: WasmHandle<any>,
-  ptr: ptr<T>,
+  ptr: null | ptr<T>,
 ): Exportable {
-  if (ptr == 0) return null;
+  if (ptr === null || ptr == 0) return null;
   const type = hdl.access.SKIP_SKJSON_typeOf(ptr) as Type;
   switch (type) {
     case Type.Null:

--- a/skipruntime-ts/ts/src/internals/skjson.ts
+++ b/skipruntime-ts/ts/src/internals/skjson.ts
@@ -403,7 +403,7 @@ export type Exportable =
 
 export interface SKJSON extends Shared {
   importJSON: (value: ptr<Internal.CJSON>, copy?: boolean) => Exportable;
-  exportJSON: <T>(v: T) => ptr<Internal.CJSON>;
+  exportJSON: (v: Exportable) => ptr<Internal.CJSON>;
   importOptJSON: (
     value: Opt<ptr<Internal.CJSON>>,
     copy?: boolean,
@@ -417,14 +417,14 @@ class SKJSONShared implements SKJSON {
   getName = () => "SKJSON";
 
   importJSON: (value: ptr<Internal.CJSON>, copy?: boolean) => Exportable;
-  exportJSON: <T>(v: T) => ptr<Internal.CJSON>;
+  exportJSON: (v: Exportable) => ptr<Internal.CJSON>;
   importString: (v: ptr<Internal.String>) => string;
   exportString: (v: string) => ptr<Internal.String>;
   runWithGC: <T>(fn: () => T) => T;
 
   constructor(
     importJSON: (value: ptr<Internal.CJSON>, copy?: boolean) => Exportable,
-    exportJSON: <T>(v: T) => ptr<Internal.CJSON>,
+    exportJSON: (v: Exportable) => ptr<Internal.CJSON>,
     importString: (v: ptr<Internal.String>) => string,
     exportString: (v: string) => ptr<Internal.String>,
     runWithGC: <T>(fn: () => T) => T,
@@ -466,7 +466,7 @@ class LinksImpl implements Links {
       return copy && value !== null ? clone(value) : value;
     };
 
-    const exportJSON = (value: any): ptr<Internal.CJSON> => {
+    const exportJSON = (value: Exportable): ptr<Internal.CJSON> => {
       if (value === null || value === undefined) {
         return fromWasm.SKIP_SKJSON_createCJNull();
       } else if (typeof value == "number") {
@@ -486,13 +486,13 @@ class LinksImpl implements Links {
           return value.__pointer;
         } else {
           const obj = fromWasm.SKIP_SKJSON_startCJObject();
-          for (const key of Object.keys(value as object)) {
+          Object.entries(value).forEach(([key, val]) => {
             fromWasm.SKIP_SKJSON_addToCJObject(
               obj,
               utils.exportString(key),
-              exportJSON(value[key]),
+              exportJSON(val),
             );
-          }
+          });
           return fromWasm.SKIP_SKJSON_endCJObject(obj);
         }
       } else {

--- a/skipruntime-ts/ts/src/internals/skstore_internal_types.ts
+++ b/skipruntime-ts/ts/src/internals/skstore_internal_types.ts
@@ -19,13 +19,16 @@ declare const cjstring: unique symbol;
 export type CJString = CJSON<typeof cjstring>;
 
 declare const cjarray: unique symbol;
-export type CJArray = CJSON<typeof cjarray>;
+export type CJArray<Sub extends CJSON = CJSON> = CJSON<typeof cjarray, Sub>;
 
 declare const cjobject: unique symbol;
 export type CJObject = CJSON<typeof cjobject>;
 
 declare const cjson: unique symbol;
-export type CJSON<Sub = any> = T<typeof cjson> & { sub: Sub };
+export type CJSON<Sub = any, Sub2 = any> = T<typeof cjson> & {
+  sub: Sub;
+  sub2: Sub2;
+};
 
 declare const context: unique symbol;
 export type Context = T<typeof context>;

--- a/skjson/src/JSON.sk
+++ b/skjson/src/JSON.sk
@@ -60,7 +60,7 @@ base class CJSON uses Orderable {
     SKJSON.TObject(SKJSON.Fields::create(result.chill()))
 }
 
-class CJArray(Array<CJSON>) extends CJSON
+class CJArray<+T: CJSON>(Array<T>) extends CJSON
 
 value class CJFields(cols: Array<String>, values: Array<CJSON>) uses Orderable {
   fun isEmpty(): Bool {

--- a/skjson/src/JSON.sk
+++ b/skjson/src/JSON.sk
@@ -12,7 +12,6 @@ base class CJSON uses Orderable {
   | CJInt(Int)
   | CJFloat(Float)
   | CJString(String)
-  | CJArray(Array<CJSON>)
   | CJObject(CJFields)
 
   fun toJSON(): JSON.Value
@@ -60,6 +59,8 @@ base class CJSON uses Orderable {
     };
     SKJSON.TObject(SKJSON.Fields::create(result.chill()))
 }
+
+class CJArray(Array<CJSON>) extends CJSON
 
 value class CJFields(cols: Array<String>, values: Array<CJSON>) uses Orderable {
   fun isEmpty(): Bool {

--- a/skjson/src/RandomJSON.sk
+++ b/skjson/src/RandomJSON.sk
@@ -38,7 +38,7 @@ mutable class RandomJSON{rand: mutable Random} {
       this.genObject()
     } else {
       if (this.check(static::probArray)) {
-        this.genArray()
+        this.genArray(this.genValue)
       } else {
         if (this.check(static::probNull)) {
           CJNull()
@@ -71,11 +71,11 @@ mutable class RandomJSON{rand: mutable Random} {
     )
   }
 
-  mutable fun genArray(): CJArray {
+  mutable fun genArray<T: CJSON>(genValue: () -> T): CJArray<T> {
     size = this.rand.random(static::arrayMinSize, static::arrayMaxSize);
     values = mutable Vector[];
     for (_ in Range(0, size)) {
-      values.push(this.genValue());
+      values.push(genValue());
     };
     CJArray(values.toArray())
   }


### PR DESCRIPTION
Allows to reduce runtime checks when deconstructing well-typed JSON arrays.

Based on #309 