### PR TITLE
Rename SkipService inputCollections to initialData

### DIFF
--- a/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
@@ -27,7 +27,7 @@ type Upvote = {
 type Upvoted = Post & { upvotes: number; author: User };
 
 export default class HackerNewsService implements SkipService {
-  inputCollections: {
+  initialData: {
     posts: Entry<string, Post>[];
     users: Entry<string, User>[];
     upvotes: Entry<string, Upvote>[];
@@ -39,7 +39,7 @@ export default class HackerNewsService implements SkipService {
     users: Entry<string, User>[],
     upvotes: Entry<string, Upvote>[],
   ) {
-    this.inputCollections = { posts, users, upvotes };
+    this.initialData = { posts, users, upvotes };
   }
 
   reactiveCompute(inputCollections: {

--- a/skipruntime-ts/core/native/src/BaseTypes.sk
+++ b/skipruntime-ts/core/native/src/BaseTypes.sk
@@ -82,7 +82,7 @@ base class ResourceBuilder {
 }
 
 base class Service(
-  inputCollections: Array<Input>,
+  initialData: Array<Input>,
   resources: Map<String, ResourceBuilder>,
   remoteCollections: Map<String, ExternalSupplier> = Map[],
 ) {

--- a/skipruntime-ts/core/native/src/Runtime.sk
+++ b/skipruntime-ts/core/native/src/Runtime.sk
@@ -245,7 +245,7 @@ fun initService(service: Service): Result<void, .Exception> {
         Array[(SKStore.IID(0), SKStore.StringFile(session))],
       );
       mInputs = mutable Map<String, Collection>[];
-      service.inputCollections.each(input -> {
+      service.initialData.each(input -> {
         iDirName = SKStore.DirName::create(`/${input.name}/`);
         context.mkdirMulti(
           iDirName,

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -887,7 +887,7 @@ class LinksImpl implements Links {
       }
       const skservice = this.fromWasm.SkipRuntime_createService(
         this.handles.register(service),
-        skjson.exportJSON(service.inputCollections ?? {}),
+        skjson.exportJSON(service.initialData ?? {}),
         skresources,
         skExternalServices,
       );

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -382,8 +382,8 @@ export interface Resource {
 }
 
 export interface SkipService {
-  /** The input collections specification of the service */
-  inputCollections?: Record<string, Entry<TJSON, TJSON>[]>;
+  /** The data used to initially populate the input collections of the service */
+  initialData?: Record<string, Entry<TJSON, TJSON>[]>;
   /** The external services of the service */
   externalServices?: Record<string, ExternalSupplier>;
   /** The reactive resources of the service */

--- a/skipruntime-ts/core/test/runtime.spec.ts
+++ b/skipruntime-ts/core/test/runtime.spec.ts
@@ -37,7 +37,7 @@ class Map1Resource implements Resource {
 }
 
 class Map1Service implements SkipService {
-  inputCollections = { input: [] };
+  initialData = { input: [] };
   resources = { map1: Map1Resource };
 
   reactiveCompute(inputCollections: {
@@ -83,7 +83,7 @@ class Map2Resource implements Resource {
 }
 
 class Map2Service implements SkipService {
-  inputCollections = { input1: [], input2: [] };
+  initialData = { input1: [], input2: [] };
   resources = { map2: Map2Resource };
 
   reactiveCompute(inputCollections: {
@@ -129,7 +129,7 @@ class Map3Resource implements Resource {
 }
 
 class Map3Service implements SkipService {
-  inputCollections = { input1: [], input2: [] };
+  initialData = { input1: [], input2: [] };
   resources = { map3: Map3Resource };
 
   reactiveCompute(inputCollections: {
@@ -177,7 +177,7 @@ class OneToOneMapperResource implements Resource {
 }
 
 class OneToOneMapperService implements SkipService {
-  inputCollections = { input: [] };
+  initialData = { input: [] };
   resources = { valueMapper: OneToOneMapperResource };
 
   reactiveCompute(inputCollections: {
@@ -227,7 +227,7 @@ class SizeResource implements Resource {
 }
 
 class SizeService implements SkipService {
-  inputCollections = { input1: [], input2: [] };
+  initialData = { input1: [], input2: [] };
   resources = { size: SizeResource };
 
   reactiveCompute(inputCollections: {
@@ -289,7 +289,7 @@ class SlicedMap1Resource implements Resource {
 }
 
 class SlicedMap1Service implements SkipService {
-  inputCollections = { input: [] };
+  initialData = { input: [] };
   resources = { slice: SlicedMap1Resource };
 
   reactiveCompute(inputCollections: {
@@ -356,7 +356,7 @@ class LazyResource implements Resource {
 }
 
 class LazyService implements SkipService {
-  inputCollections = { input: [] };
+  initialData = { input: [] };
   resources = { lazy: LazyResource };
 
   reactiveCompute(inputCollections: {
@@ -410,7 +410,7 @@ class MapReduceResource implements Resource {
 }
 
 class MapReduceService implements SkipService {
-  inputCollections = { input: [] };
+  initialData = { input: [] };
   resources = { mapReduce: MapReduceResource };
 
   reactiveCompute(inputCollections: {
@@ -465,7 +465,7 @@ class Merge1Resource implements Resource {
 }
 
 class Merge1Service implements SkipService {
-  inputCollections = { input1: [], input2: [] };
+  initialData = { input1: [], input2: [] };
   resources = { merge1: Merge1Resource };
 
   reactiveCompute(inputCollections: {
@@ -522,7 +522,7 @@ class MergeReduceResource implements Resource {
 }
 
 class MergeReduceService implements SkipService {
-  inputCollections = { input1: [], input2: [] };
+  initialData = { input1: [], input2: [] };
   resources = { mergeReduce: MergeReduceResource };
 
   reactiveCompute(inputCollections: {
@@ -582,7 +582,7 @@ class JSONExtractResource implements Resource {
 }
 
 class JSONExtractService implements SkipService {
-  inputCollections = { input: [] };
+  initialData = { input: [] };
   resources = { jsonExtract: JSONExtractResource };
 
   reactiveCompute(inputCollections: {
@@ -740,7 +740,7 @@ class ExternalResource implements Resource {
 }
 
 class TestExternalService implements SkipService {
-  inputCollections = { input1: [], input2: [] };
+  initialData = { input1: [], input2: [] };
   resources = { external: ExternalResource };
   externalServices = { external: new External() };
 
@@ -811,7 +811,7 @@ class TokensResource implements Resource {
 const system = new ExternalService({ timer: new TimeCollection() });
 
 class TokensService implements SkipService {
-  inputCollections = { input: [] };
+  initialData = { input: [] };
   resources = { tokens: TokensResource };
   externalServices = { system };
 
@@ -854,7 +854,7 @@ class Resource2 implements Resource {
 }
 
 class MultipleResourcesService implements SkipService {
-  inputCollections = { input1: [], input2: [] };
+  initialData = { input1: [], input2: [] };
   resources = { resource1: Resource1, resource2: Resource2 };
 
   reactiveCompute(inputCollections: {

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -87,10 +87,10 @@ class UsersResource implements Resource {
 /*****************************************************************************/
 
 class Service implements SkipService {
-  inputCollections: { users: Entry<string, User>[] };
+  initialData: { users: Entry<string, User>[] };
 
   constructor(users: Entry<string, User>[]) {
-    this.inputCollections = { users };
+    this.initialData = { users };
   }
 
   resources = {

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -51,7 +51,7 @@ class DeparturesResource implements Resource {
 }
 
 class Service implements SkipService {
-  inputCollections = { config: [] };
+  initialData = { config: [] };
   resources = {
     departures: DeparturesResource,
   };

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -73,7 +73,7 @@ class ComputedCells implements Resource {
 }
 
 class Service implements SkipService {
-  inputCollections = { cells: [] };
+  initialData = { cells: [] };
   resources = { computed: ComputedCells };
 
   reactiveCompute(

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -43,7 +43,7 @@ class Sub implements Resource {
 }
 
 class Service implements SkipService {
-  inputCollections = { input1: [], input2: [] };
+  initialData = { input1: [], input2: [] };
   resources = { add: Add, sub: Sub };
 
   reactiveCompute(


### PR DESCRIPTION
I am finding the name of the inputCollections field of SkipService
confusing, and so propose a renaming. There are two aspects: the type of the
field is not a Collection in the Skip sense, and the name inputCollections
is also used for that actual collections argument of reactiveCompute. The
reuse of the name is confusing, I think, as the field is the initial data
while the argument is the working data of the service. Users should not ever
read the inputCollections field, only provide it for runService (and
eventually initService) to read. But users should read from the
inputCollections argument. I think that renaming to emphasize that the field
is only the initial data will help.