### PR TITLE
[runtime] Switch from steady_clock to system_clock

### DIFF
--- a/prelude/runtime/runtime64_specific.cpp
+++ b/prelude/runtime/runtime64_specific.cpp
@@ -459,7 +459,7 @@ int64_t SKIP_time() {
 uint64_t SKIP_time_ms() {
   using namespace std::chrono;
 
-  return duration_cast<milliseconds>(steady_clock::now().time_since_epoch())
+  return duration_cast<milliseconds>(system_clock::now().time_since_epoch())
       .count();
 }
 


### PR DESCRIPTION
- system_clock is not monotonic (bad) (NTP adjustments, etc.) but counts from the Unix epoch (good)
  - steady_clock is monotonic (good) but counts from system boot (bad!)