### PR TITLE
Comments pointing replicated Json type definitions to source definition

### DIFF
--- a/skiplang/skjson/ts/src/skjson.ts
+++ b/skiplang/skjson/ts/src/skjson.ts
@@ -393,9 +393,8 @@ class Mapping {
   }
 }
 
+export type Json = number | boolean | string | (Json | null)[] | JsonObject;
 export type JsonObject = { [key: string]: Json | null };
-
-export type Json = number | JsonObject | boolean | (Json | null)[] | string;
 
 export type Exportable =
   | Json

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -11,6 +11,7 @@ import type { Opaque, Opt, int, Constant } from "./internals.js";
  * and values in the Skip Runtime, ensuring that they can be serialized and managed by the
  * reactive computation engine.
  */
+// Replicate definition of Json from skjson to avoid a dependency
 export type Json = number | boolean | string | JsonObject | (Json | null)[];
 export type JsonObject = { [key: string]: Json | null };
 

--- a/skipruntime-ts/client/src/protocol.ts
+++ b/skipruntime-ts/client/src/protocol.ts
@@ -1,9 +1,8 @@
 // Interfaces
 
-export interface JsonObject {
-  [key: string]: Json | null;
-}
-export type Json = number | JsonObject | boolean | (Json | null)[] | string;
+// Replicate definition of Json from skjson to avoid a dependency
+export type Json = number | boolean | string | (Json | null)[] | JsonObject;
+export type JsonObject = { [key: string]: Json | null };
 
 export type Entry<K extends Json, V extends Json> = [K, V[]];
 


### PR DESCRIPTION
Also change `interface` to `type` and reorder alternatives to make
definitions exactly the same.