### PR TITLE
[skipruntime-ts] Improvements on TimedQueue

### DIFF
--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1238,7 +1238,7 @@ class LinksImpl implements Links {
       // Get a run uuid to build to allow function mapping reload in case of persistence
       const uuid = this.env.crypto().randomUUID();
       const jsu = skjson();
-      const time = new Date().getTime();
+      const time = Date.now();
       const result = utils.runWithGc(() =>
         Math.trunc(
           fromWasm.SkipRuntime_createFor(
@@ -1432,7 +1432,7 @@ export class TimedQueue {
   }
 
   check() {
-    const time = new Date().getTime();
+    const time = Date.now();
     const torenew = new Map<number, TQ_Token[]>();
     let i = 0;
     for (i; i < this.queue.length; i++) {

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1397,11 +1397,10 @@ type TQ_Elt = {
 };
 
 export class TimedQueue {
-  constructor(
-    private update: (time: number, tokens: string[]) => void,
-    private queue: TQ_Elt[] = [],
-    private timeout: string | number | Timeout | null = null,
-  ) {}
+  private queue: TQ_Elt[] = [];
+  private timeout: string | number | Timeout | null = null;
+
+  constructor(private update: (time: number, tokens: string[]) => void) {}
 
   start(tokens: TQ_Token[], time: number) {
     const tostart = new Map<number, TQ_Token[]>();

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1466,6 +1466,9 @@ export class TimedQueue {
   }
 
   start(tokens: TQ_Token[], time: number): void {
+    if (this.timeout) {
+      throw new Error(`TimedQueue already started!`);
+    }
     this.add(tokens, time);
     this.schedule();
   }

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1415,11 +1415,11 @@ export class TimedQueue {
         tostart.set(endtime, [token]);
       }
     }
-    this.queue = [];
-    const keys = Array.from(tostart.keys()).sort();
-    for (const key of keys) {
-      this.queue.push({ endtime: key, tokens: tostart.get(key)! });
-    }
+    this.queue = Array.from(tostart, ([endtime, tokens]) => ({
+      endtime,
+      tokens,
+    }));
+    this.queue.sort((a, b) => a.endtime - b.endtime);
     if (this.queue.length > 0) {
       const next = Math.max(this.queue[0].endtime - time, 0);
       this.timeout = setTimeout(() => {

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1401,7 +1401,11 @@ export class TimedQueue {
   start(tokens: TQ_Token[], time: number): void {
     const tostart = new Map<number, TQ_Token[]>();
     for (const token of tokens) {
-      if (token.interval <= 0) continue;
+      if (token.interval < 1 || token.interval > 2147483647) {
+        throw new Error(
+          `Invalid interval ${token.interval} for token '${token.ident}'. The interval must be between 1 and 2147483647.`,
+        );
+      }
       const endtime = time + token.interval;
       const current = tostart.get(endtime);
       if (current) {

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1435,7 +1435,7 @@ export class TimedQueue {
     }
   }
 
-  check(): void {
+  private check(): void {
     const time = Date.now();
     const torenew = new Map<number, TQ_Token[]>();
     let i = 0;

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1463,6 +1463,17 @@ export class TimedQueue {
       const endtime = time + token.interval;
       this.queue.insert(endtime, token);
     }
+    this.schedule();
+  }
+
+  stop(): void {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      delete this.timeout;
+    }
+  }
+
+  private schedule(): void {
     const first = this.queue.peekPriority();
     if (first !== undefined) {
       const next = Math.max(first - Date.now(), 1);
@@ -1470,13 +1481,6 @@ export class TimedQueue {
         this.check();
       }, next);
       this.timeout.unref();
-    }
-  }
-
-  stop(): void {
-    if (this.timeout) {
-      clearTimeout(this.timeout);
-      delete this.timeout;
     }
   }
 
@@ -1496,14 +1500,7 @@ export class TimedQueue {
         this.queue.insert(endtime, token);
       }
     }
-    const first = this.queue.peekPriority();
-    if (first !== undefined) {
-      const next = Math.max(first - Date.now(), 1);
-      this.timeout = setTimeout(() => {
-        this.check();
-      }, next);
-      this.timeout.unref();
-    }
+    this.schedule();
   }
 }
 

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1449,7 +1449,6 @@ export class TimedQueue {
         this.queue[i].tokens.map((t) => t.ident),
       );
       for (const token of this.queue[i].tokens) {
-        if (token.interval <= 0) continue;
         let endtime = cendtime + token.interval;
         while (endtime <= time) endtime += token.interval;
         const current = torenew.get(endtime);

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1420,7 +1420,7 @@ export class TimedQueue {
     }));
     this.queue.sort((a, b) => a.endtime - b.endtime);
     if (this.queue.length > 0) {
-      const next = Math.max(this.queue[0].endtime - time, 0);
+      const next = Math.max(this.queue[0].endtime - Date.now(), 1);
       this.timeout = setTimeout(() => {
         this.check();
       }, next);
@@ -1466,7 +1466,7 @@ export class TimedQueue {
       this.insert({ endtime: key, tokens: torenew.get(key)! });
     }
     if (this.queue.length > 0) {
-      const next = Math.max(this.queue[0].endtime - time, 0);
+      const next = Math.max(this.queue[0].endtime - Date.now(), 1);
       this.timeout = setTimeout(() => {
         this.check();
       }, next);

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1453,7 +1453,7 @@ export class TimedQueue {
 
   constructor(private update: (time: number, tokens: string[]) => void) {}
 
-  start(tokens: TQ_Token[], time: number): void {
+  private add(tokens: TQ_Token[], time: number): void {
     for (const token of tokens) {
       if (token.interval < 1 || token.interval > 2147483647) {
         throw new Error(
@@ -1463,6 +1463,10 @@ export class TimedQueue {
       const endtime = time + token.interval;
       this.queue.insert(endtime, token);
     }
+  }
+
+  start(tokens: TQ_Token[], time: number): void {
+    this.add(tokens, time);
     this.schedule();
   }
 

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1398,7 +1398,7 @@ export class TimedQueue {
 
   constructor(private update: (time: number, tokens: string[]) => void) {}
 
-  start(tokens: TQ_Token[], time: number) {
+  start(tokens: TQ_Token[], time: number): void {
     const tostart = new Map<number, TQ_Token[]>();
     for (const token of tokens) {
       if (token.interval <= 0) continue;
@@ -1424,14 +1424,14 @@ export class TimedQueue {
     }
   }
 
-  stop() {
+  stop(): void {
     if (this.timeout) {
       clearTimeout(this.timeout);
       delete this.timeout;
     }
   }
 
-  check() {
+  check(): void {
     const time = Date.now();
     const torenew = new Map<number, TQ_Token[]>();
     let i = 0;
@@ -1471,7 +1471,7 @@ export class TimedQueue {
   }
 
   // TODO: Binary version
-  private insert(elt: TQ_Elt) {
+  private insert(elt: TQ_Elt): void {
     for (let i = 0; i < this.queue.length; i++) {
       if (this.queue[i].endtime == elt.endtime) {
         this.queue[i].tokens.push(...elt.tokens);

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1450,7 +1450,7 @@ export class TimedQueue {
       );
       for (const token of this.queue[i].tokens) {
         let endtime = cendtime + token.interval;
-        while (endtime <= time) endtime += token.interval;
+        if (endtime <= time) endtime = time + 1; // re-update was missed => reschedule ASAP
         const current = torenew.get(endtime);
         if (current) {
           current.push(token);

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1386,10 +1386,6 @@ class Manager implements ToWasmManager {
   };
 }
 
-interface Timeout {
-  unref: () => void;
-}
-
 type TQ_Token = { ident: string; interval: number };
 type TQ_Elt = {
   endtime: number;
@@ -1398,7 +1394,7 @@ type TQ_Elt = {
 
 export class TimedQueue {
   private queue: TQ_Elt[] = [];
-  private timeout: string | number | Timeout | null = null;
+  private timeout?: NodeJS.Timeout;
 
   constructor(private update: (time: number, tokens: string[]) => void) {}
 
@@ -1424,15 +1420,14 @@ export class TimedQueue {
       this.timeout = setTimeout(() => {
         this.check();
       }, next);
-      if (typeof this.timeout == "object" && "unref" in this.timeout) {
-        this.timeout.unref();
-      }
+      this.timeout.unref();
     }
   }
 
   stop() {
     if (this.timeout) {
-      clearTimeout(this.timeout as number);
+      clearTimeout(this.timeout);
+      delete this.timeout;
     }
   }
 
@@ -1471,9 +1466,7 @@ export class TimedQueue {
       this.timeout = setTimeout(() => {
         this.check();
       }, next);
-      if (typeof this.timeout == "object" && "unref" in this.timeout) {
-        this.timeout.unref();
-      }
+      this.timeout.unref();
     }
   }
 

--- a/skipruntime-ts/core/test/runtime.spec.ts
+++ b/skipruntime-ts/core/test/runtime.spec.ts
@@ -1024,7 +1024,7 @@ it("testTimedQueue", () => {
       tokens: tokens.sort(),
     });
   });
-  const rstarttime = new Date().getTime();
+  const rstarttime = Date.now();
   timedQueue.start(
     [
       { ident: "token_2s", interval: 2000 },


### PR DESCRIPTION
Mainly:
- using a binary heap for the priority queue
- [RFC] do not leap re-updates (see commit with the same title)
