### PR TITLE
[skipruntime] Fix wasm import.

### DIFF
--- a/skipruntime-ts/ts/src/skip-runtime.ts
+++ b/skipruntime-ts/ts/src/skip-runtime.ts
@@ -85,11 +85,11 @@ async function wasmUrl(): Promise<URL> {
   if (import.meta.env || import.meta.webpack) {
     /* eslint-disable @typescript-eslint/no-unsafe-return */
     //@ts-expect-error  Cannot find module './skstore.wasm?url' or its corresponding type declarations.
-    return await import("./skip-runtime.wasm?url");
+    return await import("./libskip-runtime.wasm?url");
     /* eslint-enable @typescript-eslint/no-unsafe-return */
   }
 
-  return new URL("./skip-runtime.wasm", import.meta.url);
+  return new URL("./libskip-runtime.wasm", import.meta.url);
 }
 
 export async function createSKStore(


### PR DESCRIPTION
Following #340, wasm libraries are now exported as `lib{package-name}.wasm` instead of `{package-name}.wasm`.