### PR TITLE
[sktest] Fix `build.sk`.

### DIFF
--- a/skiplang/sktest/build.sk
+++ b/skiplang/sktest/build.sk
@@ -2,7 +2,7 @@ fun main(): void {
   target = Environ.var("TARGET");
 
   extra_srcs = target match {
-  | "wasm32-unknown-unknown" -> wasm_srcs = Array["extra/src/wasm32.sk"]
+  | "wasm32-unknown-unknown" -> Array["extra/src/wasm32.sk"]
   | _ -> Array["extra/src/host.sk"]
   };
 


### PR DESCRIPTION
This wasn't caught by CI because CI was in an inconsistent state (cf. #374).