### PR TITLE
Consolidate npm packages around npm workspaces.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ check: $(CHECK_TARGETS)
 clean:
 	rm -Rf build
 	find . -name 'Skargo.toml' -print0 | sed 's|Skargo.toml|target|g' | xargs -0 rm -rf
+	npm run clean
 
 .PHONY: clean-all
 clean-all: clean

--- a/package.json
+++ b/package.json
@@ -1,4 +1,17 @@
 {
+  "workspaces": [
+    "eslint-config",
+    "tsconfig",
+    "prelude/ts",
+    "skdate/ts",
+    "skjson/ts",
+    "replication",
+    "skipruntime-ts/ts",
+    "skipruntime-ts/ts/tests",
+    "skipruntime-ts/ts/examples",
+    "sql/ts",
+    "sql/ts/tests"
+  ],
   "devDependencies": {
     "typescript": "^5.6.2",
     "@types/node": "^22.5.5",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,11 @@
     "sql/ts/tests"
   ],
   "devDependencies": {
-    "typescript": "^5.6.2",
     "@types/node": "^22.5.5",
-    "prettier": "^3.3.3"
+    "eslint": "^9.9.0",
+    "eslint-config-skiplabs": "^1.0.0",
+    "prettier": "^3.3.3",
+    "tsconfig-skiplabs": "^1.0.0",
+    "typescript": "^5.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,11 @@
     "prettier": "^3.3.3",
     "tsconfig-skiplabs": "^1.0.0",
     "typescript": "^5.6.2"
+  },
+  "scripts": {
+    "build": "npm run build --workspaces --if-present",
+    "clean": "npm run clean --workspaces --if-present",
+    "lint": "npm run lint --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present"
   }
 }

--- a/prelude/ts/package.json
+++ b/prelude/ts/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "std",
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,8 +33,8 @@
     "typescript": "^5.6.2",
     "@types/node": "^22.5.5",
     "@types/ws": "^8.5.12",
-    "eslint-config-skiplabs": "file:../../eslint-config",
-    "tsconfig-skiplabs": "file:../../tsconfig"
+    "eslint-config-skiplabs": "^1.0.0",
+    "tsconfig-skiplabs": "^1.0.0"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/prelude/ts/package.json
+++ b/prelude/ts/package.json
@@ -30,11 +30,7 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "typescript": "^5.6.2",
-    "@types/node": "^22.5.5",
-    "@types/ws": "^8.5.12",
-    "eslint-config-skiplabs": "^1.0.0",
-    "tsconfig-skiplabs": "^1.0.0"
+    "@types/ws": "^8.5.12"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/prelude/ts/package.json
+++ b/prelude/ts/package.json
@@ -27,7 +27,9 @@
     }
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "lint": "eslint"
   },
   "devDependencies": {
     "@types/ws": "^8.5.12"

--- a/replication/package.json
+++ b/replication/package.json
@@ -16,6 +16,8 @@
   },
   "scripts": {
     "build": "tsc",
+    "clean": "rm -rf dist",
+    "lint": "eslint",
     "test": "mocha"
   },
   "author": "SkipLabs",

--- a/replication/package.json
+++ b/replication/package.json
@@ -29,7 +29,7 @@
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
     "eslint": "^9.9.0",
-    "eslint-config-skiplabs": "file:../eslint-config",
-    "tsconfig-skiplabs": "file:../tsconfig"
+    "eslint-config-skiplabs": "^1.0.0",
+    "tsconfig-skiplabs": "^1.0.0"
   }
 }

--- a/replication/package.json
+++ b/replication/package.json
@@ -26,10 +26,6 @@
     "@types/ws": "^8.5.12",
     "earl": "^1.3.0",
     "mocha": "^10.7.3",
