### PR TITLE
Rename NonEmptyIterator.convert to map

### DIFF
--- a/skiplang/prelude/src/skstore/Handle.sk
+++ b/skiplang/prelude/src/skstore/Handle.sk
@@ -120,7 +120,7 @@ mutable class NonEmptyIterator<+T>(
     )
   }
 
-  mutable fun convert<V>(conv: T ~> V): mutable NonEmptyIterator<V> {
+  mutable fun map<V>(conv: T -> V): mutable NonEmptyIterator<V> {
     this.materializeIter();
     materializedIter = this.materializedIter.map(v -> v.map(conv));
     mutable NonEmptyIterator(

--- a/skipruntime-ts/core/native/src/Runtime.sk
+++ b/skipruntime-ts/core/native/src/Runtime.sk
@@ -521,7 +521,7 @@ class Collection(
           try {
             for (entry in mapper.mapElement(
               keyConverter.toJSON(key),
-              it.convert(fileConverter.toJSON),
+              it.map(fileConverter.toJSON),
             )) {
               writer.append(
                 keyConverter.fromJSON(entry.i0),
@@ -703,7 +703,7 @@ class Collection(
           try {
             for (entry in mapper.mapElement(
               keyConverter.toJSON(key),
-              it.convert(fileConverter.toJSON),
+              it.map(fileConverter.toJSON),
             )) {
               writer.append(
                 keyConverter.fromJSON(entry.i0),


### PR DESCRIPTION
To do so requires allowing the mapped function to be impure.