### PR TITLE
Simplify nomenclature around external services

### DIFF
--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -320,9 +320,20 @@ export type ReactiveResponse = {
 };
 
 /**
- * ExternalSupplier allows to have access to external ressources
+ * External services must be carefully managed in reactive Skip services to make sure that
+ * dependencies are properly tracked and data from external systems is kept up to date.
+ *
+ * There are two main implementations of `ExternalService`, depending on whether the external
+ * data source is a reactive Skip service or not.
+ *
+ * If it _is_ a Skip service, then use `SkipExternalService`, specifying an entrypoint and/or
+ * auth handler.  The external Skip service will update its resources reactively and those
+ * changes will propagate through this service.
+ *
+ * If it is _not_ a Skip service, then use `GenericExternalService` and `Polled` to specify
+ * the external source and desired polling frequency.
  */
-export interface ExternalSupplier {
+export interface ExternalService {
   /**
    * Subscribe to the external resource
    * @param resource - the name of the external resource
@@ -383,7 +394,7 @@ export interface SkipService {
   /** The data used to initially populate the input collections of the service */
   initialData?: Record<string, Entry<TJSON, TJSON>[]>;
   /** The external services of the service */
-  externalServices?: Record<string, ExternalSupplier>;
+  externalServices?: Record<string, ExternalService>;
   /** The reactive resources of the service */
   resources?: Record<string, new (params: Record<string, string>) => Resource>;
 

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -5,7 +5,7 @@ import type {
   Resource,
 } from "skip-wasm";
 import { runService } from "@skipruntime/server";
-import { ExternalService, Polled } from "skip-wasm";
+import { GenericExternalService, Polled } from "skip-wasm";
 
 type Departure = {
   year: string;
@@ -56,7 +56,7 @@ class Service implements SkipService {
     departures: DeparturesResource,
   };
   externalServices = {
-    externalDeparturesAPI: new ExternalService({
+    externalDeparturesAPI: new GenericExternalService({
       departuresFromAPI: new Polled(
         "https://api.unhcr.org/rsq/v1/departures",
         10000,

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -6,7 +6,7 @@ import type {
   SkipService,
   Resource,
 } from "skip-wasm";
-import { ExternalSkipService, ManyToOneMapper } from "skip-wasm";
+import { SkipExternalService, ManyToOneMapper } from "skip-wasm";
 
 import { runService } from "@skipruntime/server";
 
@@ -36,7 +36,7 @@ class MultResource implements Resource {
 class Service implements SkipService {
   resources = { data: MultResource };
   externalServices = {
-    sumexample: ExternalSkipService.direct({ host: "localhost", port: 3587 }),
+    sumexample: SkipExternalService.direct({ host: "localhost", port: 3587 }),
   };
 
   reactiveCompute(

--- a/skipruntime-ts/helpers/src/external.ts
+++ b/skipruntime-ts/helpers/src/external.ts
@@ -1,4 +1,4 @@
-import type { Entry, ExternalSupplier, TJSON } from "@skipruntime/api";
+import type { Entry, ExternalService, TJSON } from "@skipruntime/api";
 import { fetchJSON } from "./rest.js";
 
 export interface ExternalResource {
@@ -18,7 +18,7 @@ export interface ExternalResource {
   ): void;
 }
 
-export class ExternalService implements ExternalSupplier {
+export class GenericExternalService implements ExternalService {
   constructor(private resources: Record<string, ExternalResource>) {}
 
   subscribe(

--- a/skipruntime-ts/helpers/src/external.ts
+++ b/skipruntime-ts/helpers/src/external.ts
@@ -61,7 +61,7 @@ export class GenericExternalService implements ExternalService {
 
 type Timeout = ReturnType<typeof setInterval>;
 
-export class TimeCollection implements ExternalResource {
+export class TimerResource implements ExternalResource {
   private intervals = new Map<string, Record<string, Timeout>>();
 
   open(

--- a/skipruntime-ts/helpers/src/index.ts
+++ b/skipruntime-ts/helpers/src/index.ts
@@ -1,5 +1,9 @@
-export { ExternalSkipService } from "./remote.js";
-export { type ExternalResource, ExternalService, Polled } from "./external.js";
+export { SkipExternalService } from "./remote.js";
+export {
+  type ExternalResource,
+  GenericExternalService,
+  Polled,
+} from "./external.js";
 export {
   Sum,
   Min,

--- a/skipruntime-ts/helpers/src/remote.ts
+++ b/skipruntime-ts/helpers/src/remote.ts
@@ -1,6 +1,6 @@
 import type {
   Entry,
-  ExternalSupplier,
+  ExternalService,
   ReactiveResponse,
   TJSON,
 } from "@skipruntime/api";
@@ -13,7 +13,7 @@ interface Closable {
   close(): void;
 }
 
-export class ExternalSkipService implements ExternalSupplier {
+export class SkipExternalService implements ExternalService {
   private client?: Promise<[Client, Protocol.Creds]>;
   private resources = new Map<string, Closable>();
 

--- a/skipruntime-ts/helpers/src/remote.ts
+++ b/skipruntime-ts/helpers/src/remote.ts
@@ -35,17 +35,17 @@ export class SkipExternalService implements ExternalService {
       reactiveAuth: Uint8Array,
     ) => Promise<ReactiveResponse>,
     creds?: Protocol.Creds,
-  ): ExternalSkipService {
+  ): SkipExternalService {
     let url = `ws://${entrypoint.host}:${entrypoint.port.toString()}`;
     if (entrypoint.secured)
       url = `wss://${entrypoint.host}:${entrypoint.port.toString()}`;
-    return new ExternalSkipService(url, auth, creds);
+    return new SkipExternalService(url, auth, creds);
   }
 
   static direct(
     entrypoint: Entrypoint,
     creds?: Protocol.Creds,
-  ): ExternalSkipService {
+  ): SkipExternalService {
     let url = `http://${entrypoint.host}:${entrypoint.port.toString()}`;
     if (entrypoint.secured)
       url = `https://${entrypoint.host}:${entrypoint.port.toString()}`;
@@ -68,7 +68,7 @@ export class SkipExternalService implements ExternalService {
         throw new Error("Reactive response must be suplied.");
       return reactiveResponse;
     };
-    return new ExternalSkipService(url, auth, creds);
+    return new SkipExternalService(url, auth, creds);
   }
 
   subscribe(

--- a/skipruntime-ts/native/src/BaseTypes.sk
+++ b/skipruntime-ts/native/src/BaseTypes.sk
@@ -53,7 +53,7 @@ base class PValue uses Show, Orderable {
   | PString(v) -> v
 }
 
-base class ExternalSupplier {
+base class ExternalService {
   fun subscribe(
     collection: CollectionWriter,
     resource: String,
@@ -84,7 +84,7 @@ base class ResourceBuilder {
 base class Service(
   initialData: Array<Input>,
   resources: Map<String, ResourceBuilder>,
-  remoteCollections: Map<String, ExternalSupplier> = Map[],
+  remoteCollections: Map<String, ExternalService> = Map[],
 ) {
   fun reactiveCompute(
     inputCollections: Map<String, Collection>,

--- a/skipruntime-ts/native/src/Extern.sk
+++ b/skipruntime-ts/native/src/Extern.sk
@@ -138,11 +138,11 @@ class ExternLazyCompute(eptr: SKStore.ExternalPointer) extends LazyCompute {
   }
 }
 
-/************  ExternalSupplier ****************/
+/************  ExternalService ****************/
 
-@cpp_extern("SkipRuntime_ExternalSupplier__subscribe")
+@cpp_extern("SkipRuntime_ExternalService__subscribe")
 @debug
-native fun subscribeOfExternalSupplier(
+native fun subscribeOfExternalService(
   externalSupplier: UInt32,
   collection: String,
   resource: String,
@@ -150,40 +150,40 @@ native fun subscribeOfExternalSupplier(
   reactiveAuth: ?Array<UInt8>,
 ): void;
 
-@cpp_extern("SkipRuntime_ExternalSupplier__unsubscribe")
+@cpp_extern("SkipRuntime_ExternalService__unsubscribe")
 @debug
-native fun unsubscribeOfExternalSupplier(
+native fun unsubscribeOfExternalService(
   externalSupplier: UInt32,
   resource: String,
   params: SKJSON.CJObject,
   reactiveAuth: ?Array<UInt8>,
 ): void;
 
-@cpp_extern("SkipRuntime_ExternalSupplier__shutdown")
+@cpp_extern("SkipRuntime_ExternalService__shutdown")
 @debug
-native fun shutdownOfExternalSupplier(externalSupplier: UInt32): void;
+native fun shutdownOfExternalService(externalSupplier: UInt32): void;
 
-@cpp_extern("SkipRuntime_deleteExternalSupplier")
+@cpp_extern("SkipRuntime_deleteExternalService")
 @debug
-native fun deleteExternalSupplier(externalSupplier: UInt32): void;
+native fun deleteExternalService(externalSupplier: UInt32): void;
 
-@export("SkipRuntime_createExternalSupplier")
-fun createExternalSupplier(externalSupplier: UInt32): ExternExternalSupplier {
-  ExternExternalSupplier(
-    SKStore.ExternalPointer::create(externalSupplier, deleteExternalSupplier),
+@export("SkipRuntime_createExternalService")
+fun createExternalService(externalSupplier: UInt32): ExternExternalService {
+  ExternExternalService(
+    SKStore.ExternalPointer::create(externalSupplier, deleteExternalService),
   )
 }
 
-class ExternExternalSupplier(
+class ExternExternalService(
   eptr: SKStore.ExternalPointer,
-) extends ExternalSupplier {
+) extends ExternalService {
   fun subscribe(
     collection: CollectionWriter,
     resource: String,
     params: Map<String, PValue>,
     reactiveAuth: ?Array<UInt8>,
   ): void {
-    subscribeOfExternalSupplier(
+    subscribeOfExternalService(
       this.eptr.value,
       collection.dirName.toString(),
       resource,
@@ -197,7 +197,7 @@ class ExternExternalSupplier(
     params: Map<String, PValue>,
     reactiveAuth: ?Array<UInt8>,
   ): void {
-    unsubscribeOfExternalSupplier(
+    unsubscribeOfExternalService(
       this.eptr.value,
       resource,
       jsonParams(params),
@@ -206,7 +206,7 @@ class ExternExternalSupplier(
   }
 
   fun shutdown(): void {
-    shutdownOfExternalSupplier(this.eptr.value)
+    shutdownOfExternalService(this.eptr.value)
   }
 }
 
@@ -346,7 +346,7 @@ fun createService(
   service: UInt32,
   jsInputs: SKJSON.CJObject,
   resources: mutable Map<String, ResourceBuilder>,
-  remotes: mutable Map<String, ExternalSupplier>,
+  remotes: mutable Map<String, ExternalService>,
 ): ExternService {
   keyConverter = JSONKeyConverter();
   fileConverter = JSONFileConverter();
@@ -422,18 +422,18 @@ fun addOfResourceBuilderMap(
   builders.add(name, builder)
 }
 
-/************  ExternalSupplierMap ****************/
+/************  ExternalServiceMap ****************/
 
-@export("SkipRuntime_ExternalSupplierMap__create")
-fun createOfExternalSupplierMap(): mutable Map<String, ExternalSupplier> {
+@export("SkipRuntime_ExternalServiceMap__create")
+fun createOfExternalServiceMap(): mutable Map<String, ExternalService> {
   mutable Map[]
 }
 
-@export("SkipRuntime_ExternalSupplierMap__add")
-fun addOfExternalSupplierMap(
-  suppliers: mutable Map<String, ExternalSupplier>,
+@export("SkipRuntime_ExternalServiceMap__add")
+fun addOfExternalServiceMap(
+  suppliers: mutable Map<String, ExternalService>,
   name: String,
-  supplier: ExternalSupplier,
+  supplier: ExternalService,
 ): void {
   suppliers.add(name, supplier)
 }

--- a/skipruntime-ts/native/src/Runtime.sk
+++ b/skipruntime-ts/native/src/Runtime.sk
@@ -163,7 +163,7 @@ class RequestStatuses(statuses: Array<ResourceStatus>) extends SKStore.File {
 }
 
 class RemoteSpecifiers(
-  value: Map<String, ExternalSupplier>,
+  value: Map<String, ExternalService>,
 ) extends SKStore.File
 
 class ResourceInfo(
@@ -523,7 +523,7 @@ class CheckRequest(
 }
 
 class LinkToResource(
-  supplier: ExternalSupplier,
+  supplier: ExternalService,
   writer: CollectionWriter,
   name: String,
   params: Map<String, PValue>,
@@ -544,7 +544,7 @@ class LinkToResource(
 }
 
 class CloseResource(
-  supplier: ExternalSupplier,
+  supplier: ExternalService,
   name: String,
   params: Map<String, PValue>,
   reactiveAuth: ?Array<UInt8>,

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -12,14 +12,14 @@ import type {
   SkipService,
   Resource,
   Entry,
-  ExternalSupplier,
+  ExternalService,
   ReactiveResponse,
 } from "@skipruntime/api";
 import { OneToOneMapper } from "@skipruntime/api";
 import { Sum } from "@skipruntime/helpers";
 import {
   TimeCollection,
-  ExternalService,
+  GenericExternalService,
 } from "@skipruntime/helpers/external.js";
 
 type Values<K extends TJSON, V extends TJSON> = {
@@ -432,13 +432,13 @@ class JSONExtractService implements SkipService {
   }
 }
 
-//// testExternalSupplier
+//// testExternalService
 
 async function timeout(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-class MockExternal implements ExternalSupplier {
+class MockExternal implements ExternalService {
   subscribe(
     resource: string,
     params: { v1: string; v2: string },
@@ -551,7 +551,7 @@ class TokensResource implements Resource {
   }
 }
 
-const system = new ExternalService({ timer: new TimeCollection() });
+const system = new GenericExternalService({ timer: new TimeCollection() });
 
 class TokensService implements SkipService {
   initialData = { input: [] };

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -438,7 +438,7 @@ async function timeout(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-class External implements ExternalSupplier {
+class MockExternal implements ExternalSupplier {
   subscribe(
     resource: string,
     params: { v1: string; v2: string },
@@ -484,7 +484,7 @@ class External implements ExternalSupplier {
   }
 }
 
-class ExternalCheck implements Mapper<number, number, number, number[]> {
+class MockExternalCheck implements Mapper<number, number, number, number[]> {
   constructor(private external: EagerCollection<number, number>) {}
 
   mapElement(
@@ -500,7 +500,7 @@ class ExternalCheck implements Mapper<number, number, number, number[]> {
   }
 }
 
-class ExternalResource implements Resource {
+class MockExternalResource implements Resource {
   reactiveCompute(
     cs: {
       input1: EagerCollection<number, number>;
@@ -517,14 +517,14 @@ class ExternalResource implements Resource {
       params: { v1, v2 },
       reactiveAuth,
     });
-    return cs.input1.map(ExternalCheck, external);
+    return cs.input1.map(MockExternalCheck, external);
   }
 }
 
 class TestExternalService implements SkipService {
   initialData = { input1: [], input2: [] };
-  resources = { external: ExternalResource };
-  externalServices = { external: new External() };
+  resources = { external: MockExternalResource };
+  externalServices = { external: new MockExternal() };
 
   reactiveCompute(inputCollections: {
     input1: EagerCollection<number, number>;

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -18,7 +18,7 @@ import type {
 import { OneToOneMapper } from "@skipruntime/api";
 import { Sum } from "@skipruntime/helpers";
 import {
-  TimeCollection,
+  TimerResource,
   GenericExternalService,
 } from "@skipruntime/helpers/external.js";
 
@@ -551,7 +551,7 @@ class TokensResource implements Resource {
   }
 }
 
-const system = new GenericExternalService({ timer: new TimeCollection() });
+const system = new GenericExternalService({ timer: new TimerResource() });
 
 class TokensService implements SkipService {
   initialData = { input: [] };

--- a/skipruntime-ts/wasm/src/internals/skipruntime_internal_types.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_internal_types.ts
@@ -29,7 +29,7 @@ export type LazyCompute = T<typeof lazycompute> & {
 };
 
 declare const externalsupplier: unique symbol;
-export type ExternalSupplier = T<typeof externalsupplier>;
+export type ExternalService = T<typeof externalsupplier>;
 
 declare const resource: unique symbol;
 export type Resource = T<typeof resource>;
@@ -44,7 +44,7 @@ declare const resourcebuildermap: unique symbol;
 export type ResourceBuilderMap = T<typeof resourcebuildermap>;
 
 declare const externalsuppliermap: unique symbol;
-export type ExternalSupplierMap = T<typeof externalsuppliermap>;
+export type ExternalServiceMap = T<typeof externalsuppliermap>;
 
 declare const accumulator: unique symbol;
 export type Accumulator = T<typeof accumulator>;

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -24,7 +24,7 @@ import type {
   Mapper,
   Context,
   LazyCompute,
-  ExternalSupplier,
+  ExternalService,
   Resource,
   ReactiveResponse,
   CollectionUpdate,
@@ -156,11 +156,11 @@ export interface FromWasm {
     ref: Handle<LazyCompute<K, V>>,
   ): ptr<Internal.LazyCompute>;
 
-  // ExternalSupplier
+  // ExternalService
 
-  SkipRuntime_createExternalSupplier(
-    ref: Handle<ExternalSupplier>,
-  ): ptr<Internal.ExternalSupplier>;
+  SkipRuntime_createExternalService(
+    ref: Handle<ExternalService>,
+  ): ptr<Internal.ExternalService>;
 
   // CollectionWriter
 
@@ -193,7 +193,7 @@ export interface FromWasm {
     ref: Handle<SkipService>,
     jsInputs: ptr<Internal.CJObject>,
     resources: ptr<Internal.ResourceBuilderMap>,
-    remotes: ptr<Internal.ExternalSupplierMap>,
+    remotes: ptr<Internal.ExternalServiceMap>,
   ): ptr<Internal.Service>;
 
   // ResourceBuilderMap
@@ -206,13 +206,13 @@ export interface FromWasm {
     collection: ptr<Internal.ResourceBuilder>,
   ): void;
 
-  // ExternalSupplierMap
+  // ExternalServiceMap
 
-  SkipRuntime_ExternalSupplierMap__create(): ptr<Internal.ExternalSupplierMap>;
-  SkipRuntime_ExternalSupplierMap__add(
-    map: ptr<Internal.ExternalSupplierMap>,
+  SkipRuntime_ExternalServiceMap__create(): ptr<Internal.ExternalServiceMap>;
+  SkipRuntime_ExternalServiceMap__add(
+    map: ptr<Internal.ExternalServiceMap>,
     key: ptr<Internal.String>,
-    collection: ptr<Internal.ExternalSupplier>,
+    collection: ptr<Internal.ExternalService>,
   ): void;
 
   // Collection
@@ -391,28 +391,28 @@ interface ToWasm {
 
   SkipRuntime_deleteLazyCompute(mapper: Handle<JSONLazyCompute>): void;
 
-  // ExternalSupplier
+  // ExternalService
 
-  SkipRuntime_ExternalSupplier__subscribe(
-    supplier: Handle<ExternalSupplier>,
+  SkipRuntime_ExternalService__subscribe(
+    supplier: Handle<ExternalService>,
     collection: ptr<Internal.String>,
     resource: ptr<Internal.String>,
     params: ptr<Internal.CJObject>,
     reactiveAuth: ptr<Internal.Array<Internal.Byte>>,
   ): void;
 
-  SkipRuntime_ExternalSupplier__unsubscribe(
-    supplier: Handle<ExternalSupplier>,
+  SkipRuntime_ExternalService__unsubscribe(
+    supplier: Handle<ExternalService>,
     skresource: ptr<Internal.String>,
     skparams: ptr<Internal.CJObject>,
     reactiveAuth: ptr<Internal.Array<Internal.Byte>>,
   ): void;
 
-  SkipRuntime_ExternalSupplier__shutdown(
-    supplier: Handle<ExternalSupplier>,
+  SkipRuntime_ExternalService__shutdown(
+    supplier: Handle<ExternalService>,
   ): void;
 
-  SkipRuntime_deleteExternalSupplier(supplier: Handle<ExternalSupplier>): void;
+  SkipRuntime_deleteExternalService(supplier: Handle<ExternalService>): void;
 
   // Resource
 
@@ -778,10 +778,10 @@ class LinksImpl implements Links {
     this.handles.deleteHandle(accumulator);
   }
 
-  // ExternalSupplier
+  // ExternalService
 
-  subscribeOfExternalSupplier(
-    sksupplier: Handle<ExternalSupplier>,
+  subscribeOfExternalService(
+    sksupplier: Handle<ExternalService>,
     skwriter: ptr<Internal.String>,
     skresource: ptr<Internal.String>,
     skparams: ptr<Internal.CJObject>,
@@ -810,8 +810,8 @@ class LinksImpl implements Links {
     );
   }
 
-  unsubscribeOfExternalSupplier(
-    sksupplier: Handle<ExternalSupplier>,
+  unsubscribeOfExternalService(
+    sksupplier: Handle<ExternalService>,
     skresource: ptr<Internal.String>,
     skparams: ptr<Internal.CJObject>,
     skreactiveAuth: ptr<Internal.Array<Internal.Byte>>,
@@ -826,12 +826,12 @@ class LinksImpl implements Links {
     supplier.unsubscribe(resource, params, reactiveAuth);
   }
 
-  shutdownOfExternalSupplier(sksupplier: Handle<ExternalSupplier>) {
+  shutdownOfExternalService(sksupplier: Handle<ExternalService>) {
     const supplier = this.handles.get(sksupplier);
     supplier.shutdown();
   }
 
-  deleteExternalSupplier(supplier: Handle<ExternalSupplier>) {
+  deleteExternalService(supplier: Handle<ExternalService>) {
     this.handles.deleteHandle(supplier);
   }
 
@@ -851,13 +851,13 @@ class LinksImpl implements Links {
     const skjson = this.getSkjson();
     const result = skjson.runWithGC(() => {
       const skExternalServices =
-        this.fromWasm.SkipRuntime_ExternalSupplierMap__create();
+        this.fromWasm.SkipRuntime_ExternalServiceMap__create();
       if (service.externalServices) {
         for (const [name, remote] of Object.entries(service.externalServices)) {
-          const skremote = this.fromWasm.SkipRuntime_createExternalSupplier(
+          const skremote = this.fromWasm.SkipRuntime_createExternalService(
             this.handles.register(remote),
           );
-          this.fromWasm.SkipRuntime_ExternalSupplierMap__add(
+          this.fromWasm.SkipRuntime_ExternalServiceMap__add(
             skExternalServices,
             skjson.exportString(name),
             skremote,
@@ -1662,16 +1662,16 @@ class Manager implements ToWasmManager {
       links.computeOfLazyCompute.bind(links);
     toWasm.SkipRuntime_deleteLazyCompute = links.deleteLazyCompute.bind(links);
 
-    // ExternalSupplier
+    // ExternalService
 
-    toWasm.SkipRuntime_ExternalSupplier__unsubscribe =
-      links.unsubscribeOfExternalSupplier.bind(links);
-    toWasm.SkipRuntime_ExternalSupplier__subscribe =
-      links.subscribeOfExternalSupplier.bind(links);
-    toWasm.SkipRuntime_ExternalSupplier__shutdown =
-      links.shutdownOfExternalSupplier.bind(links);
-    toWasm.SkipRuntime_deleteExternalSupplier =
-      links.deleteExternalSupplier.bind(links);
+    toWasm.SkipRuntime_ExternalService__unsubscribe =
+      links.unsubscribeOfExternalService.bind(links);
+    toWasm.SkipRuntime_ExternalService__subscribe =
+      links.subscribeOfExternalService.bind(links);
+    toWasm.SkipRuntime_ExternalService__shutdown =
+      links.shutdownOfExternalService.bind(links);
+    toWasm.SkipRuntime_deleteExternalService =
+      links.deleteExternalService.bind(links);
 
     // Resource
 

--- a/skipruntime-ts/wasm/src/skip-runtime.ts
+++ b/skipruntime-ts/wasm/src/skip-runtime.ts
@@ -34,7 +34,7 @@ export {
   Max,
   parseReactiveResponse,
   reactiveResponseHeader,
-  ExternalSkipService,
+  SkipExternalService,
   type ExternalResource,
   GenericExternalService,
   Polled,
@@ -45,4 +45,3 @@ export {
   SkipRESTService,
   type Entrypoint,
 } from "@skipruntime/helpers/rest.js";
-

--- a/skipruntime-ts/wasm/src/skip-runtime.ts
+++ b/skipruntime-ts/wasm/src/skip-runtime.ts
@@ -15,7 +15,7 @@ export type {
   ReactiveResponse,
   SkipService,
   Resource,
-  ExternalSupplier,
+  ExternalService,
   CollectionUpdate,
   Watermark,
   SubscriptionID,
@@ -36,7 +36,7 @@ export {
   reactiveResponseHeader,
   ExternalSkipService,
   type ExternalResource,
-  ExternalService,
+  GenericExternalService,
   Polled,
 } from "@skipruntime/helpers";
 
@@ -45,3 +45,4 @@ export {
   SkipRESTService,
   type Entrypoint,
 } from "@skipruntime/helpers/rest.js";
+


### PR DESCRIPTION
Writing docs about external services/resources/suppliers, I found the namings to be quite confusing and at times conflicting or redundant.

The previous situatiuon was as follows: `ExternalSupplier` is an umbrella interface for all kinds of external data sources, whether skip or not.  It had two main implementations: `ExternalService` for generic non-skip externals, and `ExternalSkipService` for skip externals.  `ExternalService`s were composed of multiple `ExternalResource`s and `ExternalSkipService`s also had an internal notion of "resource"; skip services had a field "externalServices" which held a collection of "ExternalSupplier"s, etc. etc.

This diff attempts to unify/streamline the naming scheme.  

The umbrella interface is now `ExternalService`, and it is implemented by `SkipExternalService` and `GenericSkipService`.  Both forms have a notion of resource still, but they are analogous and I don't think will cause too much trouble.  There may still be some places where parameter/variable names are conflicting as that's tricky to grep for, but I tried to find/fix the ones I could.

I'm continuing to work on further in-code and markdown docs around this stuff, but thought I'd put this up to get feedback and minimize rebase pain.