### PR TITLE
[skipruntime-ts] Drop `multimap` from public API in favor of `merge`

### DIFF
--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -279,6 +279,32 @@ fun mapReduce(
     .toString()
 }
 
+@export("SkipRuntime_union")
+fun union(
+  context: mutable Context,
+  name: String,
+  collections: SKJSON.CJArray,
+): String {
+  mappings = collections match {
+  | SKJSON.CJArray(v) ->
+    v.map(handleID -> {
+      ehandle = EHandle(
+        JSONID::keyType,
+        JSONFile::type,
+        DirName::create(SKJSON.asString(handleID)),
+      );
+      id_mapper = (_ctx, writer, key, vals) ~> {
+        //identity mapper function: write values straight through
+        writer.setArray(key, vals.collect(Array))
+      };
+      (ehandle, id_mapper)
+    })
+  };
+  eagerMultiMap(JSONID::keyType, JSONFile::type, name, context, mappings)
+    .getDirName()
+    .toString()
+}
+
 @export("SkipRuntime_multimap")
 fun multimap(
   context: mutable Context,

--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -295,11 +295,7 @@ fun merge(context: mutable Context, collections: SKJSON.CJArray): String {
         JSONFile::type,
         DirName::create(handleID),
       );
-      id_mapper = (_ctx, writer, key, vals) ~> {
-        //identity mapper function: write values straight through
-        writer.setArray(key, vals.collect(Array))
-      };
-      (ehandle, id_mapper)
+      (ehandle, identityMap)
     })
   };
   eagerMultiMap(JSONID::keyType, JSONFile::type, name, context, mappings)

--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -280,19 +280,19 @@ fun mapReduce(
 }
 
 @export("SkipRuntime_union")
