### PR TITLE
More renamings and cleanups around external resource API

### DIFF
--- a/skipruntime-ts/core/native/src/Extern.sk
+++ b/skipruntime-ts/core/native/src/Extern.sk
@@ -719,14 +719,19 @@ fun jsonExtractOfContext(
   SKJSON.CJArray(jsonExtract(from, pattern))
 }
 
-@export("SkipRuntime_Context__manageResource")
-fun manageResourceOfSKStore(
+@export("SkipRuntime_Context__useExternalResource")
+fun useExternalResource(
   supplier: String,
   resource: String,
   jsonparams: SKJSON.CJObject,
   reactiveAuth: ?Array<UInt8>,
 ): String {
-  manageResource(supplier, resource, params(jsonparams), reactiveAuth).getId()
+  useExternalCollection(
+    supplier,
+    resource,
+    params(jsonparams),
+    reactiveAuth,
+  ).getId()
 }
 
 /************ initService ****************/

--- a/skipruntime-ts/core/native/src/Runtime.sk
+++ b/skipruntime-ts/core/native/src/Runtime.sk
@@ -358,7 +358,7 @@ fun jsonExtract(from: SKJSON.CJObject, pattern: String): Array<SKJSON.CJSON> {
   values.toArray()
 }
 
-fun manageResource(
+fun useExternalCollection(
   supplier: String,
   resource: String,
   params: Map<String, PValue>,

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1010,7 +1010,7 @@ class ContextImpl extends SkFrozen implements Context {
   useExternalResource<K extends TJSON, V extends TJSON>(
     supplier: string,
     resource: string,
-    params: Record<string, string | number>,
+    params: Record<string, string | number> = {},
     reactiveAuth?: Uint8Array,
   ): EagerCollection<K, V> {
     const skcollection =

--- a/skipruntime-ts/core/src/skip-runtime.ts
+++ b/skipruntime-ts/core/src/skip-runtime.ts
@@ -31,7 +31,7 @@ export {
   SkipRESTRuntime,
   type Entrypoint,
 } from "./skipruntime_rest.js";
-export { RemoteResources } from "./skipruntime_remote.js";
+export { ExternalSkipService } from "./skipruntime_remote.js";
 export {
   type ExternalResource,
   ExternalService,

--- a/skipruntime-ts/core/src/skip-runtime.ts
+++ b/skipruntime-ts/core/src/skip-runtime.ts
@@ -34,6 +34,6 @@ export {
 export { RemoteResources } from "./skipruntime_remote.js";
 export {
   type ExternalResource,
-  ExternalResources,
+  ExternalService,
   Polled,
 } from "./skipruntime_helpers.js";

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -252,7 +252,7 @@ export interface Context extends Constant {
   useExternalResource<K extends TJSON, V extends TJSON>(
     supplier: string,
     resource: string,
-    params: Record<string, string | number>,
+    params?: Record<string, string | number>,
     reactiveAuth?: Uint8Array,
   ): EagerCollection<K, V>;
 

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -249,7 +249,7 @@ export interface Context extends Constant {
     ...params: Params
   ): LazyCollection<K, V>;
 
-  manageResource<K extends TJSON, V extends TJSON>(
+  useExternalResource<K extends TJSON, V extends TJSON>(
     supplier: string,
     resource: string,
     params: Record<string, string | number>,
@@ -347,7 +347,7 @@ export interface Resource {
 
 export interface SkipService {
   inputCollections?: Record<string, [TJSON, TJSON][]>;
-  remoteCollections?: Record<string, ExternalSupplier>;
+  externalServices?: Record<string, ExternalSupplier>;
   resources?: Record<string, new (params: Record<string, string>) => Resource>;
 
   reactiveCompute(

--- a/skipruntime-ts/core/src/skipruntime_helpers.ts
+++ b/skipruntime-ts/core/src/skipruntime_helpers.ts
@@ -14,7 +14,7 @@ export interface ExternalResource {
   ): void;
 }
 
-export class ExternalResources implements ExternalSupplier {
+export class ExternalService implements ExternalSupplier {
   constructor(private resources: Record<string, ExternalResource>) {}
 
   link(

--- a/skipruntime-ts/core/src/skipruntime_remote.ts
+++ b/skipruntime-ts/core/src/skipruntime_remote.ts
@@ -12,7 +12,7 @@ interface Closable {
   close(): void;
 }
 
-export class RemoteResources implements ExternalSupplier {
+export class ExternalSkipService implements ExternalSupplier {
   private client?: Promise<[Client, Protocol.Creds]>;
   private resources = new Map<string, Closable>();
 
@@ -34,17 +34,17 @@ export class RemoteResources implements ExternalSupplier {
       reactiveAuth: Uint8Array,
     ) => Promise<ReactiveResponse>,
     creds?: Protocol.Creds,
-  ): RemoteResources {
+  ): ExternalSkipService {
     let uri = `ws://${entrypoint.host}:${entrypoint.port.toString()}`;
     if (entrypoint.secured)
       uri = `wss://${entrypoint.host}:${entrypoint.port.toString()}`;
-    return new RemoteResources(uri, auth, creds);
+    return new ExternalSkipService(uri, auth, creds);
   }
 
   static direct(
     entrypoint: Entrypoint,
     creds?: Protocol.Creds,
-  ): RemoteResources {
+  ): ExternalSkipService {
     let uri = `http://${entrypoint.host}:${entrypoint.port.toString()}`;
     if (entrypoint.secured)
       uri = `https://${entrypoint.host}:${entrypoint.port.toString()}`;
@@ -70,7 +70,7 @@ export class RemoteResources implements ExternalSupplier {
         return value;
       }) as ReactiveResponse;
     };
-    return new RemoteResources(uri, auth, creds);
+    return new ExternalSkipService(uri, auth, creds);
   }
 
   link(

--- a/skipruntime-ts/core/test/runtime.spec.ts
+++ b/skipruntime-ts/core/test/runtime.spec.ts
@@ -778,28 +778,22 @@ class ExternalResource implements Resource {
     },
     reactiveAuth?: Uint8Array,
   ): EagerCollection<number, number[]> {
-    const v1 = cs.input2.maybeGetOne(0);
-    const v2 = cs.input2.maybeGetOne(1);
-    const external = context.manageResource(
+    const v1 = (cs.input2.maybeGetOne(0) ?? 0).toString();
+    const v2 = (cs.input2.maybeGetOne(1) ?? 0).toString();
+    const external = context.useExternalResource<number, number>(
       "external",
       "mock",
-      {
-        v1: (v1 ?? 0).toString(),
-        v2: (v2 ?? 0).toString(),
-      },
+      { v1, v2 },
       reactiveAuth,
     );
-    return cs.input1.map(
-      ExternalCheck,
-      external as EagerCollection<number, number>,
-    );
+    return cs.input1.map(ExternalCheck, external);
   }
 }
 
 class ExternalService implements SkipService {
   inputCollections = { input1: [], input2: [] };
   resources = { external: ExternalResource };
-  remoteCollections = { external: new External() };
+  externalServices = { external: new External() };
 
   reactiveCompute(
     _context: Context,
@@ -859,7 +853,7 @@ class TokensResource implements Resource {
     _cs: Record<string, EagerCollection<TJSON, TJSON>>,
     reactiveAuth?: Uint8Array,
   ): EagerCollection<string, number> {
-    return context.manageResource(
+    return context.useExternalResource(
       "system",
       "timer",
       { "5ms": 5 },
@@ -874,7 +868,7 @@ const system = new ExternalResources({ timer: new TimeCollection() });
 class TokensService implements SkipService {
   inputCollections = { input: [] };
   resources = { tokens: TokensResource };
-  remoteCollections = { system };
+  externalServices = { system };
 
   reactiveCompute(
     _context: Context,

--- a/skipruntime-ts/core/test/runtime.spec.ts
+++ b/skipruntime-ts/core/test/runtime.spec.ts
@@ -15,10 +15,7 @@ import type {
   ExternalSupplier,
 } from "../src/skip-runtime.js";
 import { Sum, ValueMapper, initService } from "../src/skip-runtime.js";
-import {
-  TimeCollection,
-  ExternalResources,
-} from "../src/skipruntime_helpers.js";
+import { TimeCollection, ExternalService } from "../src/skipruntime_helpers.js";
 
 //// testMap1
 
@@ -790,7 +787,7 @@ class ExternalResource implements Resource {
   }
 }
 
-class ExternalService implements SkipService {
+class TestExternalService implements SkipService {
   inputCollections = { input1: [], input2: [] };
   resources = { external: ExternalResource };
   externalServices = { external: new External() };
@@ -806,9 +803,9 @@ class ExternalService implements SkipService {
   }
 }
 
-it("testExtenal", async () => {
+it("testExternal", async () => {
   const resource = "external";
-  const runtime = await initService(new ExternalService());
+  const runtime = await initService(new TestExternalService());
   runtime.update("input1", [
     [0, [10]],
     [1, [20]],
@@ -863,7 +860,7 @@ class TokensResource implements Resource {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-const system = new ExternalResources({ timer: new TimeCollection() });
+const system = new ExternalService({ timer: new TimeCollection() });
 
 class TokensService implements SkipService {
   inputCollections = { input: [] };

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -5,7 +5,7 @@ import type {
   Resource,
 } from "@skipruntime/core";
 import { runService } from "@skipruntime/server";
-import { ExternalResources, Polled } from "@skipruntime/core";
+import { ExternalService, Polled } from "@skipruntime/core";
 
 type Departure = {
   year: string;
@@ -58,7 +58,7 @@ class Service implements SkipService {
     departures: DeparturesResource,
   };
   externalServices = {
-    http: new ExternalResources({ departures }),
+    http: new ExternalService({ departures }),
   };
 
   reactiveCompute(

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -47,7 +47,8 @@ class DeparturesResource implements Resource {
       asylum: get("asylum", "JOR,LBN"),
       resettlement: get("resettlement", "NOR,USA"),
     };
-    return context.manageResource("http", "departures", params);
+
+    return context.useExternalResource("http", "departures", params);
   }
 }
 
@@ -56,7 +57,7 @@ class Service implements SkipService {
   resources = {
     departures: DeparturesResource,
   };
-  remoteCollections = {
+  externalServices = {
     http: new ExternalResources({ departures }),
   };
 

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -7,7 +7,7 @@ import type {
   SkipService,
   Resource,
 } from "@skipruntime/core";
-import { RemoteResources } from "@skipruntime/core";
+import { ExternalSkipService } from "@skipruntime/core";
 
 import { runService } from "@skipruntime/server";
 
@@ -41,7 +41,7 @@ class MultResource implements Resource {
 class Service implements SkipService {
   resources = { data: MultResource };
   externalServices = {
-    sumexample: RemoteResources.direct({ host: "localhost", port: 3587 }),
+    sumexample: ExternalSkipService.direct({ host: "localhost", port: 3587 }),
   };
 
   reactiveCompute(

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -26,15 +26,23 @@ class MultResource implements Resource {
     context: Context,
     _collections: Record<string, EagerCollection<TJSON, TJSON>>,
   ): EagerCollection<string, number> {
-    const sub = context.manageResource<string, number>("sumexample", "sub", {});
-    const add = context.manageResource<string, number>("sumexample", "add", {});
+    const sub = context.useExternalResource<string, number>(
+      "sumexample",
+      "sub",
+      {},
+    );
+    const add = context.useExternalResource<string, number>(
+      "sumexample",
+      "add",
+      {},
+    );
     return sub.merge(add).map(Mult);
   }
 }
 
 class Service implements SkipService {
   resources = { data: MultResource };
-  remoteCollections = {
+  externalServices = {
     sumexample: RemoteResources.direct({ host: "localhost", port: 3587 }),
   };
 

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -29,12 +29,10 @@ class MultResource implements Resource {
     const sub = context.useExternalResource<string, number>(
       "sumexample",
       "sub",
-      {},
     );
     const add = context.useExternalResource<string, number>(
       "sumexample",
       "add",
-      {},
     );
     return sub.merge(add).map(Mult);
   }


### PR DESCRIPTION
These are from discussion yesterday at the office hours with Julien and Daniel.  Nothing too controversial I hope, and can always tweak more going forward.

Also made the `params` argument to useExternalResource optional, defaulting to empty.