-    "tsx": "^4.19.1",
-    "typescript": "^5.6.2",
-    "eslint": "^9.9.0",
-    "eslint-config-skiplabs": "^1.0.0",
-    "tsconfig-skiplabs": "^1.0.0"
+    "tsx": "^4.19.1"
   }
 }

--- a/skdate/ts/package.json
+++ b/skdate/ts/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "skdate",
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/sk_date.js",
   "types": "./dist/sk_date.d.ts",
@@ -20,10 +22,10 @@
     "@types/ws": "^8.5.12",
     "prettier": "3.2.5",
     "eslint": "^9.9.0",
-    "eslint-config-skiplabs": "file:../../eslint-config",
-    "tsconfig-skiplabs": "file:../../tsconfig"
+    "eslint-config-skiplabs": "^1.0.0",
+    "tsconfig-skiplabs": "^1.0.0"
   },
   "dependencies": {
-    "std": "file:../../prelude/ts"
+    "std": "^1.0.0"
   }
 }

--- a/skdate/ts/package.json
+++ b/skdate/ts/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "eslint ."
+    "clean": "rm -rf dist",
+    "lint": "eslint"
   },
   "devDependencies": {
     "@playwright/test": "^1.36.2",

--- a/skdate/ts/package.json
+++ b/skdate/ts/package.json
@@ -15,15 +15,9 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "typescript": "^5.6.2",
     "@playwright/test": "^1.36.2",
     "@types/express": "^4.17.21",
-    "@types/node": "^22.6.0",
-    "@types/ws": "^8.5.12",
-    "prettier": "3.2.5",
-    "eslint": "^9.9.0",
-    "eslint-config-skiplabs": "^1.0.0",
-    "tsconfig-skiplabs": "^1.0.0"
+    "@types/ws": "^8.5.12"
   },
   "dependencies": {
     "std": "^1.0.0"

--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -5,83 +5,59 @@ SKARGO_PROFILE?=release
 SCRIPT_DIR=$(shell dirname $(shell realpath $(firstword $(MAKEFILE_LIST))))
 
 
-.PHONY: replication
-replication:
-	cd ../replication && npm i && npm run build
-
-.PHONY: skjson
-skjson:
-	cd ../skjson/ts && npm i && npm run build
-
-.PHONY: prelude
-prelude:
-	cd ../prelude/ts && npm i && npm run build
-
-.PHONY: eslint-config
-eslint-config:
-	cd ../eslint-config && npm i
-
 .PHONY: check-src
-check-src: eslint-config prelude skjson replication
+check-src: build
 	echo "make: Entering directory '${SCRIPT_DIR}/ts'"
-	cd ts && npm install && npm run build && npm run lint
+	cd ts && npm run lint
 	echo "make: Leaving directory '${SCRIPT_DIR}/ts'"
 
 .PHONY: check-examples
-check-examples: eslint-config prelude skjson replication
-	cd ts && npm i && npm run build
-	cd ts/examples && npm install
+check-examples: build
 	echo "make: Entering directory '${SCRIPT_DIR}/ts/examples'"
-	cd ts/examples && npm run build && npm run lint
+	cd ts/examples && npm run lint
 	echo "make: Leaving directory '${SCRIPT_DIR}/ts/examples'"
 
 .PHONY: check-tests
-check-tests: eslint-config prelude skjson replication
-	cd ts && npm i && npm run build
-	cd ts/tests && npm install && npm run build && npm run lint
+check-tests: build
+	echo "make: Entering directory '${SCRIPT_DIR}/ts/tests'"
+	cd ts/tests && npm run lint
+	echo "make: Leaving directory '${SCRIPT_DIR}/ts/tests'"
 
 .PHONY: check-all
-check-all: check-src # check-tests check-examples
+check-all: build check-src # check-tests check-examples
 
 .PHONY: build
-build: prelude skjson replication
-	cd ts && npm i && npm run build
+build:
+	cd .. && npm install && npm run build
 
-bunrun-%: build
-	cd ts/examples && bun install && bun run $*.ts
+.PHONY: bunbuild
+bunbuild:
+	cd .. && bum install && bun run build
 
-bunclient-%: build
-	cd ts/examples && bun install && bun run $*-client.ts
+bunrun-%: bunbuild
+	bun run ts/examples/$*.ts
 
-bunserver-%: build
-	cd ts/examples && bun install && bun run $*-server.ts
+bunclient-%: bunbuild
+	bun run ts/examples/$*-client.ts
 
-check-%:
-	cd ts/examples && npm install
-	npx tsc -- --project ts/examples/tsconfig.json
+bunserver-%: bunbuild
+	bun run ts/examples/$*-server.ts
 
 noderun-%: build
-	cd ts/examples && npm install
-	npx tsc -- --project ts/examples/tsconfig.json
-	cd ts/examples && node dist/$*.js
+	node ts/examples/dist/$*.js
 
 nodeclient-%: build
-	cd ts/examples && npm install
-	npx tsc -- --project ts/examples/tsconfig.json
-	cd ts/examples && node dist/$*-client.js
+	node ts/examples/dist/$*-client.js
 
 nodeserver-%: build
-	cd ts/examples && npm install
-	npx tsc -- --project ts/examples/tsconfig.json
-	cd ts/examples && node dist/$*-server.js
+	node ts/examples/dist/&*-server.js
 
 .PHONY: clean
 clean:
-	rm -rf ./ts/dist ./ts/playwright-report ./ts/test-results
+	rm -rf ./ts/playwright-report ./ts/test-results
 	cd .. && make clean
 
 .PHONY: test
 test: build
-	cd ts/tests && npm i && npm run build
 	cd ts/tests && npx playwright install
 	cd ts/tests && npx playwright test --reporter=line

--- a/skipruntime-ts/ts/examples/package.json
+++ b/skipruntime-ts/ts/examples/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "skipruntime-examples",
   "type": "module",
   "scripts": {
     "build": "tsc",
@@ -8,12 +9,12 @@
     "typescript": "^5.6.2",
     "@types/sqlite3": "^3.1.11",
     "eslint": "^9.11.0",
-    "eslint-config-skiplabs": "file:../../../eslint-config",
-    "tsconfig-skiplabs": "file:../../tsconfig"
+    "eslint-config-skiplabs": "^1.0.0",
+    "tsconfig-skiplabs": "^1.0.0"
   },
   "dependencies": {
     "sqlite3": "^5.1.7",
-    "skip-runtime": "file:../",
-    "skipruntime-replication-client": "file:../../../replication"
+    "skip-runtime": "^1.0.0",
+    "skipruntime-replication-client": "^1.0.0"
   }
 }

