### PR TITLE
Pass object to use external resource

### DIFF
--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1021,18 +1021,18 @@ class ContextImpl extends SkFrozen implements Context {
     return new LazyCollectionImpl<K, V>(lazyCollection, this.refs);
   }
 
-  useExternalResource<K extends TJSON, V extends TJSON>(
+  useExternalResource<K extends TJSON, V extends TJSON>(service: {
     supplier: string,
     resource: string,
-    params: Record<string, string | number> = {},
+    params?: Record<string, string | number>,
     reactiveAuth?: Uint8Array,
-  ): EagerCollection<K, V> {
+  }): EagerCollection<K, V> {
     const skcollection =
       this.refs.fromWasm.SkipRuntime_Context__useExternalResource(
-        this.refs.skjson.exportString(supplier),
-        this.refs.skjson.exportString(resource),
-        this.refs.skjson.exportJSON(params),
-        reactiveAuth ? this.refs.skjson.exportBytes(reactiveAuth) : null,
+        this.refs.skjson.exportString(service.supplier),
+        this.refs.skjson.exportString(service.resource),
+        this.refs.skjson.exportJSON((service.params === undefined)? {} : service.params),
+        service.reactiveAuth ? this.refs.skjson.exportBytes(service.reactiveAuth) : null,
       );
     const collection = this.refs.skjson.importString(skcollection);
     return new EagerCollectionImpl<K, V>(collection, this.refs);

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1031,9 +1031,7 @@ class ContextImpl extends SkFrozen implements Context {
       this.refs.fromWasm.SkipRuntime_Context__useExternalResource(
         this.refs.skjson.exportString(service.supplier),
         this.refs.skjson.exportString(service.resource),
-        this.refs.skjson.exportJSON(
-          service.params === undefined ? {} : service.params,
-        ),
+        this.refs.skjson.exportJSON(service.params ?? {}),
         service.reactiveAuth
           ? this.refs.skjson.exportBytes(service.reactiveAuth)
           : null,

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -1022,17 +1022,21 @@ class ContextImpl extends SkFrozen implements Context {
   }
 
   useExternalResource<K extends TJSON, V extends TJSON>(service: {
-    supplier: string,
-    resource: string,
-    params?: Record<string, string | number>,
-    reactiveAuth?: Uint8Array,
+    supplier: string;
+    resource: string;
+    params?: Record<string, string | number>;
+    reactiveAuth?: Uint8Array;
   }): EagerCollection<K, V> {
     const skcollection =
       this.refs.fromWasm.SkipRuntime_Context__useExternalResource(
         this.refs.skjson.exportString(service.supplier),
         this.refs.skjson.exportString(service.resource),
-        this.refs.skjson.exportJSON((service.params === undefined)? {} : service.params),
-        service.reactiveAuth ? this.refs.skjson.exportBytes(service.reactiveAuth) : null,
+        this.refs.skjson.exportJSON(
+          service.params === undefined ? {} : service.params,
+        ),
+        service.reactiveAuth
+          ? this.refs.skjson.exportBytes(service.reactiveAuth)
+          : null,
       );
     const collection = this.refs.skjson.importString(skcollection);
     return new EagerCollectionImpl<K, V>(collection, this.refs);

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -251,10 +251,11 @@ export interface Context extends Constant {
 
   /**
    * Call a external service to manage an external resource
-   * @param supplier - the name of the external supplier corresponding to a key in externalServices field of SkipService
-   * @param resource - the resource name managed by the supplier
-   * @param params - the parameters to apply to the resource
-   * @param reactiveAuth - the caller client user Skip session authentification
+   * @param service - the object configuring the external service
+   * @param service.supplier - the name of the external supplier corresponding to a key in externalServices field of SkipService
+   * @param service.resource - the resource name managed by the supplier
+   * @param service.params - the parameters to apply to the resource
+   * @param service.reactiveAuth - the caller client user Skip session authentification
    * @returns The reactive collection of the external resource
    */
   useExternalResource<K extends TJSON, V extends TJSON>(service: {

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -258,10 +258,10 @@ export interface Context extends Constant {
    * @returns The reactive collection of the external resource
    */
   useExternalResource<K extends TJSON, V extends TJSON>(service: {
-    supplier: string,
-    resource: string,
-    params?: Record<string, string | number>,
-    reactiveAuth?: Uint8Array,
+    supplier: string;
+    resource: string;
+    params?: Record<string, string | number>;
+    reactiveAuth?: Uint8Array;
   }): EagerCollection<K, V>;
 
   jsonExtract(value: JSONObject, pattern: string): TJSON[];

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -257,12 +257,12 @@ export interface Context extends Constant {
    * @param reactiveAuth - the caller client user Skip session authentification
    * @returns The reactive collection of the external resource
    */
-  useExternalResource<K extends TJSON, V extends TJSON>(
+  useExternalResource<K extends TJSON, V extends TJSON>(service: {
     supplier: string,
     resource: string,
     params?: Record<string, string | number>,
     reactiveAuth?: Uint8Array,
-  ): EagerCollection<K, V>;
+  }): EagerCollection<K, V>;
 
   jsonExtract(value: JSONObject, pattern: string): TJSON[];
 }

--- a/skipruntime-ts/core/test/runtime.spec.ts
+++ b/skipruntime-ts/core/test/runtime.spec.ts
@@ -781,11 +781,12 @@ class ExternalResource implements Resource {
   ): EagerCollection<number, number[]> {
     const v1 = (cs.input2.maybeGetOne(0) ?? 0).toString();
     const v2 = (cs.input2.maybeGetOne(1) ?? 0).toString();
-    const external = context.useExternalResource<number, number>(
-      "external",
-      "mock",
-      { v1, v2 },
+    const external = context.useExternalResource<number, number>({
+      supplier: "external",
+      resource: "mock",
+      params: { v1, v2 },
       reactiveAuth,
+    }
     );
     return cs.input1.map(ExternalCheck, external);
   }
@@ -854,11 +855,12 @@ class TokensResource implements Resource {
     _cs: Record<string, EagerCollection<TJSON, TJSON>>,
     reactiveAuth?: Uint8Array,
   ): EagerCollection<string, number> {
-    return context.useExternalResource(
-      "system",
-      "timer",
-      { "5ms": 5 },
+    return context.useExternalResource({
+      supplier: "system",
+      resource: "timer",
+      params: { "5ms": 5 },
       reactiveAuth,
+    }
     );
   }
 }

--- a/skipruntime-ts/core/test/runtime.spec.ts
+++ b/skipruntime-ts/core/test/runtime.spec.ts
@@ -786,8 +786,7 @@ class ExternalResource implements Resource {
       resource: "mock",
       params: { v1, v2 },
       reactiveAuth,
-    }
-    );
+    });
     return cs.input1.map(ExternalCheck, external);
   }
 }
@@ -860,8 +859,7 @@ class TokensResource implements Resource {
       resource: "timer",
       params: { "5ms": 5 },
       reactiveAuth,
-    }
-    );
+    });
   }
 }
 

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -42,11 +42,7 @@ class DeparturesResource implements Resource {
       resettlement: get("resettlement", "NOR,USA"),
     };
 
