### PR TITLE
[skipruntime-ts] Sliced instead of MapOptions

### DIFF
--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -216,7 +216,7 @@ class ExternAccumulator(
   }
 }
 
-fun asKeyRanges(jsonRanges: SKJSON.CJSON): ?Array<KeyRange> {
+fun asKeyRangesOpt(jsonRanges: SKJSON.CJSON): ?Array<KeyRange> {
   if (jsonRanges is SKJSON.CJNull()) return None();
   ranges = SKJSON.expectArray(jsonRanges);
   Some(
@@ -244,7 +244,7 @@ fun map(
     name,
     context,
     mapHandle.map,
-    asKeyRanges(rangeOpt),
+    asKeyRangesOpt(rangeOpt),
   )
     .getDirName()
     .toString()
@@ -271,7 +271,7 @@ fun mapReduce(
     context,
     mapHandle.map,
     ExternAccumulator(accumulatorHandle, JSONFile(default)),
-    asKeyRanges(rangeOpt),
+    asKeyRangesOpt(rangeOpt),
   )
     .getDirName()
     .toString()
@@ -427,7 +427,7 @@ fun mapTable(
     name,
     context,
     mapHandle.mapTable,
-    asKeyRanges(rangeOpt),
+    asKeyRangesOpt(rangeOpt),
   )
 }
 
@@ -448,7 +448,7 @@ fun toSkdb(
     context,
     mapHandle.toRow,
     connected != 0,
-    asKeyRanges(rangeOpt),
+    asKeyRangesOpt(rangeOpt),
   )
 }
 

--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -454,6 +454,39 @@ fun toSkdb(
   )
 }
 
+fun identityMap<K: Key, V: File>(
+  _context: mutable Context,
+  writer: mutable TWriter<K, V>,
+  key: K,
+  it: mutable NonEmptyIterator<V>,
+): void {
+  writer.setArray(key, it.collect(Array));
+}
+
+@export("SkipRuntime_sliced")
+fun sliced(
+  context: mutable Context,
+  handleId: String,
+  name: String,
+  jsonRanges: SKJSON.CJArray,
+): String {
+  ranges = jsonRanges match {
+  | SKJSON.CJArray(ranges) -> asKeyRanges(ranges)
+  };
+  eager = EHandle(JSONID::keyType, JSONFile::type, DirName::create(handleId));
+  eagerMap(
+    eager,
+    JSONID::keyType,
+    JSONFile::type,
+    name,
+    context,
+    identityMap,
+    Some(ranges),
+  )
+    .getDirName()
+    .toString()
+}
+
 @export("SkipRuntime_getFromTable")
 fun getFromTable(
   _context: mutable Context,

--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -216,15 +216,17 @@ class ExternAccumulator(
   }
 }
 
+fun asKeyRanges(ranges: Array<SKJSON.CJSON>): Array<KeyRange> {
+  ranges.map((jsonRange) -> {
+    range = SKJSON.expectArray(jsonRange);
+    KeyRange(JSONID(range[0]), JSONID(range[1]))
+  })
+}
+
 fun asKeyRangesOpt(jsonRanges: SKJSON.CJSON): ?Array<KeyRange> {
   if (jsonRanges is SKJSON.CJNull()) return None();
   ranges = SKJSON.expectArray(jsonRanges);
-  Some(
-    ranges.map((jsonRange) -> {
-      range = SKJSON.expectArray(jsonRange);
-      KeyRange(JSONID(range[0]), JSONID(range[1]))
-    }),
-  )
+  Some(asKeyRanges(ranges))
 }
 
 @export("SkipRuntime_map")

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -110,6 +110,19 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
     return this.context.size(this.eagerHdl);
   };
 
+  sliced(ranges: readonly [K, K][]): EagerCollection<K, V> {
+    const sliceName =
+      "range_" +
+      ranges
+        .map(
+          ([k1, k2]) =>
+            `${this.context.keyOfJSON(k1)}--${this.context.keyOfJSON(k2)}`,
+        )
+        .join("_");
+    const eagerHdl = this.context.sliced(this.eagerHdl, sliceName, ranges);
+    return this.derive<K, V>(eagerHdl);
+  }
+
   map<K2 extends TJSON, V2 extends TJSON, Params extends Param[]>(
     mapper: new (...params: Params) => Mapper<K, V, K2, V2>,
     ...paramsAndOptions: WithOptions<Params, K>

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -125,9 +125,8 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
 
   map<K2 extends TJSON, V2 extends TJSON, Params extends Param[]>(
     mapper: new (...params: Params) => Mapper<K, V, K2, V2>,
-    ...paramsAndOptions: WithOptions<Params, K>
+    ...params: Params
   ): EagerCollection<K2, V2> {
-    const [params, options] = splitMapParams(paramsAndOptions);
     params.forEach(check);
     const mapperObj = new mapper(...params);
     Object.freeze(mapperObj);
@@ -139,7 +138,6 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
       mapperObj.constructor.name,
       (key: K, it: NonEmptyIterator<V>) =>
         assertNoKeysNaN(mapperObj.mapElement(key, it)),
-      options.ranges,
     );
     return this.derive<K2, V2>(eagerHdl);
   }
