### PR TITLE
[ts runtime] External calls API

### DIFF
--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -446,7 +446,7 @@ export class SKStoreImpl extends SkFrozen implements SKStore {
   >(
     compute: new (...params: Params) => AsyncLazyCompute<K, V, P, M>,
     ...params: Params
-  ): LazyCollection<K, Loadable<V, M>> {
+  ): AsyncLazyCollection<K, V, M> {
     params.forEach(check);
     const computeObj = new compute(...params);
     const name = computeObj.constructor.name;

--- a/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/ts/src/internals/skipruntime_impl.ts
@@ -6,6 +6,7 @@ import type {
   Accumulator,
   EagerCollection,
   LazyCollection,
+  AsyncLazyCollection,
   Mapper,
   InputMapper,
   OutputMapper,
@@ -27,6 +28,7 @@ import type {
   Local,
   EntryPoint,
   Inputs,
+  ExternalCall,
 } from "../skipruntime_api.js";
 
 // prettier-ignore
@@ -455,6 +457,31 @@ export class SKStoreImpl extends SkFrozen implements SKStore {
       (key: K, params: P) => computeObj.call(key, params),
     );
     return new LazyCollectionImpl<K, Loadable<V, M>>(this.context, lazyHdl);
+  }
+
+  external<
+    K extends TJSON,
+    V extends TJSON,
+    Metadata extends TJSON,
+    Params extends Param[],
+  >(
+    refreshToken: string,
+    compute: new (...params: Params) => ExternalCall<K, V, Metadata>,
+    ...params: Params
+  ): AsyncLazyCollection<K, V, Metadata> {
+    params.forEach(check);
+    const computeObj = new compute(...params);
+    const name = computeObj.constructor.name;
+    Object.freeze(computeObj);
+    const lazyHdl = this.context.asyncLazy<K, V, number, TJSON>(
+      name,
+      (_key: K) => this.getRefreshToken(refreshToken),
+      (key: K, timestamp: number) => computeObj.call(key, timestamp),
+    );
+    return new LazyCollectionImpl<K, Loadable<V, Metadata>>(
+      this.context,
+      lazyHdl,
+    );
   }
 
   getRefreshToken(key: string) {

--- a/skipruntime-ts/ts/src/skip-runtime.ts
+++ b/skipruntime-ts/ts/src/skip-runtime.ts
@@ -62,6 +62,7 @@ export type {
   Loadable,
   AsyncLazyCollection,
   EntryPoint,
+  ExternalCall,
 } from "./skipruntime_api.js";
 
 export { ValueMapper } from "./skipruntime_api.js";

--- a/skipruntime-ts/ts/src/skipruntime_api.ts
+++ b/skipruntime-ts/ts/src/skipruntime_api.ts
@@ -528,6 +528,14 @@ export interface AsyncLazyCompute<
   call: (key: K, params: P) => Promise<AValue<V, M>>;
 }
 
+export interface ExternalCall<
+  K extends TJSON,
+  V extends TJSON,
+  Metadata extends TJSON,
+> {
+  call(key: K, timestamp: number): Promise<AValue<V, Metadata>>;
+}
+
 export interface SKStore extends Constant {
   /**
    * Creates a lazy reactive collection.
@@ -555,6 +563,17 @@ export interface SKStore extends Constant {
     compute: new (...params: Params) => AsyncLazyCompute<K, V, P, M>,
     ...params: Params
   ): AsyncLazyCollection<K, V, M>;
+
+  external<
+    K extends TJSON,
+    V extends TJSON,
+    Metadata extends TJSON,
+    Params extends Param[],
+  >(
+    refreshToken: string,
+    compute: new (...params: Params) => ExternalCall<K, V, Metadata>,
+    ...params: Params
+  ): AsyncLazyCollection<K, V, Metadata>;
 
   getRefreshToken: (key: string) => RefreshToken;
 


### PR DESCRIPTION
Adds a new `externalCall` operation on the SKStore context, which lets you set up an async lazy collection over some arbitrary async function, automatically wiring up a refresh token to govern polling frequency.