-    return context.useExternalResource(
-      "externalDeparturesAPI",
-      "departures",
-      params,
-    );
+    return context.useExternalResource({supplier: "http", resource: "departures", params});
   }
 }
 

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -42,7 +42,11 @@ class DeparturesResource implements Resource {
       resettlement: get("resettlement", "NOR,USA"),
     };
 
-    return context.useExternalResource({supplier: "http", resource: "departures", params});
+    return context.useExternalResource({
+      supplier: "http",
+      resource: "departures",
+      params,
+    });
   }
 }
 

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -27,12 +27,10 @@ class MultResource implements Resource {
     _collections: Record<string, EagerCollection<TJSON, TJSON>>,
   ): EagerCollection<string, number> {
     const sub = context.useExternalResource<string, number>(
-      "sumexample",
-      "sub",
+      {supplier: "sumexample", resource: "sub"},
     );
     const add = context.useExternalResource<string, number>(
-      "sumexample",
-      "add",
+      {supplier: "sumexample", resource: "add"},
     );
     return sub.merge(add).map(Mult);
   }

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -26,12 +26,14 @@ class MultResource implements Resource {
     context: Context,
     _collections: Record<string, EagerCollection<TJSON, TJSON>>,
   ): EagerCollection<string, number> {
-    const sub = context.useExternalResource<string, number>(
-      {supplier: "sumexample", resource: "sub"},
-    );
-    const add = context.useExternalResource<string, number>(
-      {supplier: "sumexample", resource: "add"},
-    );
+    const sub = context.useExternalResource<string, number>({
+      supplier: "sumexample",
+      resource: "sub",
+    });
+    const add = context.useExternalResource<string, number>({
+      supplier: "sumexample",
+      resource: "add",
+    });
     return sub.merge(add).map(Mult);
   }
 }


### PR DESCRIPTION
 Refactor useExternalResource to take an object as a parameter.
    
The idea is that this:
```
useExternalResource({ supplier: "foo", resource: "rname", params: ... })
```
    
Is more readable than:
```
useExternalResource("foo", "rname", ...)
```
