### PR TITLE
Adds the constructor signature to the Resource interface.

### DIFF
--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -353,6 +353,8 @@ export interface ExternalSupplier {
 }
 
 export interface Resource {
+  constructor(params: Record<string, string>);
+
   reactiveCompute(
     context: Context,
     collections: Record<string, EagerCollection<TJSON, TJSON>>,


### PR DESCRIPTION
This doesn't change anything at runtime, but helps with discoverability. When somebody is trying to define a resource, what will happen is that they will sometimes need parameters. So for example, if we hit the endpoint:
http://myapi.foo.com/myresource?name=julien.  In this example, we are defining the resource myresource and we have { "name": "julien" } as a arguments.

The arguments are passed to us through the constructor. But since the constructor signature was not part of the interface, it was hard to discover ... This diff fixes that.