--- a/skipruntime-ts/ts/examples/package.json
+++ b/skipruntime-ts/ts/examples/package.json
@@ -6,11 +6,7 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "typescript": "^5.6.2",
-    "@types/sqlite3": "^3.1.11",
-    "eslint": "^9.11.0",
-    "eslint-config-skiplabs": "^1.0.0",
-    "tsconfig-skiplabs": "^1.0.0"
+    "@types/sqlite3": "^3.1.11"
   },
   "dependencies": {
     "sqlite3": "^5.1.7",

--- a/skipruntime-ts/ts/examples/package.json
+++ b/skipruntime-ts/ts/examples/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint ."
+    "clean": "rm -rf dist",
+    "lint": "eslint"
   },
   "devDependencies": {
     "@types/sqlite3": "^3.1.11"

--- a/skipruntime-ts/ts/package.json
+++ b/skipruntime-ts/ts/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "skip-runtime",
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/skip-runtime.js",
   "types": "./dist/skip-runtime.d.ts",
@@ -18,14 +20,14 @@
     "typescript": "^5.6.2",
     "@types/express": "^4.17.21",
     "eslint": "^9.11.0",
-    "eslint-config-skiplabs": "file:../../eslint-config",
-    "tsconfig-skiplabs": "file:../../tsconfig"
+    "eslint-config-skiplabs": "^1.0.0",
+    "tsconfig-skiplabs": "^1.0.0"
   },
   "dependencies": {
     "express": "^4.21.0",
-    "skjson": "file:../../skjson/ts",
-    "std": "file:../../prelude/ts",
-    "skipruntime-replication-client": "file:../../replication",
+    "skjson": "^1.0.0",
+    "std": "^1.0.0",
+    "skipruntime-replication-client": "^1.0.0",
     "ws": "^8.18.0"
   }
 }