@@ -152,9 +150,8 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
   >(
     mapper: new (...params: Params) => Mapper<K, V, K2, V2>,
     accumulator: Accumulator<V2, V3>,
-    ...paramsAndOptions: WithOptions<Params, K>
+    ...params: Params
   ) {
-    const [params, options] = splitMapParams(paramsAndOptions);
     params.forEach(check);
     const mapperObj = new mapper(...params);
     Object.freeze(mapperObj);
@@ -167,7 +164,6 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
       (key: K, it: NonEmptyIterator<V>) =>
         assertNoKeysNaN(mapperObj.mapElement(key, it)),
       accumulator,
-      options.ranges,
     );
     return this.derive<K2, V3>(eagerHdl);
   }
@@ -175,9 +171,8 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
   mapTo<R extends TJSON[], Params extends Param[]>(
     table: TableCollection<R>,
     mapper: new (...params: Params) => OutputMapper<R, K, V>,
-    ...paramsAndOptions: WithOptions<Params, K>
+    ...params: Params
   ): void {
-    const [params, options] = splitMapParams(paramsAndOptions);
     params.forEach(check);
     const mapperObj = new mapper(...params);
     Object.freeze(mapperObj);
@@ -189,7 +184,6 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
       table.getSchema(),
       (key: K, it: NonEmptyIterator<V>) => mapperObj.mapElement(key, it),
       table.isConnected(),
-      options.ranges,
     );
   }
 }

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -359,6 +359,20 @@ export class ContextImpl implements Context {
     );
   }
 
