### PR TITLE
[skipruntime-ts] A few cleanups on the API

### DIFF
--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -110,9 +110,9 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
     return this.context.maybeGetOne(this.eagerHdl, key);
   }
 
-  size = () => {
+  size(): int {
     return this.context.size(this.eagerHdl);
-  };
+  }
 
   sliced(ranges: readonly [K, K][]): EagerCollection<K, V> {
     const sliceName =
@@ -381,7 +381,8 @@ export class TableImpl<R extends TJSON[]> implements Table<R> {
       query.params ? toParams(query.params) : undefined,
     );
   }
-  watch = (update: (rows: JSONObject[]) => void, feedback: boolean = false) => {
+
+  watch(update: (rows: JSONObject[]) => void, feedback: boolean = false) {
     const name = feedback
       ? this.getName() + serverResponseSuffix
       : this.getName();
@@ -391,13 +392,13 @@ export class TableImpl<R extends TJSON[]> implements Table<R> {
       query.params ? toParams(query.params) : {},
       update,
     );
-  };
+  }
 
-  watchChanges = (
+  watchChanges(
     init: (rows: JSONObject[]) => void,
     update: (added: JSONObject[], removed: JSONObject[]) => void,
     feedback: boolean = false,
-  ) => {
+  ) {
     const name = feedback
       ? this.getName() + serverResponseSuffix
       : this.getName();
@@ -408,7 +409,7 @@ export class TableImpl<R extends TJSON[]> implements Table<R> {
       init,
       update,
     );
-  };
+  }
 }
 
 export class SKStoreImpl extends SkFrozen implements SKStore {
@@ -481,9 +482,11 @@ export class SKStoreFactoryImpl implements SKStoreFactory {
     private createKey: (key: string) => Promise<CryptoKey>,
   ) {}
 
-  getName = () => "SKStore";
+  getName() {
+    return "SKStore";
+  }
 
-  runSKStore = async (
+  async runSKStore(
     init: (
       skstore: SKStore,
       tables: Record<string, TableCollection<TJSON[]>>,
@@ -492,7 +495,7 @@ export class SKStoreFactoryImpl implements SKStoreFactory {
     remotes: Record<string, Remote> = {},
     tokens: Record<string, number> = {},
     initLocals?: (tables: Record<string, Table<TJSON[]>>) => Promise<void>,
-  ): Promise<Record<string, Table<TJSON[]>>> => {
+  ): Promise<Record<string, Table<TJSON[]>>> {
     const context = this.context();
     const tables = await mirror(
       context,
@@ -519,7 +522,7 @@ export class SKStoreFactoryImpl implements SKStoreFactory {
       result[key] = (value as TableCollectionImpl<TJSON[]>).toTable();
     }
     return result;
-  };
+  }
 }
 
 function toWs(entryPoint: EntryPoint) {

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -47,7 +47,7 @@ function assertNoKeysNaN<K extends TJSON, V extends TJSON>(
 }
 export const serverResponseSuffix = "__skdb_mirror_feedback";
 
-const sk_frozen: unique symbol = Symbol();
+export const sk_frozen: unique symbol = Symbol();
 
 export interface Constant {
   [sk_frozen]: true;

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -835,10 +835,13 @@ function toUpdateWhereQuery(
 }
 
 export function check<T>(value: T): void {
-  const type = typeof value;
-  if (type == "string" || type == "number" || type == "boolean") {
+  if (
+    typeof value == "string" ||
+    typeof value == "number" ||
+    typeof value == "boolean"
+  ) {
     return;
-  } else if (type == "object") {
+  } else if (typeof value == "object") {
     const jso = value as any;
     if (jso.__sk_frozen) {
       return;
@@ -857,7 +860,7 @@ export function check<T>(value: T): void {
       throw new Error("Invalid object: must be frozen.");
     }
   } else {
-    throw new Error("'" + type + "' cannot be manage by skstore.");
+    throw new Error(`'${typeof value}' cannot be managed by skstore.`);
   }
 }
 
@@ -881,10 +884,13 @@ export function check<T>(value: T): void {
  * @returns The same object that was passed in.
  */
 export function freeze<T>(value: T): T {
-  const type = typeof value;
-  if (type == "string" || type == "number" || type == "boolean") {
+  if (
+    typeof value == "string" ||
+    typeof value == "number" ||
+    typeof value == "boolean"
+  ) {
     return value;
-  } else if (type == "object") {
+  } else if (typeof value == "object") {
     if ((value as any).__sk_frozen) {
       return value;
     } else if (Object.isFrozen(value)) {
@@ -914,6 +920,6 @@ export function freeze<T>(value: T): T {
       return Object.freeze(jso) as T;
     }
   } else {
-    throw new Error("'" + type + "' cannot be frozen.");
+    throw new Error(`'${typeof value}' cannot be frozen.`);
   }
 }

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -842,6 +842,9 @@ export function check<T>(value: T): void {
   ) {
     return;
   } else if (typeof value == "object") {
+    if (value === null) {
+      return;
+    }
     const jso = value as any;
     if (jso.__sk_frozen) {
       return;
@@ -891,7 +894,9 @@ export function freeze<T>(value: T): T {
   ) {
     return value;
   } else if (typeof value == "object") {
-    if ((value as any).__sk_frozen) {
+    if (value === null) {
+      return value;
+    } else if ((value as any).__sk_frozen) {
       return value;
     } else if (Object.isFrozen(value)) {
       check(value);

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -850,14 +850,10 @@ export function check<T>(value: T): void {
       return;
     } else if (Object.isFrozen(jso)) {
       if (Array.isArray(jso)) {
-        for (let i = 0; i < length; i++) {
-          check(jso[i]);
-        }
+        jso.forEach(check);
       } else {
         /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
-        for (const key of Object.keys(jso)) {
-          check(jso[key]);
-        }
+        Object.values(jso).forEach(check);
       }
     } else {
       throw new Error("Invalid object: must be frozen.");

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -47,12 +47,14 @@ function assertNoKeysNaN<K extends TJSON, V extends TJSON>(
 }
 export const serverResponseSuffix = "__skdb_mirror_feedback";
 
+const sk_frozen: unique symbol = Symbol();
+
 export interface Constant {
-  __sk_frozen: true;
+  [sk_frozen]: true;
 }
 
 function sk_freeze<T extends object>(x: T): T & Constant {
-  return Object.defineProperty(x, "__sk_frozen", {
+  return Object.defineProperty(x, sk_frozen, {
     enumerable: false,
     writable: false,
     value: true,
@@ -60,12 +62,12 @@ function sk_freeze<T extends object>(x: T): T & Constant {
 }
 
 function isSkFrozen(x: any): x is Constant {
-  return "__sk_frozen" in x && x.__sk_frozen === true;
+  return sk_frozen in x && x[sk_frozen] === true;
 }
 
 abstract class SkFrozen implements Constant {
   // tsc misses that Object.defineProperty in the constructor inits this
-  __sk_frozen!: true;
+  [sk_frozen]!: true;
 
   constructor() {
     sk_freeze(this);

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -78,14 +78,11 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
   extends SkFrozen
   implements EagerCollection<K, V>
 {
-  //
-  protected context: Context;
-  eagerHdl: string;
-
-  constructor(context: Context, eagerHdl: string) {
+  constructor(
+    protected context: Context,
+    protected eagerHdl: string,
+  ) {
     super();
-    this.context = context;
-    this.eagerHdl = eagerHdl;
   }
 
   getId(): string {
@@ -209,13 +206,11 @@ class LazyCollectionImpl<K extends TJSON, V extends TJSON>
   extends SkFrozen
   implements LazyCollection<K, V>
 {
-  protected context: Context;
-  protected lazyHdl: string;
-
-  constructor(context: Context, lazyHdl: string) {
+  constructor(
+    protected context: Context,
+    protected lazyHdl: string,
+  ) {
     super();
-    this.context = context;
-    this.lazyHdl = lazyHdl;
   }
 
   getArray(key: K): V[] {
@@ -235,13 +230,11 @@ export class LSelfImpl<K extends TJSON, V extends TJSON>
   extends SkFrozen
   implements LazyCollection<K, V>
 {
-  protected context: Context;
-  protected lazyHdl: ptr<Internal.LHandle>;
-
-  constructor(context: Context, lazyHdl: ptr<Internal.LHandle>) {
+  constructor(
+    protected context: Context,
+    protected lazyHdl: ptr<Internal.LHandle>,
+  ) {
     super();
-    this.context = context;
-    this.lazyHdl = lazyHdl;
   }
 
   getArray(key: K): V[] {
@@ -312,15 +305,12 @@ export class TableCollectionImpl<R extends TJSON[]>
 }
 
 export class TableImpl<R extends TJSON[]> implements Table<R> {
-  protected context: Context;
-  protected skdb: SKDBSync;
-  protected schema: Schema;
-
-  constructor(context: Context, skdb: SKDBSync, schema: Schema) {
-    this.context = context;
-    this.skdb = skdb;
-    this.schema = schema;
-  }
+  //
+  constructor(
+    protected context: Context,
+    protected skdb: SKDBSync,
+    protected schema: Schema,
+  ) {}
 
   getName(): string {
     return this.schema.name;
@@ -416,11 +406,9 @@ export class TableImpl<R extends TJSON[]> implements Table<R> {
 }
 
 export class SKStoreImpl extends SkFrozen implements SKStore {
-  private context: Context;
-
-  constructor(context: Context) {
+  //
+  constructor(private context: Context) {
     super();
-    this.context = context;
   }
 
   lazy<K extends TJSON, V extends TJSON, Params extends Param[]>(
@@ -475,25 +463,16 @@ export class SKStoreImpl extends SkFrozen implements SKStore {
 }
 
 export class SKStoreFactoryImpl implements SKStoreFactory {
-  private context: () => Context;
-  private create: (init: () => void, tokens: Record<string, number>) => void;
-  private createSync: (
-    dbName?: string,
-    asWorker?: boolean,
-  ) => Promise<SKDBSync>;
-  private createKey: (key: string) => Promise<CryptoKey>;
-
+  //
   constructor(
-    context: () => Context,
-    create: (init: () => void, tokens: Record<string, number>) => void,
-    createSync: (dbName?: string, asWorker?: boolean) => Promise<SKDBSync>,
-    createKey: (key: string) => Promise<CryptoKey>,
-  ) {
-    this.context = context;
-    this.create = create;
-    this.createSync = createSync;
-    this.createKey = createKey;
-  }
+    private context: () => Context,
+    private create: (init: () => void, tokens: Record<string, number>) => void,
+    private createSync: (
+      dbName?: string,
+      asWorker?: boolean,
+    ) => Promise<SKDBSync>,
+    private createKey: (key: string) => Promise<CryptoKey>,
+  ) {}
 
   getName = () => "SKStore";
 

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -71,6 +71,8 @@ abstract class SkFrozen implements Constant {
 
   constructor() {
     sk_freeze(this);
+    // Inheriting classes should call Object.freeze at the end of their
+    // constructor
   }
 }
 
@@ -83,6 +85,7 @@ class EagerCollectionImpl<K extends TJSON, V extends TJSON>
     protected eagerHdl: string,
   ) {
     super();
+    Object.freeze(this);
   }
 
   getId(): string {
@@ -211,6 +214,7 @@ class LazyCollectionImpl<K extends TJSON, V extends TJSON>
     protected lazyHdl: string,
   ) {
     super();
+    Object.freeze(this);
   }
 
   getArray(key: K): V[] {
@@ -235,6 +239,7 @@ export class LSelfImpl<K extends TJSON, V extends TJSON>
     protected lazyHdl: ptr<Internal.LHandle>,
   ) {
     super();
+    Object.freeze(this);
   }
 
   getArray(key: K): V[] {
@@ -260,6 +265,7 @@ export class TableCollectionImpl<R extends TJSON[]>
     protected schema: Schema,
   ) {
     super();
+    Object.freeze(this);
   }
 
   getName() {
@@ -409,6 +415,7 @@ export class SKStoreImpl extends SkFrozen implements SKStore {
   //
   constructor(private context: Context) {
     super();
+    Object.freeze(this);
   }
 
   lazy<K extends TJSON, V extends TJSON, Params extends Param[]>(

--- a/skipruntime-ts/ts/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_module.ts
@@ -4,7 +4,6 @@ import type { SKJSON } from "#skjson/skjson.js";
 import type {
   Accumulator,
   NonEmptyIterator,
-  Result,
   AValue,
   EagerCollection,
   LazyCollection,
@@ -12,6 +11,7 @@ import type {
   Schema,
   RefreshToken,
   JSONObject,
+  Success,
 } from "../skipruntime_api.js";
 
 import type {
@@ -612,6 +612,35 @@ class Ref {
     this.pointers.pop();
   }
 }
+
+/**
+ * Skip Runtime async function calls return a `Result` value which is one of `Success`,
+ * `Failure`, or `Unchanged`
+ */
+
+/**
+ * A `Failure` return value indicates a runtime error and contains:
+ * `error` - the error message associated with the error
+ */
+type Failure = {
+  status: "failure";
+  error: string;
+};
+
+/**
+ * An `Unchanged` return value indicates that the data is the same as the last invocation,
+ * and is analogous to HTTP response code 304 'Not Modified'.  It contains:
+ * `metadata` - optional data that can be added to supersede metadata on the unchanged return value
+ */
+type Unchanged<M extends TJSON> = {
+  status: "unchanged";
+  metadata?: M;
+};
+
+type Result<V extends TJSON, M extends TJSON> =
+  | Success<V, M>
+  | Failure
+  | Unchanged<M>;
 
 class LinksImpl implements Links {
   env: Environment;

--- a/skipruntime-ts/ts/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_types.ts
@@ -184,12 +184,13 @@ export interface FromWasm {
     V extends TJSON,
     K2 extends TJSON,
     V2 extends TJSON,
+    V3 extends TJSON,
   >(
     ctx: ptr<Internal.Context>,
     eagerCollectionId: ptr<Internal.String>,
     name: ptr<Internal.String>,
     fnPtr: Handle<(key: K, it: NonEmptyIterator<V>) => Iterable<[K2, V2]>>,
-    accumulator: int,
+    accumulator: Handle<Accumulator<V2, V3>>,
     accInit: ptr<Internal.CJSON>,
     rangeOpt: ptr<
       Internal.CJArray<Internal.CJArray<Internal.CJSON>> | Internal.CJNull

--- a/skipruntime-ts/ts/src/skip-runtime.ts
+++ b/skipruntime-ts/ts/src/skip-runtime.ts
@@ -6,7 +6,7 @@ import type {
   SimpleServiceOutput,
   Writer,
 } from "./skipruntime_service.js";
-import { check } from "./internals/skipruntime_impl.js";
+export { freeze } from "./internals/skipruntime_impl.js";
 import type {
   DBFilter,
   DBType,
@@ -166,63 +166,6 @@ export async function createLocalSKStore(
     {},
     tokens,
   );
-}
-
-/**
- * _Deep-freeze_ an object, returning the same object that was passed in.
- *
- * This function is similar to
- * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze | `Object.freeze()`}
- * but freezes the object and deep-freezes all its properties,
- * recursively. The object is then not only _immutable_ but also
- * _constant_. Note that as a result all objects reachable from the
- * parameter will be frozen and no longer mutable or extensible, even from
- * other references.
- *
- * The primary use for this function is to satisfy the requirement that all
- * parameters to Skip `Mapper` constructors must be deep-frozen: objects
- * that have not been constructed by Skip can be passed to `freeze()` before
- * passing them to a `Mapper` constructor.
- *
- * @param value - The object to deep-freeze.
- * @returns The same object that was passed in.
- */
-export function freeze<T>(value: T): T {
-  const type = typeof value;
-  if (type == "string" || type == "number" || type == "boolean") {
-    return value;
-  } else if (type == "object") {
-    if ((value as any).__sk_frozen) {
-      return value;
-    } else if (Object.isFrozen(value)) {
-      check(value);
-      return value;
-    } else if (Array.isArray(value)) {
-      Object.defineProperty(value, "__sk_frozen", {
-        enumerable: false,
-        writable: false,
-        value: true,
-      });
-      const length: number = value.length;
-      for (let i = 0; i < length; i++) {
-        value[i] = freeze(value[i]);
-      }
-      return Object.freeze(value) as T;
-    } else {
-      const jso = value as Record<string, any>;
-      Object.defineProperty(value, "__sk_frozen", {
-        enumerable: false,
-        writable: false,
-        value: true,
-      });
-      for (const key of Object.keys(jso)) {
-        jso[key] = freeze(jso[key]);
-      }
-      return Object.freeze(jso) as T;
-    }
-  } else {
-    throw new Error("'" + type + "' cannot be frozen.");
-  }
 }
 
 export async function runWithServer(

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -5,8 +5,8 @@
  */
 
 // prettier-ignore
-import type { Opaque, Opt, Shared, float, int, ptr } from "#std/sk_types.js";
-export type { Opt, float, int, ptr };
+import type { Opaque, Opt, Shared, int } from "#std/sk_types.js";
+export type { Opt, int };
 
 export type JSONObject = { [key: string]: TJSON | null };
 

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -13,7 +13,14 @@ export type JSONObject = { [key: string]: TJSON | null };
 
 export type TJSON = number | JSONObject | boolean | (TJSON | null)[] | string;
 
-export type Param = any;
+export type Param =
+  | null
+  | boolean
+  | number
+  | string
+  | Constant
+  | readonly Param[]
+  | { readonly [k: string]: Param };
 
 export type RefreshToken = Opaque<number, "SkipRefreshToken">;
 

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -6,6 +6,7 @@
 
 // prettier-ignore
 import type { Opaque, Opt, Shared, int } from "#std/sk_types.js";
+import type { Constant } from "./internals/skipruntime_impl.js";
 export type { Opt, int };
 
 export type JSONObject = { [key: string]: TJSON | null };
@@ -238,7 +239,8 @@ export interface NonEmptyIterator<T> extends Iterable<T> {
 /**
  * A _Lazy_ reactive collection, whose values are computed only when queried
  */
-export interface LazyCollection<K extends TJSON, V extends TJSON> {
+export interface LazyCollection<K extends TJSON, V extends TJSON>
+  extends Constant {
   /**
    * Get (and potentially compute) all values mapped to by some key of a lazy reactive
    * collection.
@@ -269,7 +271,8 @@ export interface AsyncLazyCollection<
  * An _Eager_ reactive collection, whose values are computed eagerly and kept up
  * to date whenever inputs are changed
  */
-export interface EagerCollection<K extends TJSON, V extends TJSON> {
+export interface EagerCollection<K extends TJSON, V extends TJSON>
+  extends Constant {
   /**
    * Get (and potentially compute) all values mapped to by some key of a lazy reactive
    * collection.
@@ -361,7 +364,7 @@ export interface EagerCollection<K extends TJSON, V extends TJSON> {
  * allows it to be serialized and replicated over the wire.  `TableCollection`s
  * serve as inputs and outputs of reactive services.
  */
-export interface TableCollection<R extends TJSON[]> {
+export interface TableCollection<R extends TJSON[]> extends Constant {
   getName(): string;
   getSchema(): Schema;
   isConnected(): boolean;
@@ -516,7 +519,7 @@ export interface AsyncLazyCompute<
   call: (key: K, params: P) => Promise<AValue<V, M>>;
 }
 
-export interface SKStore {
+export interface SKStore extends Constant {
   /**
    * Creates a lazy reactive collection.
    * @param compute - the function to compute entries of the lazy collection

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -40,8 +40,8 @@ export type Schema = {
 };
 
 /**
- * Skip Runtime async function calls return a `Result` value which is one of `Success`,
- * `Failure`, or `Unchanged`
+ * Skip Runtime async function calls return a `Loadable` value which is one of `Success`,
+ * `Loading`, or `Error`
  */
 
 /**
@@ -55,30 +55,6 @@ export type Success<V extends TJSON, M extends TJSON> = {
   payload: V;
   metadata?: M;
 };
-
-/**
- * A `Failure` return value indicates a runtime error and contains:
- * `error` - the error message associated with the error
- */
-export type Failure = {
-  status: "failure";
-  error: string;
-};
-
-/**
- * An `Unchanged` return value indicates that the data is the same as the last invocation,
- * and is analogous to HTTP response code 304 'Not Modified'.  It contains:
- * `metadata` - optional data that can be added to supersede metadata on the unchanged return value
- */
-export type Unchanged<M extends TJSON> = {
-  status: "unchanged";
-  metadata?: M;
-};
-
-export type Result<V extends TJSON, M extends TJSON> =
-  | Success<V, M>
-  | Failure
-  | Unchanged<M>;
 
 /**
  * Lazy function calls carry additional structure in their `Loadable` return types, to

--- a/skipruntime-ts/ts/src/skipruntime_runner.ts
+++ b/skipruntime-ts/ts/src/skipruntime_runner.ts
@@ -257,14 +257,12 @@ export async function runService(
     const iHandles: Record<string, EagerCollection<TJSON, TJSON>> = {};
     for (const [key, value] of Object.entries(localInputs)) {
       const table = tables[key];
-      // eslint-disable-next-line  @typescript-eslint/no-unsafe-argument
       iHandles[key] = table.map(value.fromTableRow, ...value.params);
       iTables[key] = (table as TableCollectionImpl<TJSON[]>).toTable();
     }
     for (const remove of Object.values(remoteInputs)) {
       for (const [key, value] of Object.entries(remove.inputs)) {
         const table = tables[key];
-        // eslint-disable-next-line  @typescript-eslint/no-unsafe-argument
         iHandles[key] = table.map(value.fromTableRow, ...value.params);
       }
     }
@@ -289,7 +287,6 @@ export async function runService(
         throw new Error(`Unable to retrieve ${key} table.`);
       }
       oTables[key] = (table as TableCollectionImpl<TJSON[]>).toTable();
-      // eslint-disable-next-line  @typescript-eslint/no-unsafe-argument
       ehandle.mapTo(tables[key], output.toTableRow, ...output.params);
     }
     update = (event, remotes) => result.update(event, iTables, remotes);

--- a/skipruntime-ts/ts/tests/tests.ts
+++ b/skipruntime-ts/ts/tests/tests.ts
@@ -36,7 +36,7 @@ type Test = {
   name: string;
   inputs: Schema[];
   outputs: Schema[];
-  init: (skstore: SKStore, ...tables: any[]) => void;
+  init: (skstore: SKStore, ...tables: TableCollection<TJSON[]>[]) => void;
   run: (...tables: Table<TJSON[]>[]) => void | Promise<void>;
   error?: (err: any) => void;
   tokens?: Record<string, number>;


### PR DESCRIPTION
- remove unused types
- unified handling of SK-frozen objects
- more precise type for `Param`