### PR TITLE
JS rest server error logging

### DIFF
--- a/skipruntime-ts/server/src/replication.ts
+++ b/skipruntime-ts/server/src/replication.ts
@@ -99,7 +99,10 @@ function handleMessage(
         // Respond with error 1004 if collection does not exist
         // (for current user).
         if (e instanceof UnknownCollectionError) {
-          throw new ReplicationServerError(1004, "Not found");
+          throw new ReplicationServerError(
+            1004,
+            `Collection ${msg.collection} not found`,
+          );
         }
         throw e;
       }

--- a/skipruntime-ts/server/src/replication.ts
+++ b/skipruntime-ts/server/src/replication.ts
@@ -222,6 +222,7 @@ export class ReplicationServer {
   }
 
   private errorHandler(ws: WebSocket, error: any) {
+    console.error(error);
     if (error instanceof ReplicationServerError) {
       ws.send(
         Protocol.encodeMsg({


### PR DESCRIPTION
closes #453 -- in testing, this covers all of the errors that I've been able to produce.  possible there are other error paths that could use logging still.