--- a/skipruntime-ts/ts/package.json
+++ b/skipruntime-ts/ts/package.json
@@ -12,7 +12,9 @@
   },
   "scripts": {
     "build": "tsc && skargo build -r --target wasm32-unknown-unknown --lib --manifest-path=../Skargo.toml --out-dir=./dist/",
-    "lint": "eslint src/"
+    "clean": "rm -rf dist",
+    "lint": "eslint src/",
+    "test": "cd tests && npm run build && npm run test"
   },
   "devDependencies": {
     "@types/ws": "^8.5.12",

--- a/skipruntime-ts/ts/package.json
+++ b/skipruntime-ts/ts/package.json
@@ -15,13 +15,8 @@
     "lint": "eslint src/"
   },
   "devDependencies": {
-    "@types/node": "^22.5.5",
     "@types/ws": "^8.5.12",
-    "typescript": "^5.6.2",
-    "@types/express": "^4.17.21",
-    "eslint": "^9.11.0",
-    "eslint-config-skiplabs": "^1.0.0",
-    "tsconfig-skiplabs": "^1.0.0"
+    "@types/express": "^4.17.21"
   },
   "dependencies": {
     "express": "^4.21.0",

--- a/skipruntime-ts/ts/tests/package.json
+++ b/skipruntime-ts/ts/tests/package.json
@@ -3,7 +3,9 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint ."
+    "clean": "rm -rf dist",
+    "lint": "eslint",
+    "test": "npx playwright test --reporter=line"
   },
   "devDependencies": {
     "@playwright/test": "^1.47.2",

--- a/skipruntime-ts/ts/tests/package.json
+++ b/skipruntime-ts/ts/tests/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "skipruntime-tests",
   "type": "module",
   "scripts": {
     "build": "tsc",
@@ -11,14 +12,14 @@
     "@types/node": "^22.5.5",
     "@types/ws": "^8.5.12",
     "eslint": "^9.9.0",
-    "eslint-config-skiplabs": "file:../../../eslint-config"
+    "eslint-config-skiplabs": "^1.0.0"
   },
   "dependencies": {
     "express": "^4.21.0",
-    "skipruntime-replication-client": "file:../../../replication",
-    "skjson": "file:../../../skjson/ts",
-    "std": "file:../../../prelude/ts",
-    "skip-runtime": "file:../",
+    "skipruntime-replication-client": "^1.0.0",
+    "skjson": "^1.0.0",
+    "std": "^1.0.0",
+    "skip-runtime": "^1.0.0",
     "ws": "^8.18.0"
   }
 }

--- a/skipruntime-ts/ts/tests/package.json
+++ b/skipruntime-ts/ts/tests/package.json
@@ -6,13 +6,9 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "typescript": "^5.6.2",
     "@playwright/test": "^1.47.2",
     "@types/express": "^4.17.21",