+  sliced<K extends TJSON>(
+    collectionName: string,
+    sliceName: string,
+    ranges: [K, K][],
+  ): string {
+    const resHdlPtr = this.exports.SkipRuntime_sliced(
+      this.pointer(),
+      this.skjson.exportString(collectionName),
+      this.skjson.exportString(sliceName),
+      this.skjson.exportJSON(ranges),
+    );
+    return this.skjson.importString(resHdlPtr);
+  }
+
   jsonExtract(value: JSONObject, pattern: string): TJSON[] {
     return this.skjson.importJSON(
       this.exports.SKIP_SKStore_jsonExtract(

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -67,17 +67,12 @@ class HandlesImpl implements Handles {
 }
 
 export class ContextImpl implements Context {
-  skjson: SKJSON;
-  exports: FromWasm;
-  handles: Handles;
-  ref: Ref;
-
-  constructor(skjson: SKJSON, exports: FromWasm, handles: Handles, ref: Ref) {
-    this.skjson = skjson;
-    this.exports = exports;
-    this.handles = handles;
-    this.ref = ref;
-  }
+  constructor(
+    private skjson: SKJSON,
+    private exports: FromWasm,
+    private handles: Handles,
+    private ref: Ref,
+  ) {}
 
   noref() {
     return new ContextImpl(this.skjson, this.exports, this.handles, new Ref());

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -71,11 +71,18 @@ export class ContextImpl implements Context {
     private skjson: SKJSON,
     private exports: FromWasm,
     private handles: Handles,
+    private env: Environment,
     private ref: Ref,
   ) {}
 
   noref() {
-    return new ContextImpl(this.skjson, this.exports, this.handles, new Ref());
+    return new ContextImpl(
+      this.skjson,
+      this.exports,
+      this.handles,
+      this.env,
+      new Ref(),
+    );
   }
 
   lazy<K extends TJSON, V extends TJSON>(
@@ -824,7 +831,13 @@ class LinksImpl implements Links {
     ) => {
       ref.push(ctx);
       const jsu = skjson();
-      const context = new ContextImpl(jsu, fromWasm, this.handles, ref);
+      const context = new ContextImpl(
+        jsu,
+        fromWasm,
+        this.handles,
+        this.env,
+        ref,
+      );
       const res = jsu.exportJSON(
         this.handles.apply(fn, [
           new LSelfImpl(context, hdl) as LazyCollection<K, V>,
@@ -924,7 +937,7 @@ class LinksImpl implements Links {
     this.env.shared.set(
       "SKStore",
       new SKStoreFactoryImpl(
-        () => new ContextImpl(skjson(), fromWasm, this.handles, ref),
+        () => new ContextImpl(skjson(), fromWasm, this.handles, this.env, ref),
         create,
         (dbName, asWorker) =>
           (this.env.shared.get("SKDB") as SKDBShared).createSync(

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -384,6 +384,14 @@ export class ContextImpl implements Context {
     ) as TJSON[];
   }
 
+  /* Must produce a valid SKStore key ideally with no collision */
+  keyOfJSON(value: TJSON): string {
+    return (
+      "b64_" +
+      this.env.base64Encode(JSON.stringify(value), true).replaceAll("=", "")
+    );
+  }
+
   private pointer() {
     return this.ref.get()!;
   }

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -134,6 +134,12 @@ export interface Context {
     accumulator: Accumulator<V2, V3>,
   ) => string;
 
+  sliced<K extends TJSON>(
+    collectionName: string,
+    sliceName: string,
+    ranges: readonly [K, K][],
+  ): string;
+
   jsonExtract(value: JSONObject, pattern: string): TJSON[];
 
   noref: () => Context;

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -182,6 +182,13 @@ export interface FromWasm {
     >,
   ): ptr<Internal.String>;
 
+  SkipRuntime_sliced(
+    ctx: ptr<Internal.Context>,
+    eagerCollectionId: ptr<Internal.String>,
+    name: ptr<Internal.String>,
+    ranges: ptr<Internal.CJArray<Internal.CJArray<Internal.CJSON>>>,
+  ): ptr<Internal.String>;
+
   SkipRuntime_getFromTable(
     ctx: ptr<Internal.Context>,
     table: ptr<Internal.String>,

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -142,6 +142,8 @@ export interface Context {
 
   jsonExtract(value: JSONObject, pattern: string): TJSON[];
 
+  keyOfJSON(value: TJSON): string;
+
   noref: () => Context;
 }
 

--- a/skipruntime-ts/ts/src/skip-runtime.ts
+++ b/skipruntime-ts/ts/src/skip-runtime.ts
@@ -54,7 +54,7 @@ export type {
   EntryPoint,
 } from "./skipruntime_api.js";
 
-export { ValueMapper, MapOptions } from "./skipruntime_api.js";
+export { ValueMapper } from "./skipruntime_api.js";
 export {
   Sum,
   Min,

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -40,9 +40,6 @@ export type Schema = {
   filter?: DBFilter;
   alias?: string;
 };
-export class MapOptions<K extends TJSON> {
-  constructor(public ranges: [K, K][] | null = null) {}
-}
 
 /**
  * Skip Runtime async function calls return a `Result` value which is one of `Success`,
@@ -399,16 +396,6 @@ export interface TableCollection<R extends TJSON[]> {
   map<K extends TJSON, V extends TJSON, Params extends Param[]>(
     mapper: new (...params: Params) => InputMapper<R, K, V>,
     ...params: Params
-  ): EagerCollection<K, V>;
-
-  /**
-   * Create a new eager reactive collection by mapping over each entry in
-   * a table collection (with options)
-   * @returns {EagerCollection} The resulting (eager) output collection
-   */
-  map<K extends TJSON, V extends TJSON, Params extends Param[]>(
-    mapper: new (...params: Params) => InputMapper<R, K, V>,
-    ...paramsAndOptions: [...Params, MapOptions<R>]
   ): EagerCollection<K, V>;
 }
 

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -404,6 +404,12 @@ export interface EagerCollection<K extends TJSON, V extends TJSON> {
     ...paramsAndOptions: [...Params, MapOptions<K>]
   ): void;
 
+  /**
+   * Create a new eager collection by keeping only the elements whose keys are in
+   * the given ranges.
+   */
+  sliced(ranges: [K, K][]): EagerCollection<K, V>;
+
   getId(): string;
 }
 

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -328,16 +328,6 @@ export interface EagerCollection<K extends TJSON, V extends TJSON> {
   ): EagerCollection<K2, V2>;
 
   /**
-   * Create a new eager collection by mapping some computation over this one (with options)
-   * @param {Mapper} mapper - function to apply to each element of this collection
-   * @returns {EagerCollection} The resulting (eager) output collection
-   */
-  map<K2 extends TJSON, V2 extends TJSON, Params extends Param[]>(
-    mapper: new (...params: Params) => Mapper<K, V, K2, V2>,
-    ...paramsAndOptions: [...Params, MapOptions<K>]
-  ): EagerCollection<K2, V2>;
-
-  /**
    * Create a new eager reactive collection by mapping some computation `mapper` over this
    * one and then reducing the results with `accumulator`
    * @param {Mapper} mapper - function to apply to each element of this collection
@@ -356,24 +346,6 @@ export interface EagerCollection<K extends TJSON, V extends TJSON> {
   ): EagerCollection<K2, V3>;
 
   /**
-   * Create a new eager reactive collection by mapping some computation `mapper` over this
-   * one and then reducing the results with `accumulator` (with options)
-   * @param {Mapper} mapper - function to apply to each element of this collection
-   * @param {Accumulator} accumulator - function to combine results of the `mapper`
-   * @returns {EagerCollection} An eager collection containing the output of the accumulator
-   */
-  mapReduce<
-    K2 extends TJSON,
-    V2 extends TJSON,
-    V3 extends TJSON,
-    Params extends Param[],
-  >(
-    mapper: new (...params: Params) => Mapper<K, V, K2, V2>,
-    accumulator: Accumulator<V2, V3>,
-    ...paramsAndOptions: [...Params, MapOptions<K>]
-  ): EagerCollection<K2, V3>;
-
-  /**
    * The current number of elements in the collection
    */
   size: () => number;
@@ -389,19 +361,6 @@ export interface EagerCollection<K extends TJSON, V extends TJSON> {
     table: TableCollection<R>,
     mapper: new (...params: Params) => OutputMapper<R, K, V>,
     ...params: Params
-  ): void;
-
-  /**
-   * Eagerly write/update `table` with the contents of this collection (with options)
-   * @param {TableHandle} table - the table to update
-   * @param {Mapper} mapper - function to apply to each key/value pair in this collection
-   *                          to produce a table row
-   * @param paramsAndOptions - any additional parameters to the mapper followed by options
-   */
-  mapTo<R extends TJSON[], Params extends Param[]>(
-    table: TableCollection<R>,
-    mapper: new (...params: Params) => OutputMapper<R, K, V>,
-    ...paramsAndOptions: [...Params, MapOptions<K>]
   ): void;
 
   /**

--- a/skipruntime-ts/ts/tests/tests.ts
+++ b/skipruntime-ts/ts/tests/tests.ts
@@ -27,7 +27,6 @@ import {
   schema,
   ctext as text,
   cjson as json,
-  MapOptions,
 } from "skip-runtime";
 
 function check(name: String, got: TJSON, expected: TJSON): void {
@@ -310,39 +309,37 @@ tests.push({
   run: testSizeRun,
 });
 
-//// testRangedMap1
+//// testSlicedMap1
 
-function testRangedMap1Init(
+function testSlicedMap1Init(
   _skstore: SKStore,
   input: TableCollection<[number, string]>,
   output: TableCollection<[number, number]>,
 ) {
   input
     .map(TestParseInt)
-    .map(
-      SquareValues,
-      new MapOptions([
-        [1, 1],
-        [3, 4],
-        [7, 9],
-        [20, 50],
-        [42, 1337],
-      ]),
-    )
-    .mapTo(
-      output,
-      TestToOutput,
-      new MapOptions([
-        [0, 7],
-        [8, 15],
-      ]),
-    );
+    .sliced([
+      [1, 1],
+      [3, 4],
+      [7, 9],
+      [20, 50],
+      [42, 1337],
+    ])
+    .map(SquareValues)
+    .sliced([
+      [0, 7],
+      [8, 15],
+    ])
+    .mapTo(output, TestToOutput);
 }
 
-async function testRangeMap1Run(input: Table<TJSON[]>, output: Table<TJSON[]>) {
+async function testSlicedMap1Run(
+  input: Table<TJSON[]>,
+  output: Table<TJSON[]>,
+) {
   // Inserts [[0, "0"], ..., [30, "30"]]
   input.insert(Array.from({ length: 31 }, (_, i) => [i, i.toString()]));
-  check("testRangeMap1", output.select({}, ["value"]), [
+  check("testSlicedMap1", output.select({}, ["value"]), [
     { value: 1 },
     { value: 9 },
     { value: 16 },
@@ -353,11 +350,11 @@ async function testRangeMap1Run(input: Table<TJSON[]>, output: Table<TJSON[]>) {
 }
 
 tests.push({
-  name: "testRangedMap1",
+  name: "testSlicedMap1",
   inputs: [schema("input", [integer("id", true, true), text("value")])],
   outputs: [schema("output", [integer("id", true, true), integer("value")])],
-  init: testRangedMap1Init,
-  run: testRangeMap1Run,
+  init: testSlicedMap1Init,
+  run: testSlicedMap1Run,
 });
 
 //// testLazy


### PR DESCRIPTION
As we discussed today, instead of the `MapOptions` thing introduced in #311 for ranges, we add a new function `sliced` on eager collections to do the actual slicing before mapping.
~~But it was actually simpler to implement a `sliced` that just prepares the ranges for the next `map`/`mapReduce`, saving the need to do the intermediate slicing before mapping.
Current limitation (that can be lifted later if there is a need): you cannot slice an already sliced collection. This is ensured by the type system.~~