### PR TITLE
Print error message when client cannot connect to the websocket.

### DIFF
--- a/skipruntime-ts/client/src/client.ts
+++ b/skipruntime-ts/client/src/client.ts
@@ -40,16 +40,16 @@ async function createWs(uri: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const socket = new WebSocket(uri);
     socket.binaryType = "arraybuffer";
-    socket.onclose = (_event) => {
+    socket.onclose = (_event: any) => {
       reject(new Error("Socket closed before open"));
     };
-    socket.onerror = (_event) => {
+    socket.onerror = (_event: any) => {
       reject(new Error("Socket error"));
     };
-    socket.onmessage = (_event) => {
+    socket.onmessage = (_event: any) => {
       reject(new Error("Socket messaged before open"));
     };
-    socket.onopen = (_event) => {
+    socket.onopen = (_event: any) => {
       resolve(socket);
     };
   });
@@ -106,7 +106,8 @@ class ResilientWebSocket {
 
         this.socket = socket;
         return;
-      } catch (_error) {
+      } catch (error) {
+        console.error(error);
         const backoffMs = 500 + Math.random() * 1000;
         await new Promise((resolve) => setTimeout(resolve, backoffMs));
       }


### PR DESCRIPTION
I also added `import { WebSocket } from 'ws'` for older version of node that don't have it by default.