-    "@types/node": "^22.5.5",
-    "@types/ws": "^8.5.12",
-    "eslint": "^9.9.0",
-    "eslint-config-skiplabs": "^1.0.0"
+    "@types/ws": "^8.5.12"
   },
   "dependencies": {
     "express": "^4.21.0",

--- a/skjson/ts/package.json
+++ b/skjson/ts/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "skjson",
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/skjson.js",
   "types": "./dist/skjson.d.ts",
@@ -19,10 +21,10 @@
     "typescript": "^5.6.2",
     "@types/node": "^22.5.5",
     "eslint": "^9.9.0",
-    "eslint-config-skiplabs": "file:../../eslint-config",
-    "tsconfig-skiplabs": "file:../../tsconfig"
+    "eslint-config-skiplabs": "^1.0.0",
+    "tsconfig-skiplabs": "^1.0.0"
   },
   "dependencies": {
-    "std": "file:../../prelude/ts"
+    "std": "^1.0.0"
   }
 }

--- a/skjson/ts/package.json
+++ b/skjson/ts/package.json
@@ -15,7 +15,9 @@
     }
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "lint": "eslint"
   },
   "dependencies": {
     "std": "^1.0.0"

--- a/skjson/ts/package.json
+++ b/skjson/ts/package.json
@@ -17,13 +17,6 @@
   "scripts": {
     "build": "tsc"
   },
-  "devDependencies": {
-    "typescript": "^5.6.2",
-    "@types/node": "^22.5.5",
-    "eslint": "^9.9.0",
-    "eslint-config-skiplabs": "^1.0.0",
-    "tsconfig-skiplabs": "^1.0.0"
-  },
   "dependencies": {
     "std": "^1.0.0"
   }

--- a/sql/Makefile
+++ b/sql/Makefile
@@ -4,30 +4,10 @@ SKARGO_PROFILE?=release
 
 SCRIPT_DIR=$(shell dirname $(shell realpath $(firstword $(MAKEFILE_LIST))))
 
-.PHONY: eslint
-eslint:
-	cd ../eslint-config && npm i
-
-.PHONY: tsconfig
-tsconfig:
-	cd ../tsconfig && npm i
-
-.PHONY: skdate
-skdate:
-	cd ../skdate/ts && npm i && npm run build
-
-.PHONY: skjson
-skjson:
-	cd ../skjson/ts && npm i && npm run build
-
-.PHONY: prelude
-prelude:
-	cd ../prelude/ts && npm i && npm run build
-
 .PHONY: check-src
-check-src: eslint
+check-src: build
 	echo "make: Entering directory '${SCRIPT_DIR}/ts'"
-	cd ts/ && npm install && npm run build && npm run lint
+	cd ts/ && npm run lint
 	echo "make: Leaving directory '${SCRIPT_DIR}/ts'"
 
 .PHONY: check-tests
@@ -38,11 +18,8 @@ check-tests: eslint
 check-all: check-src check-tests
 
 .PHONY: build
-build: tsconfig prelude skjson skdate
-	cd ../prelude/ts && npm i && npm run build
-	cd ../skjson/ts && npm i && npm run build
-	cd ../skdate/ts && npm i && npm run build
-	cd ts && npm i && npm run build
+build:
+	cd .. && npm i && npm run build
 
 .PHONY: clean
 clean:
@@ -51,7 +28,6 @@ clean:
 
 .PHONY: install-test
 install-test: build
-	cd ts/tests && npm i && npm run build
 	cd ts/tests && npx playwright install
 
 .PHONY: test

--- a/sql/ts/package.json
+++ b/sql/ts/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "skdb",
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/skdb.js",
   "types": "./dist/skdb.d.ts",
@@ -24,12 +26,12 @@
     "@types/ws": "^8.5.12",
     "prettier": "3.2.5",
     "eslint": "^9.9.0",
-    "eslint-config-skiplabs": "file:../../eslint-config",
-    "tsconfig-skiplabs": "file:../../tsconfig"
+    "eslint-config-skiplabs": "^1.0.0",
+    "tsconfig-skiplabs": "^1.0.0"
   },
   "dependencies": {
-    "std": "file:../../prelude/ts",
-    "skdate": "file:../../skdate/ts",
-    "skjson": "file:../../skjson/ts"
+    "std": "^1.0.0",
+    "skdate": "^1.0.0",
+    "skjson": "^1.0.0"
   }
 }