-fun union(
-  context: mutable Context,
-  name: String,
-  collections: SKJSON.CJArray,
-): String {
+fun union(context: mutable Context, collections: SKJSON.CJArray): String {
+  name = "union";
   mappings = collections match {
   | SKJSON.CJArray(v) ->
-    v.map(handleID -> {
+    v.map(handleID_json -> {
+      handleID = SKJSON.asString(handleID_json);
       ehandle = EHandle(
         JSONID::keyType,
         JSONFile::type,
-        DirName::create(SKJSON.asString(handleID)),
+        DirName::create(handleID),
       );
+      invariant(handleID.endsWith("/"));
+      !name = name + handleID.splitLast("/").i0;
       id_mapper = (_ctx, writer, key, vals) ~> {
         //identity mapper function: write values straight through
         writer.setArray(key, vals.collect(Array))

--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -279,9 +279,9 @@ fun mapReduce(
     .toString()
 }
 
-@export("SkipRuntime_union")
-fun union(context: mutable Context, collections: SKJSON.CJArray): String {
-  name = "union"; // to be concatenated with the names of inputs within the loop
+@export("SkipRuntime_merge")
+fun merge(context: mutable Context, collections: SKJSON.CJArray): String {
+  name = "merge"; // to be concatenated with the names of inputs within the loop
   mappings = collections match {
   | SKJSON.CJArray(v) ->
     v.map(handleID_json -> {

--- a/skipruntime-ts/src/Extern.sk
+++ b/skipruntime-ts/src/Extern.sk
@@ -281,18 +281,20 @@ fun mapReduce(
 
 @export("SkipRuntime_union")
 fun union(context: mutable Context, collections: SKJSON.CJArray): String {
-  name = "union";
+  name = "union"; // to be concatenated with the names of inputs within the loop
   mappings = collections match {
   | SKJSON.CJArray(v) ->
     v.map(handleID_json -> {
       handleID = SKJSON.asString(handleID_json);
+
+      invariant(handleID.endsWith("/"));
+      !name = name + handleID.splitLast("/").i0;
+
       ehandle = EHandle(
         JSONID::keyType,
         JSONFile::type,
         DirName::create(handleID),
       );
-      invariant(handleID.endsWith("/"));
-      !name = name + handleID.splitLast("/").i0;
       id_mapper = (_ctx, writer, key, vals) ~> {
         //identity mapper function: write values straight through
         writer.setArray(key, vals.collect(Array))

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -12,7 +12,6 @@ import type {
   TableCollection,
   SKStore,
   SKStoreFactory,
-  Mapping,
   Schema,
   ColumnSchema,
   Table,
@@ -405,58 +404,6 @@ export class SKStoreImpl implements SKStore {
       writable: false,
       value: true,
     });
-  }
-
-  multimap<
-    K1 extends TJSON,
-    V1 extends TJSON,
-    K2 extends TJSON,
-    V2 extends TJSON,
-  >(mappings: Mapping<K1, V1, K2, V2>[]): EagerCollection<K2, V2> {
-    let name = "";
-    const ctxmapping = mappings.map((mapping) => {
-      const params = mapping.params ?? [];
-      params.forEach(check);
-      /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
-      const mapperObj = new mapping.mapper(...params);
-      Object.freeze(mapperObj);
-      name += mapperObj.constructor.name;
-      return {
-        source: mapping.source,
-        mapper: (key: K1, it: NonEmptyIterator<V1>) =>
-          mapperObj.mapElement(key, it),
-      };
-    });
-    const eagerHdl = this.context.multimap(name, ctxmapping);
-    return new EagerCollectionImpl<K2, V2>(this.context, eagerHdl);
-  }
-
-  multimapReduce<
-    K1 extends TJSON,
-    V1 extends TJSON,
-    K2 extends TJSON,
-    V2 extends TJSON,
-    V3 extends TJSON,
-  >(
-    mappings: Mapping<K1, V1, K2, V2>[],
-    accumulator: Accumulator<V2, V3>,
-  ): EagerCollection<K2, V3> {
-    let name = "";
-    const ctxmapping = mappings.map((mapping) => {
-      const params = mapping.params ?? [];
-      params.forEach(check);
-      /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
-      const mapperObj = new mapping.mapper(...params);
-      Object.freeze(mapperObj);
-      name += mapperObj.constructor.name;
-      return {
-        source: mapping.source,
-        mapper: (key: K1, it: NonEmptyIterator<V1>) =>
-          mapperObj.mapElement(key, it),
-      };
-    });
-    const eagerHdl = this.context.multimapReduce(name, ctxmapping, accumulator);
-    return new EagerCollectionImpl<K2, V3>(this.context, eagerHdl);
   }
 
   lazy<K extends TJSON, V extends TJSON, Params extends Param[]>(

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -167,10 +167,10 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
     );
   }
 
-  union(...others: EagerCollection<K, V>[]): EagerCollection<K, V> {
+  merge(...others: EagerCollection<K, V>[]): EagerCollection<K, V> {
     if (others.length == 0) return this;
     const collections = [this, ...others];
-    const eagerHdl = this.context.union(collections);
+    const eagerHdl = this.context.merge(collections);
     return new EagerCollectionImpl<K, V>(this.context, eagerHdl);
   }
 }

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -171,11 +171,7 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
   union(...others: EagerCollection<K, V>[]): EagerCollection<K, V> {
     if (others.length == 0) return this;
     const collections = [this, ...others];
-    const name = collections.reduce(
-      (acc, curr) => acc + curr.getId(),
-      "union_",
-    );
-    const eagerHdl = this.context.union(name, collections);
+    const eagerHdl = this.context.union(collections);
     return new EagerCollectionImpl<K, V>(this.context, eagerHdl);
   }
 }

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -167,6 +167,17 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
       table.isConnected(),
     );
   }
+
+  union(...others: EagerCollection<K, V>[]): EagerCollection<K, V> {
+    if (others.length == 0) return this;
+    const collections = [this, ...others];
+    const name = collections.reduce(
+      (acc, curr) => acc + curr.getId(),
+      "union_",
+    );
+    const eagerHdl = this.context.union(name, collections);
+    return new EagerCollectionImpl<K, V>(this.context, eagerHdl);
+  }
 }
 
 class LazyCollectionImpl<K extends TJSON, V extends TJSON>
@@ -398,16 +409,6 @@ export class SKStoreImpl implements SKStore {
       writable: false,
       value: true,
     });
-  }
-
-  union<K extends TJSON, V extends TJSON>(
-    ...collections: EagerCollection<K, V>[]
-  ) {
-    if (collections.length < 2)
-      throw new Error("Union requires at least two input collections.");
-    const name = collections.reduce((acc, curr) => acc + curr.getId(), "union_");
-    const eagerHdl = this.context.union(name, collections);
-    return new EagerCollectionImpl<K, V>(this.context, eagerHdl);
   }
 
   multimap<

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -400,6 +400,16 @@ export class SKStoreImpl implements SKStore {
     });
   }
 
+  union<K extends TJSON, V extends TJSON>(
+    ...collections: EagerCollection<K, V>[]
+  ) {
+    if (collections.length < 2)
+      throw new Error("Union requires at least two input collections.");
+    const name = collections.reduce((acc, curr) => acc + curr.getId(), "union_");
+    const eagerHdl = this.context.union(name, collections);
+    return new EagerCollectionImpl<K, V>(this.context, eagerHdl);
+  }
+
   multimap<
     K1 extends TJSON,
     V1 extends TJSON,

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -113,13 +113,11 @@ export class ContextImpl implements Context {
   }
 
   union<K extends TJSON, V extends TJSON>(
-    name: string,
     collections: EagerCollection<K, V>[],
   ) {
     const collectionIDs = collections.map((c) => c.getId());
     const unionPtr = this.exports.SkipRuntime_union(
       this.pointer(),
-      this.skjson.exportString(name),
       this.skjson.exportJSON(collectionIDs),
     );
     return this.skjson.importString(unionPtr);

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -6,6 +6,7 @@ import type {
   NonEmptyIterator,
   Result,
   AValue,
+  EagerCollection,
   LazyCollection,
   TJSON,
   Schema,
@@ -109,6 +110,19 @@ export class ContextImpl implements Context {
       this.handles.register(call),
     );
     return this.skjson.importString(lazyHdl);
+  }
+
+  union<K extends TJSON, V extends TJSON>(
+    name: string,
+    ...collections: EagerCollection<K, V>[]
+  ) {
+    const collectionIDs = collections.map((c) => c.getId());
+    const unionPtr = this.exports.SkipRuntime_union(
+      this.pointer(),
+      this.skjson.exportString(name),
+      this.skjson.exportJSON(collectionIDs),
+    );
+    return this.skjson.importString(unionPtr);
   }
 
   multimap<

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -114,7 +114,7 @@ export class ContextImpl implements Context {
 
   union<K extends TJSON, V extends TJSON>(
     name: string,
-    ...collections: EagerCollection<K, V>[]
+    collections: EagerCollection<K, V>[],
   ) {
     const collectionIDs = collections.map((c) => c.getId());
     const unionPtr = this.exports.SkipRuntime_union(

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -112,15 +112,15 @@ export class ContextImpl implements Context {
     return this.skjson.importString(lazyHdl);
   }
 
-  union<K extends TJSON, V extends TJSON>(
+  merge<K extends TJSON, V extends TJSON>(
     collections: EagerCollection<K, V>[],
   ) {
     const collectionIDs = collections.map((c) => c.getId());
-    const unionPtr = this.exports.SkipRuntime_union(
+    const mergePtr = this.exports.SkipRuntime_merge(
       this.pointer(),
       this.skjson.exportJSON(collectionIDs),
     );
-    return this.skjson.importString(unionPtr);
+    return this.skjson.importString(mergePtr);
   }
 
   multimap<

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -112,6 +112,11 @@ export interface Context {
     rangeOpt?: [K, K][] | null,
   ) => void;
 
+  union: <K extends TJSON, V extends TJSON>(
+    name: string,
+    ...collections: EagerCollection<K, V>[]
+  ) => string;
+
   multimap: <
     K1 extends TJSON,
     V1 extends TJSON,
@@ -326,13 +331,6 @@ export interface FromWasm {
       Internal.CJArray<Internal.CJArray<Internal.CJSON>> | Internal.CJNull
     >,
   ): ptr<Internal.String>;
-  SkipRuntime_multimap(
-    ctx: ptr<Internal.Context>,
-    name: ptr<Internal.String>,
-    mappings: ptr<
-      Internal.CJArray<Internal.CJArray<Internal.CJString | Internal.CJInt>>
-    >,
-  ): ptr<Internal.String>;
   SkipRuntime_asyncResult(
     callId: ptr<Internal.String>,
     name: ptr<Internal.String>,
@@ -341,6 +339,18 @@ export interface FromWasm {
     value: ptr<Internal.CJObject>,
   ): number;
 
+  SkipRuntime_union(
+    ctx: ptr<Internal.Context>,
+    name: ptr<Internal.String>,
+    collections: ptr<Internal.CJArray>,
+  ): ptr<Internal.String>;
+  SkipRuntime_multimap(
+    ctx: ptr<Internal.Context>,
+    name: ptr<Internal.String>,
+    mappings: ptr<
+      Internal.CJArray<Internal.CJArray<Internal.CJString | Internal.CJInt>>
+    >,
+  ): ptr<Internal.String>;
   SkipRuntime_multimapReduce<V2 extends TJSON, V3 extends TJSON>(
     ctx: ptr<Internal.Context>,
     name: ptr<Internal.String>,

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -114,7 +114,7 @@ export interface Context {
 
   union: <K extends TJSON, V extends TJSON>(
     name: string,
-    ...collections: EagerCollection<K, V>[]
+    collections: EagerCollection<K, V>[],
   ) => string;
 
   multimap: <

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -113,7 +113,6 @@ export interface Context {
   ) => void;
 
   union: <K extends TJSON, V extends TJSON>(
-    name: string,
     collections: EagerCollection<K, V>[],
   ) => string;
 
@@ -341,7 +340,6 @@ export interface FromWasm {
 
   SkipRuntime_union(
     ctx: ptr<Internal.Context>,
-    name: ptr<Internal.String>,
     collections: ptr<Internal.CJArray>,
   ): ptr<Internal.String>;
   SkipRuntime_multimap(

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -340,7 +340,7 @@ export interface FromWasm {
 
   SkipRuntime_union(
     ctx: ptr<Internal.Context>,
-    collections: ptr<Internal.CJArray>,
+    collections: ptr<Internal.CJArray<Internal.CJString>>,
   ): ptr<Internal.String>;
   SkipRuntime_multimap(
     ctx: ptr<Internal.Context>,

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -112,7 +112,7 @@ export interface Context {
     rangeOpt?: [K, K][] | null,
   ) => void;
 
-  union: <K extends TJSON, V extends TJSON>(
+  merge: <K extends TJSON, V extends TJSON>(
     collections: EagerCollection<K, V>[],
   ) => string;
 
@@ -338,7 +338,7 @@ export interface FromWasm {
     value: ptr<Internal.CJObject>,
   ): number;
 
-  SkipRuntime_union(
+  SkipRuntime_merge(
     ctx: ptr<Internal.Context>,
     collections: ptr<Internal.CJArray<Internal.CJString>>,
   ): ptr<Internal.String>;

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -367,7 +367,7 @@ export interface EagerCollection<K extends TJSON, V extends TJSON> {
    * @param others - some other eager collections of compatible type
    * @returns {EagerCollection} The resulting combination of all input key/value pairs
    */
-  union(...others: EagerCollection<K, V>[]): EagerCollection<K, V>;
+  merge(...others: EagerCollection<K, V>[]): EagerCollection<K, V>;
 
   /**
    * The current number of elements in the collection

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -343,11 +343,6 @@ export interface EagerCollection<K extends TJSON, V extends TJSON> {
   ): EagerCollection<K2, V3>;
 
   /**
-   * The current number of elements in the collection
-   */
-  size: () => number;
-
-  /**
    * Eagerly write/update `table` with the contents of this collection
    * @param {TableHandle} table - the table to update
    * @param {Mapper} mapper - function to apply to each key/value pair in this collection
@@ -365,6 +360,19 @@ export interface EagerCollection<K extends TJSON, V extends TJSON> {
    * the given ranges.
    */
   sliced(ranges: [K, K][]): EagerCollection<K, V>;
+
+  /**
+   * Combine some eager collections into one, associating with each key _all_ values
+   * associated with that key in any of the input collections.
+   * @param others - some other eager collections of compatible type
+   * @returns {EagerCollection} The resulting combination of all input key/value pairs
+   */
+  union(...others: EagerCollection<K, V>[]): EagerCollection<K, V>;
+
+  /**
+   * The current number of elements in the collection
+   */
+  size: () => number;
 
   getId(): string;
 }
@@ -554,16 +562,6 @@ export interface SKStore {
     compute: new (...params: Params) => LazyCompute<K, V>,
     ...params: Params
   ): LazyCollection<K, V>;
-
-  /**
-   * Combine some eager collections into one, associating with each key _all_ values
-   * associated with that key in any of the input collections.
-   * @param collections - the input collections to union together
-   * @returns {EagerCollection} The resulting combination of all input key/value pairs
-   */
-  union<K extends TJSON, V extends TJSON>(
-    ...collections: EagerCollection<K, V>[]
-  ): EagerCollection<K, V>;
 
   /**
    * Creates a lazy reactive collection with an asynchronous computation

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -485,21 +485,6 @@ export interface Table<R extends TJSON[]> {
   ) => { close: () => void };
 }
 
-/**
- * A `Mapping` is an edge in the reactive computation graph, specified by a source
- * collection and a mapper function (along with parameters to that mapper, if needed)
- */
-export type Mapping<
-  K1 extends TJSON,
-  V1 extends TJSON,
-  K2 extends TJSON,
-  V2 extends TJSON,
-> = {
-  source: EagerCollection<K1, V1>;
-  mapper: new (...params: Param[]) => Mapper<K1, V1, K2, V2>;
-  params?: Param[];
-};
-
 export type EntryPoint = {
   host: string;
   port: number;

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -556,6 +556,16 @@ export interface SKStore {
   ): LazyCollection<K, V>;
 
   /**
+   * Combine some eager collections into one, associating with each key _all_ values
+   * associated with that key in any of the input collections.
+   * @param collections - the input collections to union together
+   * @returns {EagerCollection} The resulting combination of all input key/value pairs
+   */
+  union<K extends TJSON, V extends TJSON>(
+    ...collections: EagerCollection<K, V>[]
+  ): EagerCollection<K, V>;
+
+  /**
    * Map over each entry of each eager reactive map and apply the corresponding mapper function
    * @param {Mapping[]} mappings - the input collections and corresponding mappers
    * @returns {EagerCollection} An eager collection containing the combined outputs of the `mappings`

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -566,39 +566,6 @@ export interface SKStore {
   ): EagerCollection<K, V>;
 
   /**
-   * Map over each entry of each eager reactive map and apply the corresponding mapper function
-   * @param {Mapping[]} mappings - the input collections and corresponding mappers
-   * @returns {EagerCollection} An eager collection containing the combined outputs of the `mappings`
-   */
-  multimap<
-    K1 extends TJSON,
-    V1 extends TJSON,
-    K2 extends TJSON,
-    V2 extends TJSON,
-  >(
-    mappings: Mapping<K1, V1, K2, V2>[],
-  ): EagerCollection<K2, V2>;
-
-  /**
-   * Create a new eager reactive collection by applying a `multimap` and then reducing the results
-   * with a given `accumulator`
-   * @param {Mapping} mappings - the input collections and corresponding mappers
-   * @param {Accumulator} accumulator - function to combine results of the multimap
-   * @returns {EagerCollection} An eager collection containing the output of the accumulator over
-   * the combined outputs of the `mappings`
-   */
-  multimapReduce<
-    K1 extends TJSON,
-    V1 extends TJSON,
-    K2 extends TJSON,
-    V2 extends TJSON,
-    V3 extends TJSON,
-  >(
-    mappings: Mapping<K1, V1, K2, V2>[],
-    accumulator: Accumulator<V2, V3>,
-  ): EagerCollection<K2, V3>;
-
-  /**
    * Creates a lazy reactive collection with an asynchronous computation
    * @param compute - the async function to call with returned values
    * @returns {LazyCollection} The resulting async lazy collection

--- a/skipruntime-ts/ts/tests/tests.ts
+++ b/skipruntime-ts/ts/tests/tests.ts
@@ -517,7 +517,7 @@ function testMultiMap1Init(
   const eager1 = input1.map(TestParseInt).map(TestSplitter, 0);
   const eager2 = input2.map(TestParseInt).map(TestSplitter, 1);
 
-  eager1.union(eager2).mapTo(output, TestToOutput2);
+  eager1.merge(eager2).mapTo(output, TestToOutput2);
 }
 
 function testMultiMap1Run(
@@ -574,7 +574,7 @@ function testMultiMapReduceInit(
 ) {
   input1
     .map(TestParseInt)
-    .union(input2.map(TestParseInt))
+    .merge(input2.map(TestParseInt))
     .mapReduce(IdentityMapper, new Sum())
     .mapTo(output, TestToOutput);
 }

--- a/skipruntime-ts/ts/tests/tests.ts
+++ b/skipruntime-ts/ts/tests/tests.ts
@@ -560,12 +560,9 @@ tests.push({
 
 //// testMultiMapReduce
 
-class TestSet implements Mapper<number, number, number, number> {
-  mapElement(
-    key: number,
-    it: NonEmptyIterator<number>,
-  ): Iterable<[number, number]> {
-    return Array([key, it.first()]);
+class IdentityMapper extends ValueMapper<number, number, number> {
+  mapValue(v: number) {
+    return v;
   }
 }
 
@@ -578,7 +575,7 @@ function testMultiMapReduceInit(
   input1
     .map(TestParseInt)
     .union(input2.map(TestParseInt))
-    .mapReduce(Identity, new Sum())
+    .mapReduce(IdentityMapper, new Sum())
     .mapTo(output, TestToOutput);
 }
 

--- a/skipruntime-ts/ts/tests/tests.ts
+++ b/skipruntime-ts/ts/tests/tests.ts
@@ -514,13 +514,10 @@ function testMultiMap1Init(
   input2: TableCollection<[number, string]>,
   output: TableCollection<[number, number, number]>,
 ) {
-  const eager1 = input1.map(TestParseInt);
-  const eager2 = input2.map(TestParseInt);
-  const eager3 = skstore.multimap([
-    { source: eager1, mapper: TestSplitter, params: [0] },
-    { source: eager2, mapper: TestSplitter, params: [1] },
-  ]);
-  eager3.mapTo(output, TestToOutput2);
+  const eager1 = input1.map(TestParseInt).map(TestSplitter, 0);
+  const eager2 = input2.map(TestParseInt).map(TestSplitter, 1);
+
+  eager1.union(eager2).mapTo(output, TestToOutput2);
 }
 
 function testMultiMap1Run(
@@ -578,16 +575,11 @@ function testMultiMapReduceInit(
   input2: TableCollection<[number, string]>,
   output: TableCollection<[number, number]>,
 ) {
-  const eager1 = input1.map(TestParseInt);
-  const eager2 = input2.map(TestParseInt);
-  const eager3 = skstore.multimapReduce(
-    [
-      { source: eager1, mapper: TestSet },
-      { source: eager2, mapper: TestSet },
-    ],
-    new Sum(),
-  );
-  eager3.mapTo(output, TestToOutput);
+  input1
+    .map(TestParseInt)
+    .union(input2.map(TestParseInt))
+    .mapReduce(Identity, new Sum())
+    .mapTo(output, TestToOutput);
 }
 
 function testMultiMapReduceRun(


### PR DESCRIPTION
This is a slightly less space efficient but much more understandable/clean interface to my eyes.

See b99cb86 for an example of the difference in user code.
