### PR TITLE
[skc] Clean up `compile()`.

### DIFF
--- a/skiplang/compiler/src/Config.sk
+++ b/skiplang/compiler/src/Config.sk
@@ -52,7 +52,6 @@ private class Config{
   // info, but inhibits sharing, which increases compilation time and
   // binary sizes.
   useSpecializedNames: Bool,
-  version: Bool,
   check: Bool,
   stackAlign: Int,
   stackAlignStr: String,
@@ -181,13 +180,7 @@ private class Config{
     autogc = results.getBool("autogc");
     sampleRate = results.getString("sample-rate").toInt();
     useSpecializedNames = results.getBool("use-specialized-names");
-    version = results.getBool("version");
     check = results.getBool("check");
-
-    if (version) {
-      print_string(getBuildVersion());
-      skipExit(0);
-    };
 
     exportAs = mutable UnorderedMap[];
     for (f in exportedAsFunctions) {
@@ -259,7 +252,6 @@ private class Config{
       autogc,
       sampleRate,
       useSpecializedNames,
-      version,
       check,
       stackAlign,
       stackAlignStr,

--- a/skiplang/compiler/src/OuterIstToIR.sk
+++ b/skiplang/compiler/src/OuterIstToIR.sk
@@ -935,7 +935,7 @@ class GClassFile(value: GClass) extends SKStore.File
 // Manages the overall conversion from OuterIst to IR.
 class Converter private (
   program: I.Program,
-  config: Config.Config,
+  ptrBitSize: Int,
   funs: SKStore.LHandle<SKStore.Key, GFunctionFile>,
   classes: SKStore.LHandle<SKStore.Key, GClassFile>,
   lower: SKStore.LHandle<SKStore.Key, I.CallableDefFile>,
@@ -962,7 +962,7 @@ class Converter private (
 
   static fun create(
     context: mutable SKStore.Context,
-    config: Config.Config,
+    ptrBitSize: Int,
     name: SKStore.DirName,
     program: I.Program,
   ): this {
@@ -984,7 +984,7 @@ class Converter private (
       I.CallableDefFile::type,
       lowerDirName,
     );
-    converter = static(program, config, funs, classes, lower);
+    converter = static(program, ptrBitSize, funs, classes, lower);
     _ = SKStore.LHandle::create(
       SKStore.Key::unTyped,
       GFunctionFile::type,
@@ -2267,10 +2267,9 @@ class Converter private (
     | "Int16" -> Some(ScalarType(16, 16, "i16", IntegerScalarKind()))
     | "Int32" -> Some(ScalarType(32, 32, "i32", IntegerScalarKind()))
     | "Float" -> Some(ScalarType(64, 64, "double", FloatScalarKind()))
-    | "Runtime.GCPointer" -> Some(ScalarType::gcPointer(this.config.ptrBitSize))
-    | "Runtime.NonGCPointer" ->
-      Some(ScalarType::nonGCPointer(this.config.ptrBitSize))
-    | "String" -> Some(ScalarType::gcPointer(this.config.ptrBitSize))
+    | "Runtime.GCPointer" -> Some(ScalarType::gcPointer(this.ptrBitSize))
+    | "Runtime.NonGCPointer" -> Some(ScalarType::nonGCPointer(this.ptrBitSize))
+    | "String" -> Some(ScalarType::gcPointer(this.ptrBitSize))
     | _ -> None()
     };
 

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -206,7 +206,7 @@ fun compile(
   ensureCompatibleLLVMVersion();
 
   backendDirName = SKStore.DirName::create("/backend/");
-  if (context.unsafeMaybeGetDir(FileCache.fileDirName) is None()) {
+  if (context.unsafeMaybeGetEagerDir(backendDirName) is None()) {
     _ = context.mkdir(x ~> x, x ~> x, FileCache.fileDirName);
     _ = context.mkdir(x ~> x, x ~> x, FileCache.fileTimeDirName);
     _ = context.mkdir(x ~> x, x ~> x, FileCache.allFilesDirName);

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -214,7 +214,6 @@ fun compile(
       SKStore.IID::keyType,
       TickConfigFile::type,
       backendDirName,
-      Array[(SKStore.IID(0), TickConfigFile((-128, config)))],
     );
 
     outerIst = OuterIstToIR.makeOuterIst(context);
@@ -371,17 +370,14 @@ fun compile(
     config.lib_name,
   );
 
-  if (context.unsafeMaybeGetEagerDir(backendDirName) is None()) {
-    void
-  } else {
-    context
-      .unsafeGetEagerDir(backendDirName)
-      .writeArray(
-        context,
-        SKStore.IID(0),
-        Array[TickConfigFile((context.tick.value, config))],
-      );
-  };
+  context
+    .unsafeGetEagerDir(backendDirName)
+    .writeArray(
+      context,
+      SKStore.IID(0),
+      Array[TickConfigFile((context.tick.value, config))],
+    );
+
   context.update()
 }
 

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -195,7 +195,7 @@ class TickConfigFile(value: (Int, Config.Config)) extends SKStore.File
 
 fun getOrInitializeBackend(
   context: mutable SKStore.Context,
-  config: Config.Config,
+  ptrBitSize: Int,
 ): SKStore.EagerDir {
   backendDirName = SKStore.DirName::create("/backend/");
   context.unsafeMaybeGetEagerDir(backendDirName) match {
@@ -219,7 +219,7 @@ fun getOrInitializeBackend(
 
   converter = OuterIstToIR.Converter::create(
     context,
-    config,
+    ptrBitSize,
     SKStore.DirName::create("/converter/"),
     outerIst,
   );
@@ -374,7 +374,7 @@ fun compile(
 
   // FIXME: Backend initialization should _not_ peek into the config
   // as it is likely to change across invocations.
-  getOrInitializeBackend(context, config).writeArray(
+  getOrInitializeBackend(context, config.ptrBitSize).writeArray(
     context,
     SKStore.IID(0),
     Array[TickConfigFile((context.tick.value, config))],

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -229,12 +229,11 @@ fun compile(
       outerIst,
     );
 
-    backendSinkDirName = SKStore.DirName::create("/backendSink/");
     _ = backendDir.map(
       SKStore.SID::keyType,
       TickConfigFile::type,
       context,
-      backendSinkDirName,
+      SKStore.DirName::create("/backendSink/"),
       (context, _writer, _key, values) ~> {
         (_, conf) = TickConfigFile::type(values.first).value;
 

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -210,6 +210,12 @@ fun compile(
     _ = context.mkdir(x ~> x, x ~> x, FileCache.fileDirName);
     _ = context.mkdir(x ~> x, x ~> x, FileCache.fileTimeDirName);
     _ = context.mkdir(x ~> x, x ~> x, FileCache.allFilesDirName);
+    backendDir = context.mkdir(
+      SKStore.IID::keyType,
+      TickConfigFile::type,
+      backendDirName,
+      Array[(SKStore.IID(0), TickConfigFile((-128, config)))],
+    );
 
     outerIst = OuterIstToIR.makeOuterIst(context);
 
@@ -221,13 +227,6 @@ fun compile(
       config,
       SKStore.DirName::create("/converter/"),
       outerIst,
-    );
-
-    backendDir = context.mkdir(
-      SKStore.IID::keyType,
-      TickConfigFile::type,
-      backendDirName,
-      Array[(SKStore.IID(0), TickConfigFile((-128, config)))],
     );
 
     backendSinkDirName = SKStore.DirName::create("/backendSink/");

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -205,6 +205,7 @@ fun compile(
 
   ensureCompatibleLLVMVersion();
 
+  backendDirName = SKStore.DirName::create("/backend/");
   if (context.unsafeMaybeGetDir(FileCache.fileDirName) is None()) {
     _ = context.mkdir(x ~> x, x ~> x, FileCache.fileDirName);
     _ = context.mkdir(x ~> x, x ~> x, FileCache.fileTimeDirName);
@@ -217,9 +218,6 @@ fun compile(
     config.dependencies,
     config.lib_name,
   );
-
-  backendDirName = SKStore.DirName::create("/backend/");
-  backendSinkDirName = SKStore.DirName::create("/backendSink/");
 
   if (context.unsafeMaybeGetEagerDir(backendDirName) is None()) {
     outerIst = OuterIstToIR.makeOuterIst(context);
@@ -241,6 +239,7 @@ fun compile(
       Array[(SKStore.IID(0), TickConfigFile((-128, config)))],
     );
 
+    backendSinkDirName = SKStore.DirName::create("/backendSink/");
     _ = backendDir.map(
       SKStore.SID::keyType,
       TickConfigFile::type,

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -210,16 +210,7 @@ fun compile(
     _ = context.mkdir(x ~> x, x ~> x, FileCache.fileDirName);
     _ = context.mkdir(x ~> x, x ~> x, FileCache.fileTimeDirName);
     _ = context.mkdir(x ~> x, x ~> x, FileCache.allFilesDirName);
-  };
 
-  FileCache.writeFiles(
-    context,
-    fileNames,
-    config.dependencies,
-    config.lib_name,
-  );
-
-  if (context.unsafeMaybeGetEagerDir(backendDirName) is None()) {
     outerIst = OuterIstToIR.makeOuterIst(context);
 
     defsProj = outerIst.getFunsProj(context);
@@ -373,6 +364,17 @@ fun compile(
         }
       },
     );
+  };
+
+  FileCache.writeFiles(
+    context,
+    fileNames,
+    config.dependencies,
+    config.lib_name,
+  );
+
+  if (context.unsafeMaybeGetEagerDir(backendDirName) is None()) {
+    void
   } else {
     context
       .unsafeGetEagerDir(backendDirName)

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -193,6 +193,173 @@ fun ensureCompatibleLLVMVersion(): void {
 
 class TickConfigFile(value: (Int, Config.Config)) extends SKStore.File
 
+fun getOrInitializeBackend(
+  context: mutable SKStore.Context,
+  config: Config.Config,
+): SKStore.EagerDir {
+  backendDirName = SKStore.DirName::create("/backend/");
+  context.unsafeMaybeGetEagerDir(backendDirName) match {
+  | Some(dir) -> return dir
+  | None() -> void
+  };
+
+  _ = context.mkdir(x ~> x, x ~> x, FileCache.fileDirName);
+  _ = context.mkdir(x ~> x, x ~> x, FileCache.fileTimeDirName);
+  _ = context.mkdir(x ~> x, x ~> x, FileCache.allFilesDirName);
+  backendDir = context.mkdir(
+    SKStore.IID::keyType,
+    TickConfigFile::type,
+    backendDirName,
+  );
+
+  outerIst = OuterIstToIR.makeOuterIst(context);
+
+  defsProj = outerIst.getFunsProj(context);
+  constsProj = outerIst.getConstsProj(context);
+
+  converter = OuterIstToIR.Converter::create(
+    context,
+    config,
+    SKStore.DirName::create("/converter/"),
+    outerIst,
+  );
+
+  _ = backendDir.map(
+    SKStore.SID::keyType,
+    TickConfigFile::type,
+    context,
+    SKStore.DirName::create("/backendSink/"),
+    (context, _writer, _key, values) ~> {
+      (_, conf) = TickConfigFile::type(values.first).value;
+
+      context.getGlobal("ERRORS") match {
+      | None() -> void
+      | Some(errors) ->
+        SkipError.printErrorsAndExit(
+          SkipError.ErrorsFile::type(errors).value.reversed().toArray(),
+          filename -> {
+            contents = FileCache.fileDir.unsafeGetArray(
+              context,
+              SKStore.SID(filename),
+            )[0].value;
+
+            if (filename.contains(":")) {
+              !filename = filename.splitFirst(":") match {
+              // Display bare paths for errors pertaining to the sklib
+              // currently being built if any.
+              | (l, f) if (Some(l) == conf.lib_name) -> f
+
+              // Errors in dependencies are displayed as:
+              //  /path/to/foo.sklib:src/bar.sk
+              | (l, f) -> conf.dependencies[l].i0 + ":" + f
+              }
+            };
+
+            (filename, contents)
+          },
+        )
+      };
+
+      if (conf.check) {
+        return void;
+      };
+
+      if (conf.emit == "sklib") {
+        compile_sklib(conf);
+        return void
+      };
+
+      // Create a filter for what functions to compile.
+      shouldRuntimeExport = (
+        funDef ~>
+          AsmOutput.cppIsExported(
+            funDef.origName,
+            funDef.annotations,
+            funDef.getPos(),
+            conf.exportedAsFunctions,
+            conf.isWasm(),
+          )
+      );
+
+      // Are we in "disassemble" mode?
+      disasm = (
+        conf.disasmAll ||
+        conf.disasmAnnotated ||
+        !conf.disasmFiles.isEmpty() ||
+        !conf.disasmFunctions.isEmpty()
+      );
+
+      // Create a filter for what functions to disassemble.
+      //
+      // Note that for "disasmAll" we do not return true, since we only want
+      // to disassemble code which is actually used, and returning true would
+      // force everything to be compiled just so it could be disassembled.
+      shouldDisasm = (
+        funDef ~>
+          disasm &&
+            (conf.disasmFunctions.contains(funDef.origName) ||
+              (conf.disasmAnnotated &&
+                annotationsContain(
+                  funDef.annotations,
+                  "@disasm",
+                  funDef.getPos(),
+                )))
+      );
+
+      env = OuterIstToIR.createIR(
+        context,
+        conf,
+        shouldDisasm,
+        shouldRuntimeExport,
+        outerIst,
+        converter,
+        constsProj,
+        defsProj,
+      );
+
+      !env = createOptimizedFunctions(context, env, conf);
+      defs = runCompilerPhase("native/create_asm_graph", () -> {
+        AsmOutput.createAsmDefGraph(env, conf)
+      });
+
+      runCompilerPhase("native/merge_asm_graph", () -> {
+        AsmOutput.mergeIdenticalAsmDefs(defs, conf.debug)
+      });
+
+      runCompilerPhase("native/create_asm_symbols", () -> {
+        AsmOutput.assignFinalSymbols(defs)
+      });
+
+      conf.emit match {
+      | "llvm-ir" -> compile_llvm_ir(defs, conf)
+      | "link" | "cdylib" ->
+        // TODO: Remove exports stuff once --emit=cdylib is supported.
+        wasm_exports = outerIst
+          .getFuns(context, defsProj)
+          .filter(f ->
+            annotationsContainParam(
+              f.annotations,
+              "@wasm_export",
+              f.getPos(),
+            ).isSome() ||
+              annotationsContainParam(
+                f.annotations,
+                "@export",
+                f.getPos(),
+              ).isSome()
+          )
+          .map(exportName);
+        compile_binary(defs, conf, wasm_exports)
+      | "sklib" ->
+        invariant_violation("--emit=sklib should have been handled earlier")
+      | _ -> invariant_violation("Unsupported value for `--emit`: " + conf.emit)
+      }
+    },
+  );
+
+  context.unsafeGetEagerDir(backendDirName)
+}
+
 fun compile(
   config: Config.Config,
   context: mutable SKStore.Context,
@@ -205,163 +372,13 @@ fun compile(
 
   ensureCompatibleLLVMVersion();
 
-  backendDirName = SKStore.DirName::create("/backend/");
-  if (context.unsafeMaybeGetEagerDir(backendDirName) is None()) {
-    _ = context.mkdir(x ~> x, x ~> x, FileCache.fileDirName);
-    _ = context.mkdir(x ~> x, x ~> x, FileCache.fileTimeDirName);
-    _ = context.mkdir(x ~> x, x ~> x, FileCache.allFilesDirName);
-    backendDir = context.mkdir(
-      SKStore.IID::keyType,
-      TickConfigFile::type,
-      backendDirName,
-    );
-
-    outerIst = OuterIstToIR.makeOuterIst(context);
-
-    defsProj = outerIst.getFunsProj(context);
-    constsProj = outerIst.getConstsProj(context);
-
-    converter = OuterIstToIR.Converter::create(
-      context,
-      config,
-      SKStore.DirName::create("/converter/"),
-      outerIst,
-    );
-
-    _ = backendDir.map(
-      SKStore.SID::keyType,
-      TickConfigFile::type,
-      context,
-      SKStore.DirName::create("/backendSink/"),
-      (context, _writer, _key, values) ~> {
-        (_, conf) = TickConfigFile::type(values.first).value;
-
-        context.getGlobal("ERRORS") match {
-        | None() -> void
-        | Some(errors) ->
-          SkipError.printErrorsAndExit(
-            SkipError.ErrorsFile::type(errors).value.reversed().toArray(),
-            filename -> {
-              contents = FileCache.fileDir.unsafeGetArray(
-                context,
-                SKStore.SID(filename),
-              )[0].value;
-
-              if (filename.contains(":")) {
-                !filename = filename.splitFirst(":") match {
-                // Display bare paths for errors pertaining to the sklib
-                // currently being built if any.
-                | (l, f) if (Some(l) == conf.lib_name) -> f
-
-                // Errors in dependencies are displayed as:
-                //  /path/to/foo.sklib:src/bar.sk
-                | (l, f) -> conf.dependencies[l].i0 + ":" + f
-                }
-              };
-
-              (filename, contents)
-            },
-          )
-        };
-
-        if (conf.check) {
-          return void;
-        };
-
-        if (conf.emit == "sklib") {
-          compile_sklib(conf);
-          return void
-        };
-
-        // Create a filter for what functions to compile.
-        shouldRuntimeExport = (
-          funDef ~>
-            AsmOutput.cppIsExported(
-              funDef.origName,
-              funDef.annotations,
-              funDef.getPos(),
-              conf.exportedAsFunctions,
-              conf.isWasm(),
-            )
-        );
-
-        // Are we in "disassemble" mode?
-        disasm = (
-          conf.disasmAll ||
-          conf.disasmAnnotated ||
-          !conf.disasmFiles.isEmpty() ||
-          !conf.disasmFunctions.isEmpty()
-        );
-
-        // Create a filter for what functions to disassemble.
-        //
-        // Note that for "disasmAll" we do not return true, since we only want
-        // to disassemble code which is actually used, and returning true would
-        // force everything to be compiled just so it could be disassembled.
-        shouldDisasm = (
-          funDef ~>
-            disasm &&
-              (conf.disasmFunctions.contains(funDef.origName) ||
-                (conf.disasmAnnotated &&
-                  annotationsContain(
-                    funDef.annotations,
-                    "@disasm",
-                    funDef.getPos(),
-                  )))
-        );
-
-        env = OuterIstToIR.createIR(
-          context,
-          conf,
-          shouldDisasm,
-          shouldRuntimeExport,
-          outerIst,
-          converter,
-          constsProj,
-          defsProj,
-        );
-
-        !env = createOptimizedFunctions(context, env, conf);
-        defs = runCompilerPhase("native/create_asm_graph", () -> {
-          AsmOutput.createAsmDefGraph(env, conf)
-        });
-
-        runCompilerPhase("native/merge_asm_graph", () -> {
-          AsmOutput.mergeIdenticalAsmDefs(defs, conf.debug)
-        });
-
-        runCompilerPhase("native/create_asm_symbols", () -> {
-          AsmOutput.assignFinalSymbols(defs)
-        });
-
-        conf.emit match {
-        | "llvm-ir" -> compile_llvm_ir(defs, conf)
-        | "link" | "cdylib" ->
-          // TODO: Remove exports stuff once --emit=cdylib is supported.
-          wasm_exports = outerIst
-            .getFuns(context, defsProj)
-            .filter(f ->
-              annotationsContainParam(
-                f.annotations,
-                "@wasm_export",
-                f.getPos(),
-              ).isSome() ||
-                annotationsContainParam(
-                  f.annotations,
-                  "@export",
-                  f.getPos(),
-                ).isSome()
-            )
-            .map(exportName);
-          compile_binary(defs, conf, wasm_exports)
-        | "sklib" ->
-          invariant_violation("--emit=sklib should have been handled earlier")
-        | _ ->
-          invariant_violation("Unsupported value for `--emit`: " + conf.emit)
-        }
-      },
-    );
-  };
+  // FIXME: Backend initialization should _not_ peek into the config
+  // as it is likely to change across invocations.
+  getOrInitializeBackend(context, config).writeArray(
+    context,
+    SKStore.IID(0),
+    Array[TickConfigFile((context.tick.value, config))],
+  );
 
   FileCache.writeFiles(
     context,
@@ -369,14 +386,6 @@ fun compile(
     config.dependencies,
     config.lib_name,
   );
-
-  context
-    .unsafeGetEagerDir(backendDirName)
-    .writeArray(
-      context,
-      SKStore.IID(0),
-      Array[TickConfigFile((context.tick.value, config))],
-    );
 
   context.update()
 }

--- a/skiplang/compiler/src/main.sk
+++ b/skiplang/compiler/src/main.sk
@@ -92,6 +92,11 @@ fun main(): void {
   | _ -> void
   };
 
+  if (results.getBool("version")) {
+    print_string(getBuildVersion());
+    skipExit(0);
+  };
+
   config = Config.Config::make(results);
 
   isInit = results.maybeGetString("init").isSome();


### PR DESCRIPTION
A few cosmetic changes to separate the compute graph definition vs triggering of actual compute (by writing to input directories).