--- a/sql/ts/package.json
+++ b/sql/ts/package.json
@@ -11,8 +11,9 @@
     }
   },
   "scripts": {
-    "lint": "eslint .",
     "build": "tsc && skargo build -r --target wasm32-unknown-unknown --lib --manifest-path=../Skargo.toml --out-dir=./dist/",
+    "clean": "rm -rf dist",
+    "lint": "eslint",
     "cli": "node ./dist/skdb-cli.js"
   },
   "bin": {

--- a/sql/ts/package.json
+++ b/sql/ts/package.json
@@ -19,15 +19,9 @@
     "skdb-cli": "./dist/skdb-cli.js"
   },
   "devDependencies": {
-    "typescript": "^5.6.2",
     "@playwright/test": "^1.36.2",
     "@types/express": "^4.17.21",
-    "@types/node": "^22.6.0",
-    "@types/ws": "^8.5.12",
-    "prettier": "3.2.5",
-    "eslint": "^9.9.0",
-    "eslint-config-skiplabs": "^1.0.0",
-    "tsconfig-skiplabs": "^1.0.0"
+    "@types/ws": "^8.5.12"
   },
   "dependencies": {
     "std": "^1.0.0",

--- a/sql/ts/tests/node_modules
+++ b/sql/ts/tests/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules/

--- a/sql/ts/tests/package.json
+++ b/sql/ts/tests/package.json
@@ -1,12 +1,13 @@
 {
+  "name": "skdb-tests",
   "type": "module",
   "dependencies": {
     "@playwright/test": "^1.47.2",
     "ws": "^8.18.0",
-    "skdate": "file:../../../skdate/ts",
-    "skjson": "file:../../../skjson/ts",
-    "std": "file:../../../prelude/ts",
-    "skdb": "file:../"
+    "skdate": "^1.0.0",
+    "skjson": "^1.0.0",
+    "std": "^1.0.0",
+    "skdb": "^1.0.0"
   },
   "devDependencies": {
     "typescript": "^5.6.2",

--- a/sql/ts/tests/package.json
+++ b/sql/ts/tests/package.json
@@ -10,17 +10,9 @@
     "skdb": "^1.0.0"
   },
   "devDependencies": {
-    "typescript": "^5.6.2",
-    "@eslint/js": "^9.9.1",
     "@playwright/test": "^1.36.2",
-    "@stylistic/eslint-plugin-js": "^2.6.4",
     "@types/express": "^4.17.21",
-    "@types/node": "^22.6.0",
-    "@types/ws": "^8.5.12",
-    "@typescript-eslint/parser": "^8.3.0",
-    "eslint-plugin-jsdoc": "^50.2.2",
-    "prettier": "3.2.5",
-    "typescript-eslint": "^8.3.0"
+    "@types/ws": "^8.5.12"
   },
   "scripts": {
     "build": "tsc",

--- a/sql/ts/tests/package.json
+++ b/sql/ts/tests/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "eslint ."
+    "clean": "rm -rf dist",
+    "lint": "eslint"
   }
 }


### PR DESCRIPTION
This has several benefits for a monorepo such as ours:
- shared `node_modules/` directory (at the root),
- shared (dev) dependencies (we can specify common
typescript/nodejs/eslint versions in the root `package.json`),
- installing all dependencies for all packages with `npm install` at
the root,
- building/linting all packages in one go with:
```
$ npm run build --workspaces --if-present
```
- no need to replace the `file:...` dependencies with version strings
when publishing.

One caveat is that running commands on all packages with `npm run foo
--workspaces` will run them in the order of packages within the
`workspaces` key of the root `package.json`. This matters for instance
for `npm run build --workspaces` as each package needs its
dependencies' type declarations (generated by `tsc`).