### PR TITLE
SkipRuntime cleanups and doc comments

### DIFF
--- a/skipruntime-ts/core/native/src/Extern.sk
+++ b/skipruntime-ts/core/native/src/Extern.sk
@@ -984,8 +984,8 @@ fun getDiff(collection: String, from: Int): SKJSON.CJSON {
               "values",
               getAll_(context.unsafeGetEagerDir(DirName::create(collection))),
             ),
-            ("tick", SKJSON.CJInt(context.tick.value)),
-            ("update", SKJSON.CJBool(false)),
+            ("watermark", SKJSON.CJInt(context.tick.value)),
+            ("isInitial", SKJSON.CJBool(true)),
           ],
           x -> x,
         ),
@@ -1002,8 +1002,8 @@ fun getDiff(collection: String, from: Int): SKJSON.CJSON {
         SKJSON.CJFields::create(
           Array[
             ("values", SKJSON.CJArray(values.toArray())),
-            ("tick", SKJSON.CJInt(context.tick.value)),
-            ("update", SKJSON.CJBool(true)),
+            ("watermark", SKJSON.CJInt(context.tick.value)),
+            ("isInitial", SKJSON.CJBool(false)),
           ],
           x -> x,
         ),

--- a/skipruntime-ts/core/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_impl.ts
@@ -1,5 +1,5 @@
 import { type int, type ptr, type Opt, cloneIfProxy } from "std";
-import type { Context } from "./skipruntime_types.js";
+import type { Context as InternalContext } from "./skipruntime_types.js";
 import type * as Internal from "./skipruntime_internal_types.js";
 import type {
   Accumulator,
@@ -7,7 +7,7 @@ import type {
   LazyCollection,
   AsyncLazyCollection,
   Mapper,
-  SKStore,
+  Context,
   RuntimeFactory,
   Loadable,
   JSONObject,
@@ -75,7 +75,7 @@ export class EagerCollectionImpl<K extends TJSON, V extends TJSON>
   implements EagerCollection<K, V>
 {
   constructor(
-    private context: Context,
+    private context: InternalContext,
     private eagerHdl: string,
   ) {
     super();
@@ -193,7 +193,7 @@ class LazyCollectionImpl<K extends TJSON, V extends TJSON>
   implements LazyCollection<K, V>
 {
   constructor(
-    protected context: Context,
+    protected context: InternalContext,
     protected lazyHdl: string,
   ) {
     super();
@@ -218,7 +218,7 @@ export class LSelfImpl<K extends TJSON, V extends TJSON>
   implements LazyCollection<K, V>
 {
   constructor(
-    protected context: Context,
+    protected context: InternalContext,
     protected lazyHdl: ptr<Internal.LHandle>,
   ) {
     super();
@@ -238,8 +238,8 @@ export class LSelfImpl<K extends TJSON, V extends TJSON>
   }
 }
 
-export class SKStoreImpl extends SkFrozen implements SKStore {
-  constructor(private context: Context) {
+export class ContextImpl extends SkFrozen implements Context {
+  constructor(private context: InternalContext) {
     super();
     Object.freeze(this);
   }
@@ -322,7 +322,7 @@ export class SKStoreImpl extends SkFrozen implements SKStore {
 export class RuntimeFactoryImpl implements RuntimeFactory {
   //
   constructor(
-    private context: () => Context,
+    private internalContext: () => InternalContext,
     private create: (
       init: (
         collections: Record<string, EagerCollection<TJSON, TJSON>>,
@@ -439,7 +439,7 @@ export class EagerCollectionReader<K extends TJSON, V extends TJSON>
   implements CollectionReader<K, V>
 {
   constructor(
-    private context: Context,
+    private context: InternalContext,
     private eagerHdl: string,
   ) {}
 
@@ -475,7 +475,7 @@ export class EagerCollectionWriter<K extends TJSON, V extends TJSON>
   implements CollectionWriter<K, V>
 {
   constructor(
-    private context: Context,
+    private context: InternalContext,
     private eagerHdl: string,
   ) {}
 
@@ -494,7 +494,7 @@ export class EagerCollectionWriter<K extends TJSON, V extends TJSON>
 
 export class SkipRuntimeImpl implements SkipRuntime {
   constructor(
-    private context: Context,
+    private context: InternalContext,
     private writables: Record<string, CollectionWriter<TJSON, TJSON>>,
   ) {}
 

--- a/skipruntime-ts/core/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_impl.ts
@@ -24,7 +24,6 @@ import type {
   CollectionWriter,
   CallResourceCompute,
   Watermarked,
-  Notifier,
   ReactiveResponse,
   SkipBuilder,
 } from "../skipruntime_api.js";
@@ -467,8 +466,11 @@ export class EagerCollectionReader<K extends TJSON, V extends TJSON>
     return this.context.getDiff(this.eagerHdl, from);
   }
 
-  subscribe(from: string, notify: Notifier<K, V>): bigint {
-    return this.context.subscribe(this.eagerHdl, from, notify);
+  subscribe(
+    since: string,
+    f: (values: Entry<K, V>[], watermark: string, update: boolean) => void,
+  ): bigint {
+    return this.context.subscribe(this.eagerHdl, since, f);
   }
 }
 
@@ -587,10 +589,10 @@ export class SkipRuntimeImpl implements SkipRuntime {
 
   subscribe<K extends TJSON, V extends TJSON>(
     collectionName: string,
-    from: string,
-    notify: Notifier<K, V>,
+    since: string,
+    f: (values: Entry<K, V>[], watermark: string, update: boolean) => void,
   ) {
-    return this.context.subscribe(collectionName, from, notify);
+    return this.context.subscribe(collectionName, since, f);
   }
 
   unsubscribe(id: bigint): void {

--- a/skipruntime-ts/core/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_impl.ts
@@ -16,7 +16,7 @@ import type {
   LazyCompute,
   AsyncLazyCompute,
   NonEmptyIterator,
-  EntryPoint,
+  Entrypoint,
   ExternalCall,
   CollectionReader,
   SkipRuntime,
@@ -344,7 +344,7 @@ export class SKStoreFactoryImpl implements SKStoreFactory {
       collections: Record<string, EagerCollection<TJSON, TJSON>>,
     ) => CallResourceCompute,
     inputs: Record<string, [TJSON, TJSON][]> = {},
-    remotes: Record<string, EntryPoint> = {},
+    remotes: Record<string, Entrypoint> = {},
     tokens: Record<string, number> = {},
   ): SkipBuilder {
     const context = this.context();

--- a/skipruntime-ts/core/src/internals/skipruntime_impl.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_impl.ts
@@ -23,7 +23,7 @@ import type {
   Entry,
   CollectionWriter,
   CallResourceCompute,
-  Watermarked,
+  UpdatedValues,
   ReactiveResponse,
 } from "../skipruntime_api.js";
 import { UnknownCollectionError } from "../skipruntime_errors.js";
@@ -459,7 +459,7 @@ export class EagerCollectionReader<K extends TJSON, V extends TJSON>
     return this.context.getAll<K, V>(this.eagerHdl);
   }
 
-  getDiff(from: string): Watermarked<K, V> {
+  getDiff(from: string): UpdatedValues<K, V> {
     return this.context.getDiff(this.eagerHdl, from);
   }
 

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -21,7 +21,6 @@ import type {
   Entry,
   CollectionReader,
   CallResourceCompute,
-  Notifier,
   Watermarked,
 } from "../skipruntime_api.js";
 
@@ -538,8 +537,8 @@ export class ContextImpl implements Context {
 
   subscribe<K extends TJSON, V extends TJSON>(
     collectionName: string,
-    from: string,
-    nofify: Notifier<K, V>,
+    since: string,
+    f: (values: Entry<K, V>[], watermark: string, update: boolean) => void,
   ): bigint {
     const collection = this.resources[collectionName];
     if (!collection) {
@@ -550,8 +549,14 @@ export class ContextImpl implements Context {
     const result = this.skjson.runWithGC(() => {
       return this.exports.SkipRuntime_subscribe(
         this.skjson.exportString(collection),
-        BigInt(from),
-        this.handles.register(nofify as Notifier<TJSON, TJSON>),
+        BigInt(since),
+        this.handles.register(
+          f as (
+            values: Entry<TJSON, TJSON>[],
+            watermark: string,
+            update: boolean,
+          ) => void,
+        ),
       );
     });
     if (result < 0) {

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -37,7 +37,7 @@ import {
   EagerCollectionImpl,
   EagerCollectionReader,
   LSelfImpl,
-  SKStoreFactoryImpl,
+  RuntimeFactoryImpl,
 } from "./skipruntime_impl.js";
 import { UnknownCollectionError } from "../skipruntime_errors.js";
 
@@ -196,7 +196,7 @@ export class ContextImpl implements Context {
   getDiff<K extends TJSON, V extends TJSON>(collection: string, from: string) {
     const ctx = this.ref.get();
     if (ctx != null)
-      throw new Error("getDiff: Cannot be called durring update.");
+      throw new Error("getDiff: Cannot be called during update.");
     const result = this.skjson.runWithGC(() => {
       return this.skjson.clone(
         this.skjson.importJSON(
@@ -419,7 +419,7 @@ export class ContextImpl implements Context {
     ) as TJSON[];
   }
 
-  /* Must produce a valid SKStore key ideally with no collision */
+  /* Must produce a valid Skip key ideally with no collision */
   keyOfJSON(value: TJSON): string {
     return (
       "b64_" +
@@ -1243,8 +1243,8 @@ class LinksImpl implements Links {
       );
     };
     this.env.shared.set(
-      "SKStore",
-      new SKStoreFactoryImpl(
+      "SkipRuntimeFactory",
+      new RuntimeFactoryImpl(
         () => new ContextImpl(skjson(), fromWasm, this.handles, this.env, ref),
         create,
       ),

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -16,7 +16,6 @@ import type {
   EagerCollection,
   LazyCollection,
   TJSON,
-  RefreshToken,
   JSONObject,
   Success,
   Entry,
@@ -336,7 +335,7 @@ export class ContextImpl implements Context {
     return this.exports.SkipRuntime_getToken(
       this.pointer(),
       this.skjson.exportString(key),
-    ) as RefreshToken;
+    );
   }
 
   size = (eagerHdl: string) => {

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -21,7 +21,7 @@ import type {
   Entry,
   CollectionReader,
   CallResourceCompute,
-  Watermarked,
+  UpdatedValues,
 } from "../skipruntime_api.js";
 
 import type {
@@ -210,7 +210,7 @@ export class ContextImpl implements Context {
     if (typeof result == "number") {
       throw this.handles.deleteHandle(result as Handle<unknown>);
     }
-    return result as Watermarked<K, V>;
+    return result as UpdatedValues<K, V>;
   }
 
   getArray<K extends TJSON, V>(eagerHdl: string, key: K) {

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -631,21 +631,18 @@ class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
     };
   }
 
-  forEach(callbackfn: (value: T, index: number) => void, thisArg?: any): void {
+  forEach(f: (value: T, index: number) => void, thisObj?: any): void {
     let value = this.next();
     let index = 0;
     while (value != null) {
-      callbackfn.apply(thisArg, [value, index]);
+      f.apply(thisObj, [value, index]);
       value = this.next();
       index++;
     }
   }
 
-  map<U>(
-    callbackfn: (value: T, index: number) => U,
-    thisArg?: any,
-  ): Iterable<U> {
-    return this.toArray().map(callbackfn, thisArg);
+  map<U>(f: (value: T, index: number) => U, thisObj?: any): U[] {
+    return this.toArray().map(f, thisObj);
   }
 }
 

--- a/skipruntime-ts/core/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_types.ts
@@ -10,7 +10,7 @@ import type {
   JSONObject,
   Entry,
   CollectionReader,
-  Watermarked,
+  UpdatedValues,
 } from "../skipruntime_api.js";
 
 export type CtxMapping<
@@ -79,7 +79,7 @@ export interface Context {
   getDiff<K extends TJSON, V extends TJSON>(
     collection: string,
     watermark: string,
-  ): Watermarked<K, V>;
+  ): UpdatedValues<K, V>;
 
   getArrayLazy<K extends TJSON, V>(collection: string, key: K): V[];
   getOneLazy<K extends TJSON, V>(collection: string, key: K): V;

--- a/skipruntime-ts/core/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_types.ts
@@ -8,7 +8,6 @@ import type {
   NonEmptyIterator,
   EagerCollection,
   JSONObject,
-  RefreshToken,
   Entry,
   CollectionReader,
   Watermarked,
@@ -93,7 +92,7 @@ export interface Context {
     lazyHdl: ptr<Internal.LHandle>,
     key: K,
   ): Opt<V>;
-  getToken(key: string): RefreshToken;
+  getToken(key: string): number;
 
   size(collection: string): number;
 

--- a/skipruntime-ts/core/src/internals/skipruntime_types.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_types.ts
@@ -11,7 +11,6 @@ import type {
   Entry,
   CollectionReader,
   Watermarked,
-  Notifier,
 } from "../skipruntime_api.js";
 
 export type CtxMapping<
@@ -156,8 +155,8 @@ export interface Context {
 
   subscribe<K extends TJSON, V extends TJSON>(
     collection: string,
-    from: string,
-    notify: Notifier<K, V>,
+    since: string,
+    f: (values: Entry<K, V>[], watermark: string, update: boolean) => void,
   ): bigint;
 
   unsubscribe(session: bigint): void;
@@ -240,7 +239,7 @@ export interface FromWasm {
   SkipRuntime_getAll(getterHdl: ptr<Internal.String>): ptr<Internal.CJSON>;
   SkipRuntime_getDiff(
     getterHdl: ptr<Internal.String>,
-    from: bigint,
+    since: bigint,
   ): ptr<Internal.CJSON>;
 
   SkipRuntime_getToken(
@@ -404,8 +403,14 @@ export interface FromWasm {
 
   SkipRuntime_subscribe(
     resource: ptr<Internal.String>,
-    from: bigint,
-    notifyFn: Handle<Notifier<TJSON, TJSON>>,
+    since: bigint,
+    f: Handle<
+      (
+        values: Entry<TJSON, TJSON>[],
+        watermark: string,
+        update: boolean,
+      ) => void
+    >,
   ): bigint;
 
   SkipRuntime_unsubscribe(session: bigint): number;

--- a/skipruntime-ts/core/src/skip-runtime.ts
+++ b/skipruntime-ts/core/src/skip-runtime.ts
@@ -17,7 +17,7 @@ export type {
   AsyncLazyCollection,
   Entrypoint,
   ExternalCall,
-  SKStore,
+  Context,
   TJSON,
   JSONObject,
   Accumulator,

--- a/skipruntime-ts/core/src/skip-runtime.ts
+++ b/skipruntime-ts/core/src/skip-runtime.ts
@@ -8,7 +8,6 @@ export type {
   AValue,
   Mapper,
   Param,
-  RefreshToken,
   EagerCollection,
   NonEmptyIterator,
   LazyCollection,

--- a/skipruntime-ts/core/src/skip-runtime.ts
+++ b/skipruntime-ts/core/src/skip-runtime.ts
@@ -15,7 +15,7 @@ export type {
   AsyncLazyCompute,
   Loadable,
   AsyncLazyCollection,
-  EntryPoint,
+  Entrypoint,
   ExternalCall,
   SKStore,
   TJSON,

--- a/skipruntime-ts/core/src/skip-runtime.ts
+++ b/skipruntime-ts/core/src/skip-runtime.ts
@@ -2,7 +2,7 @@ export type { SkipService, Resource } from "./skipruntime_service.js";
 export { UnknownCollectionError } from "./skipruntime_errors.js";
 export type { Opaque } from "./internals/skipruntime_module.js";
 export { runService as initService } from "./skipruntime_runner.js";
-export { createSKStore } from "./skipruntime_init.js";
+export { createRuntime } from "./skipruntime_init.js";
 
 export type {
   AValue,

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -397,7 +397,7 @@ export interface ExternalCall<
   call(key: K, timestamp: number): Promise<AValue<V, Metadata>>;
 }
 
-export interface SKStore extends Constant {
+export interface Context extends Constant {
   /**
    * Creates a lazy reactive collection.
    * @param compute - the function to compute entries of the lazy collection

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -243,9 +243,9 @@ export interface CollectionReader<K extends TJSON, V extends TJSON> {
   /**
    * Get a diff of added/updated entries in a collection since some watermark.
    * @param since A watermark from which to compute the diff
-   * @returns {Watermarked} An object containing updated entries and a new watermark string.
+   * @returns {UpdatedValues} An object containing updated entries and a new watermark string.
    */
-  getDiff(since: string): Watermarked<K, V>;
+  getDiff(since: string): UpdatedValues<K, V>;
 
   /**
    * Subscribe to updates of the collection since some initial watermark
@@ -457,10 +457,10 @@ export type ReactiveResponse = {
   watermark: string;
 };
 
-export type Watermarked<K extends TJSON, V extends TJSON> = {
+export type UpdatedValues<K extends TJSON, V extends TJSON> = {
   values: Entry<K, V>[];
   watermark: string;
-  update?: boolean;
+  isInitial?: boolean;
 };
 
 export interface CollectionWriter<K extends TJSON, V extends TJSON> {

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -4,7 +4,7 @@
  * overview page] for a detailed description and introduction to the SKStore system.
  */
 
-import type { Opaque, Opt, Shared, int } from "std";
+import type { Opt, Shared, int } from "std";
 import type { Constant } from "./internals/skipruntime_impl.js";
 
 export type JSONObject = { [key: string]: TJSON | null };
@@ -19,8 +19,6 @@ export type Param =
   | Constant
   | readonly Param[]
   | { readonly [k: string]: Param };
-
-export type RefreshToken = Opaque<number, "SkipRefreshToken">;
 
 /**
  * Skip Runtime async function calls return a `Loadable` value which is one of `Success`,
@@ -422,7 +420,7 @@ export interface SKStore extends Constant {
     ...params: Params
   ): AsyncLazyCollection<K, V, Metadata>;
 
-  getRefreshToken: (key: string) => RefreshToken;
+  getRefreshToken: (key: string) => number;
 
   jsonExtract(value: JSONObject, pattern: string): TJSON[];
 

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -351,16 +351,17 @@ export type CallResourceCompute = (
   params: Record<string, string>,
 ) => string;
 
-export interface SKStoreFactory extends Shared {
-  runSKStore(
+export interface RuntimeFactory extends Shared {
+  createRuntime(
     init: (
-      skstore: SKStore,
+      context: Context,
       collections: Record<string, EagerCollection<TJSON, TJSON>>,
     ) => CallResourceCompute,
     inputs: Record<string, [TJSON, TJSON][]>,
     remotes?: Record<string, Entrypoint>,
     tokens?: Record<string, number>,
-  ): SkipBuilder;
+    writers?: Record<string, CollectionWriter<TJSON, TJSON>>,
+  ): SkipRuntime;
 }
 
 /**
@@ -461,10 +462,6 @@ export type Watermarked<K extends TJSON, V extends TJSON> = {
   watermark: string;
   update?: boolean;
 };
-
-export type SkipBuilder = (
-  iCollection: Record<string, CollectionWriter<TJSON, TJSON>>,
-) => SkipRuntime;
 
 export interface CollectionWriter<K extends TJSON, V extends TJSON> {
   write(key: K, value: V[]): void;

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -339,7 +339,7 @@ export interface EagerCollection<K extends TJSON, V extends TJSON>
   getId(): string;
 }
 
-export type EntryPoint = {
+export type Entrypoint = {
   host: string;
   port: number;
   secured?: boolean;
@@ -357,7 +357,7 @@ export interface SKStoreFactory extends Shared {
       collections: Record<string, EagerCollection<TJSON, TJSON>>,
     ) => CallResourceCompute,
     inputs: Record<string, [TJSON, TJSON][]>,
-    remotes?: Record<string, EntryPoint>,
+    remotes?: Record<string, Entrypoint>,
     tokens?: Record<string, number>,
   ): SkipBuilder;
 }

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -457,6 +457,12 @@ export type ReactiveResponse = {
   watermark: string;
 };
 
+/**
+ * Represents some update(s) to a collection, containing: an array of all updated keys and
+ * their new `values`, where an empty value array indicates deletion; a new `watermark` for
+ * the point after these updates; and, a flag `isInitial` which is set when this update is
+ * the initial chunk of data rather than an update to the preceding state.
+ */
 export type UpdatedValues<K extends TJSON, V extends TJSON> = {
   values: Entry<K, V>[];
   watermark: string;

--- a/skipruntime-ts/core/src/skipruntime_init.ts
+++ b/skipruntime-ts/core/src/skipruntime_init.ts
@@ -4,7 +4,7 @@ import type {
   SKStoreFactory,
   TJSON,
   CallResourceCompute,
-  EntryPoint,
+  Entrypoint,
   EagerCollection,
   SkipBuilder,
 } from "./skipruntime_api.js";
@@ -41,7 +41,7 @@ export async function createSKStore(
     inputs: Record<string, EagerCollection<TJSON, TJSON>>,
   ) => CallResourceCompute,
   inputs: Record<string, [TJSON, TJSON][]>,
-  remotes: Record<string, EntryPoint> = {},
+  remotes: Record<string, Entrypoint> = {},
   tokens: Record<string, number> = {},
 ): Promise<SkipBuilder> {
   const data = await run(wasmUrl, modules, [], "SKDB_factory");

--- a/skipruntime-ts/core/src/skipruntime_init.ts
+++ b/skipruntime-ts/core/src/skipruntime_init.ts
@@ -1,6 +1,6 @@
 import { run, type ModuleInit } from "std";
 import type {
-  SKStore,
+  Context,
   RuntimeFactory,
   TJSON,
   CallResourceCompute,

--- a/skipruntime-ts/core/src/skipruntime_init.ts
+++ b/skipruntime-ts/core/src/skipruntime_init.ts
@@ -1,12 +1,13 @@
 import { run, type ModuleInit } from "std";
 import type {
   SKStore,
-  SKStoreFactory,
+  RuntimeFactory,
   TJSON,
   CallResourceCompute,
   Entrypoint,
   EagerCollection,
-  SkipBuilder,
+  CollectionWriter,
+  SkipRuntime,
 } from "./skipruntime_api.js";
 
 import { init as runtimeInit } from "std/runtime.js";
@@ -33,18 +34,21 @@ async function wasmUrl(): Promise<URL> {
   return new URL("./libskip-runtime-ts.wasm", import.meta.url);
 }
 
-export type CreateSKStore = typeof createSKStore;
+export type CreateRuntime = typeof createRuntime;
 
-export async function createSKStore(
+export async function createRuntime(
   init: (
-    skstore: SKStore,
+    context: Context,
     inputs: Record<string, EagerCollection<TJSON, TJSON>>,
   ) => CallResourceCompute,
   inputs: Record<string, [TJSON, TJSON][]>,
   remotes: Record<string, Entrypoint> = {},
   tokens: Record<string, number> = {},
-): Promise<SkipBuilder> {
+  writers: Record<string, CollectionWriter<TJSON, TJSON>> = {},
+): Promise<SkipRuntime> {
   const data = await run(wasmUrl, modules, [], "SKDB_factory");
-  const factory = data.environment.shared.get("SKStore") as SKStoreFactory;
-  return factory.runSKStore(init, inputs, remotes, tokens);
+  const factory = data.environment.shared.get(
+    "SkipRuntimeFactory",
+  ) as RuntimeFactory;
+  return factory.createRuntime(init, inputs, remotes, tokens, writers);
 }

--- a/skipruntime-ts/core/src/skipruntime_rest.ts
+++ b/skipruntime-ts/core/src/skipruntime_rest.ts
@@ -1,11 +1,11 @@
 import type {
   TJSON,
   Entry,
-  EntryPoint,
+  Entrypoint,
   ReactiveResponse,
 } from "./skipruntime_api.js";
 
-function toHttp(entrypoint: EntryPoint) {
+function toHttp(entrypoint: Entrypoint) {
   if (entrypoint.secured)
     return `https://${entrypoint.host}:${entrypoint.port}`;
   return `http://${entrypoint.host}:${entrypoint.port}`;
@@ -39,7 +39,7 @@ export class SkipRESTRuntime {
   private entrypoint: string;
 
   constructor(
-    entrypoint: EntryPoint = {
+    entrypoint: Entrypoint = {
       host: "localhost",
       port: 3587,
     },

--- a/skipruntime-ts/core/src/skipruntime_runner.ts
+++ b/skipruntime-ts/core/src/skipruntime_runner.ts
@@ -9,12 +9,12 @@ import type {
 
 import type { SkipService } from "./skipruntime_service.js";
 
-import type { CreateSKStore } from "./skipruntime_init.js";
+import type { CreateRuntime } from "./skipruntime_init.js";
 import type { EagerCollectionImpl } from "./internals/skipruntime_impl.js";
 
 export async function runService(
   service: SkipService,
-  createSKStore: CreateSKStore,
+  createRuntime: CreateRuntime,
 ): Promise<SkipRuntime> {
   const iCollections: Record<string, CollectionWriter<TJSON, TJSON>> = {};
   const rCollections: Record<string, CollectionReader<TJSON, TJSON>> = {};
@@ -56,11 +56,11 @@ export async function runService(
       return resource.reactiveCompute(store, collections).getId();
     };
   };
-  const builder = await createSKStore(
-    initSKStore,
+  return await createRuntime(
+    init,
     service.inputCollections ?? {},
     service.remoteCollections ?? {},
     service.refreshTokens ?? {},
+    iCollections,
   );
-  return builder(iCollections);
 }

--- a/skipruntime-ts/core/src/skipruntime_runner.ts
+++ b/skipruntime-ts/core/src/skipruntime_runner.ts
@@ -3,7 +3,7 @@ import type {
   CollectionWriter,
   EagerCollection,
   SkipRuntime,
-  SKStore,
+  Context,
   TJSON,
 } from "./skipruntime_api.js";
 
@@ -18,8 +18,8 @@ export async function runService(
 ): Promise<SkipRuntime> {
   const iCollections: Record<string, CollectionWriter<TJSON, TJSON>> = {};
   const rCollections: Record<string, CollectionReader<TJSON, TJSON>> = {};
-  const initSKStore = (
-    store: SKStore,
+  const init = (
+    context: Context,
     inputs: Record<string, EagerCollection<TJSON, TJSON>>,
   ) => {
     if (service.inputCollections) {
@@ -38,7 +38,7 @@ export async function runService(
         ).toCollectionWriter();
       }
     }
-    const result = service.reactiveCompute(store, inputs);
+    const result = service.reactiveCompute(context, inputs);
     for (const [key, col] of Object.entries(result)) {
       rCollections[key] = (
         col as EagerCollectionImpl<TJSON, TJSON>
@@ -53,7 +53,7 @@ export async function runService(
         throw new Error(`Unknown resource ${name}`);
       }
       const resource = new resourceConst(params);
-      return resource.reactiveCompute(store, collections).getId();
+      return resource.reactiveCompute(context, collections).getId();
     };
   };
   return await createRuntime(

--- a/skipruntime-ts/core/src/skipruntime_service.ts
+++ b/skipruntime-ts/core/src/skipruntime_service.ts
@@ -1,7 +1,7 @@
 import type {
   EagerCollection,
   Entrypoint,
-  SKStore,
+  Context,
   TJSON,
 } from "./skipruntime_api.js";
 
@@ -12,7 +12,7 @@ export type ServiceOutput = {
 
 export interface Resource {
   reactiveCompute(
-    store: SKStore,
+    context: Context,
     collections: Record<string, EagerCollection<TJSON, TJSON>>,
   ): EagerCollection<TJSON, TJSON>;
 }
@@ -25,7 +25,7 @@ export interface SkipService {
   resources?: Record<string, new (params: Record<string, string>) => Resource>;
 
   reactiveCompute(
-    store: SKStore,
+    context: Context,
     inputCollections: Record<string, EagerCollection<TJSON, TJSON>>,
   ): Record<string, EagerCollection<TJSON, TJSON>>;
 }

--- a/skipruntime-ts/core/src/skipruntime_service.ts
+++ b/skipruntime-ts/core/src/skipruntime_service.ts
@@ -1,6 +1,6 @@
 import type {
   EagerCollection,
-  EntryPoint,
+  Entrypoint,
   SKStore,
   TJSON,
 } from "./skipruntime_api.js";
@@ -19,7 +19,7 @@ export interface Resource {
 
 export interface SkipService {
   inputCollections?: Record<string, [TJSON, TJSON][]>;
-  remoteCollections?: Record<string, EntryPoint>;
+  remoteCollections?: Record<string, Entrypoint>;
   // name / duration in milliseconds
   refreshTokens?: Record<string, number>;
   resources?: Record<string, new (params: Record<string, string>) => Resource>;

--- a/skipruntime-ts/core/test/runtime.spec.ts
+++ b/skipruntime-ts/core/test/runtime.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "earl";
 
 import type {
-  SKStore,
+  Context,
   TJSON,
   Mapper,
   AsyncLazyCompute,
@@ -36,7 +36,7 @@ class Map1 implements Mapper<string, number, string, number> {
 
 class Map1Resource implements Resource {
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     collections: {
       input: EagerCollection<string, number>;
     },
@@ -50,7 +50,7 @@ class Map1Service implements SkipService {
   resources = { map1: Map1Resource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: { input: EagerCollection<number, number> },
   ) {
     return inputCollections;
@@ -86,7 +86,7 @@ class Map2 implements Mapper<string, number, string, number> {
 
 class Map2Resource implements Resource {
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     collections: {
       input1: EagerCollection<string, number>;
       input2: EagerCollection<string, number>;
@@ -101,7 +101,7 @@ class Map2Service implements SkipService {
   resources = { map2: Map2Resource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input1: EagerCollection<string, number>;
       input2: EagerCollection<string, number>;
@@ -138,7 +138,7 @@ class Map3 implements Mapper<string, number, string, number> {
 
 class Map3Resource implements Resource {
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     cs: {
       input1: EagerCollection<string, number>;
       input2: EagerCollection<string, number>;
@@ -153,7 +153,7 @@ class Map3Service implements SkipService {
   resources = { map3: Map3Resource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input1: EagerCollection<number, number>;
       input2: EagerCollection<number, number>;
@@ -193,7 +193,7 @@ class AddKeyAndValue extends ValueMapper<number, number, number> {
 
 class ValueMapperResource implements Resource {
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     cs: {
       input: EagerCollection<number, number>;
     },
@@ -207,7 +207,7 @@ class ValueMapperService implements SkipService {
   resources = { valueMapper: ValueMapperResource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input: EagerCollection<number, number>;
     },
@@ -248,7 +248,7 @@ class SizeMapper implements Mapper<number, number, number, number> {
 
 class SizeResource implements Resource {
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     cs: {
       input1: EagerCollection<number, number>;
       input2: EagerCollection<number, number>;
@@ -263,7 +263,7 @@ class SizeService implements SkipService {
   resources = { size: SizeResource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input1: EagerCollection<number, number>;
       input2: EagerCollection<number, number>;
@@ -303,7 +303,7 @@ it("testSize", async () => {
 
 class SlicedMap1Resource implements Resource {
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     cs: {
       input: EagerCollection<number, number>;
     },
@@ -331,7 +331,7 @@ class SlicedMap1Service implements SkipService {
   resources = { slice: SlicedMap1Resource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input: EagerCollection<number, number>;
     },
@@ -386,12 +386,12 @@ class MapLazy implements Mapper<number, number, number, number> {
 
 class LazyResource implements Resource {
   reactiveCompute(
-    skstore: SKStore,
+    context: Context,
     cs: {
       input: EagerCollection<number, number>;
     },
   ): EagerCollection<number, number> {
-    const lazy = skstore.lazy(TestLazyAdd, cs.input);
+    const lazy = context.lazy(TestLazyAdd, cs.input);
     return cs.input.map(MapLazy, lazy);
   }
 }
@@ -401,7 +401,7 @@ class LazyService implements SkipService {
   resources = { lazy: LazyResource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input: EagerCollection<number, number>;
     },
@@ -447,7 +447,7 @@ class TestOddEven implements Mapper<number, number, number, number> {
 
 class MapReduceResource implements Resource {
   reactiveCompute(
-    _skstore: SKStore,
+    _context: Context,
     cs: {
       input: EagerCollection<number, number>;
     },
@@ -461,7 +461,7 @@ class MapReduceService implements SkipService {
   resources = { mapReduce: MapReduceResource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input: EagerCollection<number, number>;
     },
@@ -507,7 +507,7 @@ it("testMapReduce", async () => {
 
 class Merge1Resource implements Resource {
   reactiveCompute(
-    _skstore: SKStore,
+    _context: Context,
     cs: {
       input1: EagerCollection<number, number>;
       input2: EagerCollection<number, number>;
@@ -522,7 +522,7 @@ class Merge1Service implements SkipService {
   resources = { merge1: Merge1Resource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input1: EagerCollection<number, number>;
       input2: EagerCollection<number, number>;
@@ -568,7 +568,7 @@ class IdentityMapper extends ValueMapper<number, number, number> {
 
 class MergeReduceResource implements Resource {
   reactiveCompute(
-    _skstore: SKStore,
+    _context: Context,
     cs: {
       input1: EagerCollection<number, number>;
       input2: EagerCollection<number, number>;
@@ -583,7 +583,7 @@ class MergeReduceService implements SkipService {
   resources = { mergeReduce: MergeReduceResource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input1: EagerCollection<number, number>;
       input2: EagerCollection<number, number>;
@@ -653,13 +653,13 @@ class TestCheckResult implements Mapper<number, number, number, string> {
 
 class AsyncLazyResource implements Resource {
   reactiveCompute(
-    skstore: SKStore,
+    context: Context,
     cs: {
       input1: EagerCollection<number, number>;
       input2: EagerCollection<number, number>;
     },
   ): EagerCollection<number, string> {
-    const asyncLazy = skstore.asyncLazy(TestLazyWithAsync, cs.input2);
+    const asyncLazy = context.asyncLazy(TestLazyWithAsync, cs.input2);
     return cs.input1.map(TestCheckResult, asyncLazy);
   }
 }
@@ -669,7 +669,7 @@ class AsyncLazyService implements SkipService {
   resources = { asyncLazy: AsyncLazyResource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input1: EagerCollection<number, number>;
       input2: EagerCollection<number, number>;
@@ -719,7 +719,7 @@ it("testAsyncLazy", async () => {
   return new Promise<void>(waitandcheck);
 });
 
-class MockExternal implements ExternalCall<number, string, TJSON> {
+class MockExternal implements ExternalCall<number, string> {
   async call(key: number, _timestamp: number) {
     await timeout(1000 * key); // wait for `key` seconds before returning
     return { payload: `mock_result(${key.toString()})` };
@@ -741,12 +741,12 @@ class TestCheckExternalResult extends ValueMapper<number, number, string> {
 
 class ExternalResource implements Resource {
   reactiveCompute(
-    skstore: SKStore,
+    context: Context,
     cs: {
       input: EagerCollection<number, number>;
     },
   ): EagerCollection<number, string> {
-    const external = skstore.external("token_4s", MockExternal);
+    const external = context.external("token_4s", MockExternal);
     return cs.input.map(TestCheckExternalResult, external);
   }
 }
@@ -757,7 +757,7 @@ class ExternalService implements SkipService {
   refreshTokens = { token_4s: 4000 };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input: EagerCollection<number, number>;
     },
@@ -833,25 +833,25 @@ it("testExternalCall", async () => {
 class TestWithToken
   implements Mapper<number, number, number, [number, number]>
 {
-  constructor(private skstore: SKStore) {}
+  constructor(private context: Context) {}
 
   mapElement(
     key: number,
     it: NonEmptyIterator<number>,
   ): Iterable<[number, [number, number]]> {
-    const time = this.skstore.getRefreshToken("token_5s");
+    const time = this.context.getRefreshToken("token_5s");
     return [[key, [it.first(), time]]];
   }
 }
 
 class TokensResource implements Resource {
   reactiveCompute(
-    skstore: SKStore,
+    context: Context,
     cs: {
       input: EagerCollection<number, number>;
     },
   ): EagerCollection<number, [number, number]> {
-    return cs.input.map(TestWithToken, skstore);
+    return cs.input.map(TestWithToken, context);
   }
 }
 
@@ -861,7 +861,7 @@ class TokensService implements SkipService {
   refreshTokens = { token_5s: 5000 };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input: EagerCollection<number, number>;
     },
@@ -898,26 +898,26 @@ class JSONExtract
   implements
     Mapper<number, { value: JSONObject; pattern: string }, number, TJSON[]>
 {
-  constructor(private skstore: SKStore) {}
+  constructor(private context: Context) {}
 
   mapElement(
     key: number,
     it: NonEmptyIterator<{ value: JSONObject; pattern: string }>,
   ): Iterable<[number, TJSON[]]> {
     const value = it.first();
-    const result = this.skstore.jsonExtract(value.value, value.pattern);
+    const result = this.context.jsonExtract(value.value, value.pattern);
     return Array([key, result]);
   }
 }
 
 class JSONExtractResource implements Resource {
   reactiveCompute(
-    skstore: SKStore,
+    context: Context,
     cs: {
       input: EagerCollection<number, { value: JSONObject; pattern: string }>;
     },
   ): EagerCollection<number, TJSON[]> {
-    return cs.input.map(JSONExtract, skstore);
+    return cs.input.map(JSONExtract, context);
   }
 }
 
@@ -926,7 +926,7 @@ class JSONExtractService implements SkipService {
   resources = { jsonExtract: JSONExtractResource };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: {
       input: EagerCollection<number, { value: JSONObject; pattern: string }>;
     },

--- a/skipruntime-ts/core/test/runtime.spec.ts
+++ b/skipruntime-ts/core/test/runtime.spec.ts
@@ -19,7 +19,7 @@ import type {
 import {
   Sum,
   ValueMapper,
-  createSKStore,
+  createRuntime,
   initService,
 } from "../src/skip-runtime.js";
 
@@ -58,7 +58,7 @@ class Map1Service implements SkipService {
 }
 
 it("testMap1", async () => {
-  const runtime = await initService(new Map1Service(), createSKStore);
+  const runtime = await initService(new Map1Service(), createRuntime);
   runtime.put("input", "1", [10]);
   expect(runtime.getOne("map1", {}, "1")).toEqual([12]);
 });
@@ -112,7 +112,7 @@ class Map2Service implements SkipService {
 }
 
 it("testMap2", async () => {
-  const runtime = await initService(new Map2Service(), createSKStore);
+  const runtime = await initService(new Map2Service(), createRuntime);
   const resource = "map2";
   runtime.put("input1", "1", [10]);
   runtime.put("input2", "1", [20]);
@@ -164,7 +164,7 @@ class Map3Service implements SkipService {
 }
 
 it("testMap2", async () => {
-  const runtime = await initService(new Map3Service(), createSKStore);
+  const runtime = await initService(new Map3Service(), createRuntime);
   const resource = "map3";
   runtime.put("input1", "1", [1, 2, 3]);
   runtime.put("input2", "1", [10]);
@@ -217,7 +217,7 @@ class ValueMapperService implements SkipService {
 }
 
 it("valueMapper", async () => {
-  const runtime = await initService(new ValueMapperService(), createSKStore);
+  const runtime = await initService(new ValueMapperService(), createRuntime);
   const resource = "valueMapper";
   runtime.patch("input", [
     [1, [1]],
@@ -274,7 +274,7 @@ class SizeService implements SkipService {
 }
 
 it("testSize", async () => {
-  const runtime = await initService(new SizeService(), createSKStore);
+  const runtime = await initService(new SizeService(), createRuntime);
   const resource = "size";
   runtime.patch("input1", [
     [1, [0]],
@@ -341,7 +341,7 @@ class SlicedMap1Service implements SkipService {
 }
 
 it("testSlicedMap1", async () => {
-  const runtime = await initService(new SlicedMap1Service(), createSKStore);
+  const runtime = await initService(new SlicedMap1Service(), createRuntime);
   const resource = "slice";
   // Inserts [[0, 0], ..., [30, 30]
   const values = Array.from({ length: 31 }, (_, i): Entry<number, number> => {
@@ -411,7 +411,7 @@ class LazyService implements SkipService {
 }
 
 it("testLazy", async () => {
-  const runtime = await initService(new LazyService(), createSKStore);
+  const runtime = await initService(new LazyService(), createRuntime);
   const resource = "lazy";
   runtime.patch("input", [
     [0, [10]],
@@ -471,7 +471,7 @@ class MapReduceService implements SkipService {
 }
 
 it("testMapReduce", async () => {
-  const runtime = await initService(new MapReduceService(), createSKStore);
+  const runtime = await initService(new MapReduceService(), createRuntime);
   const resource = "mapReduce";
   runtime.patch("input", [
     [0, [1]],
@@ -540,7 +540,7 @@ function sorted(entries: Entry<TJSON, TJSON>[]): Entry<TJSON, TJSON>[] {
 }
 
 it("testMerge1", async () => {
-  const runtime = await initService(new Merge1Service(), createSKStore);
+  const runtime = await initService(new Merge1Service(), createRuntime);
   const resource = "merge1";
   runtime.put("input1", 1, [10]);
   runtime.put("input2", 1, [20]);
@@ -594,7 +594,7 @@ class MergeReduceService implements SkipService {
 }
 
 it("testMergeReduce", async () => {
-  const runtime = await initService(new MergeReduceService(), createSKStore);
+  const runtime = await initService(new MergeReduceService(), createRuntime);
   const resource = "mergeReduce";
   runtime.put("input1", 1, [10]);
   runtime.put("input2", 1, [20]);
@@ -680,7 +680,7 @@ class AsyncLazyService implements SkipService {
 }
 
 it("testAsyncLazy", async () => {
-  const runtime = await initService(new AsyncLazyService(), createSKStore);
+  const runtime = await initService(new AsyncLazyService(), createRuntime);
   const data = runtime.head("asyncLazy", {}, new Uint8Array([]));
 
   const updates: Entry<TJSON, TJSON>[][] = [];
@@ -767,7 +767,7 @@ class ExternalService implements SkipService {
 }
 
 it("testExternalCall", async () => {
-  const runtime = await initService(new ExternalService(), createSKStore);
+  const runtime = await initService(new ExternalService(), createRuntime);
   const resource = "external";
   const success = (id: number): Entry<TJSON, TJSON> => {
     return [id, [`success: mock_result(${id.toString()})`]];
@@ -875,7 +875,7 @@ async function timeout(ms: number) {
 }
 
 it("testTokens", async () => {
-  const runtime = await initService(new TokensService(), createSKStore);
+  const runtime = await initService(new TokensService(), createRuntime);
   const resource = "tokens";
   runtime.put("input", 1, [0]);
   const start = runtime.getOne(resource, {}, 1)[0] as [number, number];
@@ -936,7 +936,7 @@ class JSONExtractService implements SkipService {
 }
 
 it("testJSONExtract", async () => {
-  const runtime = await initService(new JSONExtractService(), createSKStore);
+  const runtime = await initService(new JSONExtractService(), createRuntime);
   const resource = "jsonExtract";
   runtime.patch("input", [
     [

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -1,5 +1,5 @@
 import type {
-  SKStore,
+  Context,
   TJSON,
   EagerCollection,
   SkipService,
@@ -77,7 +77,7 @@ type User = { name: string; country: string };
 
 class UsersResource implements Resource {
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     cs: { users: EagerCollection<string, User> },
   ): EagerCollection<string, User> {
     return cs.users;
@@ -100,7 +100,7 @@ class Service implements SkipService {
   };
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: { users: EagerCollection<string, TJSON> },
   ): Record<string, EagerCollection<string, TJSON>> {
     return inputCollections;

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -1,5 +1,5 @@
 import type {
-  SKStore,
+  Context,
   LazyCompute,
   EagerCollection,
   LazyCollection,
@@ -70,7 +70,7 @@ class CallCompute implements Mapper<string, TJSON, string, TJSON> {
 
 class ComputedCells implements Resource {
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     collections: { output: EagerCollection<string, TJSON> },
   ): EagerCollection<string, TJSON> {
     return collections.output;
@@ -82,13 +82,13 @@ class Service implements SkipService {
   resources = { computed: ComputedCells };
 
   reactiveCompute(
-    store: SKStore,
+    context: Context,
     inputCollections: Record<string, EagerCollection<string, TJSON>>,
   ): Record<string, EagerCollection<TJSON, TJSON>> {
     const cells = inputCollections["cells"];
     // Use lazy dir to create eval dependency graph
     // Its calls it self to get other computed cells
-    const evaluator = store.lazy(ComputeExpression, cells);
+    const evaluator = context.lazy(ComputeExpression, cells);
     // Build a sub dependency graph for each sheet (For example purpose)
     // A parsing phase can be added to prevent expression parsing each time:
     // Parsing => Immutable ast

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -1,5 +1,5 @@
 import type {
-  SKStore,
+  Context,
   Mapper,
   EagerCollection,
   NonEmptyIterator,
@@ -45,7 +45,7 @@ class Minus implements Mapper<string, number, string, number> {
 
 class Add implements Resource {
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     collections: {
       input1: EagerCollection<string, number>;
       input2: EagerCollection<string, number>;
@@ -57,7 +57,7 @@ class Add implements Resource {
 
 class Sub implements Resource {
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     collections: {
       input1: EagerCollection<string, number>;
       input2: EagerCollection<string, number>;
@@ -77,7 +77,7 @@ class Service implements SkipService {
   }
 
   reactiveCompute(
-    _store: SKStore,
+    _context: Context,
     inputCollections: Record<string, EagerCollection<string, number>>,
   ) {
     return inputCollections;

--- a/skipruntime-ts/examples/utils.ts
+++ b/skipruntime-ts/examples/utils.ts
@@ -1,4 +1,4 @@
-import type { TJSON, EntryPoint, Entry, JSONObject } from "@skipruntime/core";
+import type { TJSON, Entrypoint, Entry, JSONObject } from "@skipruntime/core";
 import { SkipRESTRuntime } from "@skipruntime/core";
 import { createInterface } from "readline";
 import { connect, Protocol, Client } from "@skipruntime/client";
@@ -18,7 +18,7 @@ interface Delete {
   keys: string[];
 }
 
-function toWs(entrypoint: EntryPoint) {
+function toWs(entrypoint: Entrypoint) {
   if (entrypoint.secured)
     return `wss://${entrypoint.host}:${entrypoint.port.toString()}`;
   return `ws://${entrypoint.host}:${entrypoint.port.toString()}`;
@@ -29,7 +29,7 @@ class SkipHttpAccessV1 {
   private client?: Client;
 
   constructor(
-    private entrypoint: EntryPoint = {
+    private entrypoint: Entrypoint = {
       host: "localhost",
       port: 3587,
     },

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -2,7 +2,7 @@ import { WebSocketServer } from "ws";
 import * as http from "http";
 import {
   initService,
-  createSKStore,
+  createRuntime,
   type SkipService,
 } from "@skipruntime/core";
 import { createRESTServer } from "./rest.js";
@@ -12,7 +12,7 @@ export async function runService(
   service: SkipService,
   port: number = 443,
 ): Promise<{ close: () => void }> {
-  const runtime = await initService(service, createSKStore);
+  const runtime = await initService(service, createRuntime);
   const httpServer = http.createServer();
   const app = createRESTServer(runtime);
   httpServer.on("request", app);


### PR DESCRIPTION
Some cleanups and improved inline documentation for Skip runtime, focusing on `skipruntime_api.ts` to make sure everything is understandable and well-documented.