### PR TITLE
Add target to update JS dependencies, and run it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ build/init.sql: sql/privacy/init.sql
 # dev workflow orchestration
 ################################################################################
 
+.PHONY: update-js-deps
+update-js-deps:
+	find . -name node_modules -not -prune -or -name target -not -prune -or -name package.json -exec sh -c 'cd $$(dirname "$$0"); bun update --latest' {} \;
+
 CHECK_TARGETS=$(patsubst %/Skargo.toml,check-%,$(shell ls -1 */Skargo.toml))
 
 check-%:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@types/node": "^22.5.4",
-    "prettier": "^3.0.3"
+    "@types/node": "^22.5.5",
+    "prettier": "^3.3.3"
   }
 }

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -12,6 +12,6 @@
     "skdb": "^0.0.67"
   },
   "devDependencies": {
-    "typescript": "^5.0.2"
+    "typescript": "^5.6.2"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,11 +10,11 @@
     "copy-files": "cp -r ./src/assets ./dist/ && cp ./src/dev-console.css ./dist/"
   },
   "dependencies": {
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "skdb": "^0.0.67"
   },
   "devDependencies": {
-    "@types/react": "^18.2.15",
-    "typescript": "^5.0.2"
+    "@types/react": "^18.3.8",
+    "typescript": "^5.6.2"
   }
 }

--- a/prelude/ts/src/package.json
+++ b/prelude/ts/src/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@types/node": "^22.5.4"
+    "@types/node": "^22.5.5"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/skdate/ts/src/package.json
+++ b/skdate/ts/src/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
   "devDependencies": {
-    "@types/node": "^22.5.4"
+    "@types/node": "^22.5.5"
   }
 }

--- a/skipruntime-ts/ts/tests/package.json
+++ b/skipruntime-ts/ts/tests/package.json
@@ -1,11 +1,11 @@
 {
   "type": "module",
   "dependencies": {
-    "@playwright/test": "^1.36.2",
+    "@playwright/test": "^1.47.2",
     "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/node": "^22.5.5",
-    "prettier": "3.2.5"
+    "prettier": "3.3.3"
   }
 }

--- a/skjson/ts/src/package.json
+++ b/skjson/ts/src/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
   "devDependencies": {
-    "@types/node": "^22.5.4"
+    "@types/node": "^22.5.5"
   }
 }

--- a/skmd/ts/src/package.json
+++ b/skmd/ts/src/package.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "chokidar": "^3.5.3",
-    "express": "^4.18.2",
+    "chokidar": "^4.0.1",
+    "express": "^4.21.0",
     "mime-types": "^2.1.35",
-    "sass": "^1.69.0"
+    "sass": "^1.79.3"
   },
   "devDependencies": {
-    "@types/node": "^22.5.4"
+    "@types/node": "^22.5.5"
   }
 }

--- a/sknpm/resources/tests/package.json
+++ b/sknpm/resources/tests/package.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
-    "@playwright/test": "^1.36.2",
+    "@playwright/test": "^1.47.2",
     "ws": "^8.18.0"
   },
   "type": "module",
   "devDependencies": {
-    "@types/node": "^22.5.4"
+    "@types/node": "^22.5.5"
   }
 }

--- a/sql/ts/bun/package.json
+++ b/sql/ts/bun/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "dependencies": {
-    "skdb": "^0.0.60",
+    "skdb": "^0.0.67",
     "chalk": "^5.3.0"
   }
 }

--- a/sql/ts/src/package.json
+++ b/sql/ts/src/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@types/node": "^22.5.4"
+    "@types/node": "^22.5.5"
   },
   "type": "module"
 }

--- a/sql/ts/tests/package.json
+++ b/sql/ts/tests/package.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
-    "@playwright/test": "^1.36.2",
+    "@playwright/test": "^1.47.2",
     "ws": "^8.18.0"
   },
   "type": "module",
   "devDependencies": {
-    "@types/node": "^22.5.4"
+    "@types/node": "^22.5.5"
   }
 }

--- a/sql/ts/vitejs/package.json
+++ b/sql/ts/vitejs/package.json
@@ -10,19 +10,19 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "skdb": "^0.0.60"
+    "skdb": "^0.0.67"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^6.14.0",
-    "@typescript-eslint/parser": "^6.14.0",
-    "eslint": "^8.55.0",
-    "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.4.5",
-    "express": "^4.19.1",
+    "@typescript-eslint/eslint-plugin": "^8.6.0",
+    "@typescript-eslint/parser": "^8.6.0",
+    "eslint": "^9.11.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-refresh": "^0.4.12",
+    "express": "^4.21.0",
     "mime-types": "^2.1.35",
-    "sass": "^1.69.0",
+    "sass": "^1.79.3",
     "chalk": "^5.3.0",
-    "typescript": "^5.2.2",
-    "vite": "5.1.7"
+    "typescript": "^5.6.2",
+    "vite": "5.4.7"
   }
 }

--- a/www/package.json
+++ b/www/package.json
@@ -17,20 +17,20 @@
   "dependencies": {
     "@docusaurus/core": "3.5.2",
     "@docusaurus/preset-classic": "3.5.2",
-    "@mdx-js/react": "^3.0.0",
-    "clsx": "^2.0.0",
-    "prism-react-renderer": "^2.3.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "@mdx-js/react": "^3.0.1",
+    "clsx": "^2.1.1",
+    "prism-react-renderer": "^2.4.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.5.2",
     "@docusaurus/tsconfig": "3.5.2",
     "@docusaurus/types": "3.5.2",
     "docusaurus-plugin-typedoc": "^1.0.5",
-    "typedoc": "^0.26.6",
-    "typedoc-plugin-markdown": "^4.2.6",
-    "typescript": "~5.5.2"
+    "typedoc": "^0.26.7",
+    "typedoc-plugin-markdown": "^4.2.8",
+    "typescript": "~5.6.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Add a target so that `make update-js-deps` finds every package.json in the repo and updates the versions of dependencies to the latest.