### PR TITLE
Fixes #496: support for joinCollections

### DIFF
--- a/skipruntime-ts/helpers/src/index.ts
+++ b/skipruntime-ts/helpers/src/index.ts
@@ -11,5 +11,7 @@ export {
   CountMapper,
   parseReactiveResponse,
   reactiveResponseHeader,
+  type UniqueEagerCollection,
+  joinCollections,
 } from "./utils.js";
 export { RESTWrapperOfSkipService } from "./rest.js";

--- a/skipruntime-ts/helpers/src/index.ts
+++ b/skipruntime-ts/helpers/src/index.ts
@@ -11,7 +11,6 @@ export {
   CountMapper,
   parseReactiveResponse,
   reactiveResponseHeader,
-  type UniqueEagerCollection,
   joinCollections,
 } from "./utils.js";
 export { RESTWrapperOfSkipService } from "./rest.js";

--- a/skipruntime-ts/helpers/src/utils.ts
+++ b/skipruntime-ts/helpers/src/utils.ts
@@ -5,6 +5,8 @@ import type {
   NonEmptyIterator,
   ReactiveResponse,
   Json,
+  EagerCollection,
+  Mapper,
 } from "@skipruntime/api";
 
 export class Sum implements Reducer<number, number> {
@@ -67,4 +69,133 @@ export function reactiveResponseHeader(
   reactiveResponse: ReactiveResponse,
 ): [string, string] {
   return ["Skip-Reactive-Response-Token", JSON.stringify(reactiveResponse)];
+}
+
+/*****************************************************************************/
+// Unique collection
+/*****************************************************************************/
+
+export type UniqueEagerCollection<
+  K extends Json,
+  V extends Json,
+> = EagerCollection<K, V> & { unique: true };
+
+class UniqueMapper<K extends Json, V extends Json>
+  implements Mapper<K, V, K, V>
+{
+  mapEntry(key: K, values: NonEmptyIterator<V>): Iterable<[K, V]> {
+    return [[key, values.getUnique()]];
+  }
+}
+
+export function makeUniqueCollection<K extends Json, V extends Json>(
+  col: EagerCollection<K, V>,
+): UniqueEagerCollection<K, V> {
+  return { ...col.map(UniqueMapper<K, V>), unique: true };
+}
+
+/*****************************************************************************/
+// Joins
+/*****************************************************************************/
+
+type JoinObject = { value: Json; side: "left" | "right" };
+
+class AddJoinSideField implements Mapper<Json, Json, Json, JoinObject> {
+  constructor(private joinSide: "left" | "right") {}
+  mapEntry(
+    key: Json,
+    values: NonEmptyIterator<Json>,
+  ): Iterable<[Json, JoinObject]> {
+    let result: Array<[Json, JoinObject]> = [];
+    for (const v of values) {
+      if (typeof v !== "object") {
+        throw new Error(
+          "joinCollection only works on objects, not: " + JSON.stringify(v),
+        );
+      }
+      if (v === null) {
+        throw new Error("joinCollection does not accept null");
+      }
+      result.push([key, { value: v, side: this.joinSide }]);
+    }
+    return result;
+  }
+}
+
+function mergeObjects(object1: JoinObject, object2: JoinObject): Json {
+  const v1 = object1.value;
+  const v2 = object2.value;
+  if (typeof v1 !== "object" || v1 === null) {
+    throw new Error(
+      "mergeObjects only works with objects, not: " + JSON.stringify(v1),
+    );
+  }
+  if (typeof v2 !== "object" || v1 === null) {
+    throw new Error(
+      "mergeObjects only works with objects, not: " + JSON.stringify(v2),
+    );
+  }
+  const keys1 = Object.keys(v1);
+  if (keys1.some((key) => key in v2)) {
+    throw new Error(
+      "Objects don't have distinct fields: " +
+        JSON.stringify(v1) +
+        " " +
+        JSON.stringify(v2),
+    );
+  }
+  return { ...v1, ...v2 };
+}
+
+class MergeJoinFields implements Mapper<JoinObject, JoinObject, Json, Json> {
+  constructor(private allowNN: boolean) {}
+  mapEntry(
+    key: Json,
+    values: NonEmptyIterator<JoinObject>,
+  ): Iterable<[Json, Json]> {
+    const result: Array<[Json, Json]> = [];
+    let countLeft = 0;
+    let countRight = 0;
+    for (const value of values) {
+      if (value.side === "left") {
+        countLeft++;
+      }
+      if (value.side === "right") {
+        countRight++;
+      }
+    }
+    if (countLeft > 1 && countRight > 1) {
+      if (!this.allowNN) {
+        throw new Error(
+          "More than one value detected on both sides for key: " +
+            JSON.stringify(key),
+        );
+      }
+    }
+    for (const value1 of values) {
+      if (value1.side === "left") {
+        for (const value2 of values) {
+          if (value2.side === "right") {
+            result.push([key, mergeObjects(value1, value2)]);
+          }
+        }
+      }
+    }
+    return result;
+  }
+}
+
+export function joinCollections<
+  K extends Json,
+  V1 extends Json,
+  V2 extends Json,
+>(
+  col1: EagerCollection<K, V1>,
+  col2: EagerCollection<K, V2>,
+  allowNN: boolean = false,
+): EagerCollection<K, V1 & V2> {
+  return col1
+    .map(AddJoinSideField, "left")
+    .merge(col2.map(AddJoinSideField, "right"))
+    .map(MergeJoinFields, allowNN) as EagerCollection<K, V1 & V2>;
 }

--- a/skipruntime-ts/helpers/src/utils.ts
+++ b/skipruntime-ts/helpers/src/utils.ts
@@ -123,7 +123,7 @@ function mergeObjects(object1: JoinObject, object2: JoinObject): Json {
 }
 
 class MergeJoinFields implements Mapper<JoinObject, JoinObject, Json, Json> {
-  constructor(private allowNN: boolean) {}
+  constructor(private allowMultipleValuesOnBothSides: boolean) {}
 
   mapEntry(
     key: Json,
@@ -141,7 +141,7 @@ class MergeJoinFields implements Mapper<JoinObject, JoinObject, Json, Json> {
       }
     }
     if (countLeft > 1 && countRight > 1) {
-      if (!this.allowNN) {
+      if (!this.allowMultipleValuesOnBothSides) {
         throw new Error(
           "More than one value detected on both sides for key: " +
             JSON.stringify(key),
@@ -168,10 +168,13 @@ export function joinCollections<
 >(
   col1: EagerCollection<K, V1>,
   col2: EagerCollection<K, V2>,
-  allowNN: boolean = false,
+  allowMultipleValuesOnBothSides: boolean = false,
 ): EagerCollection<K, V1 & V2> {
   return col1
     .map(AddJoinSideField, "left")
     .merge(col2.map(AddJoinSideField, "right"))
-    .map(MergeJoinFields, allowNN) as EagerCollection<K, V1 & V2>;
+    .map(MergeJoinFields, allowMultipleValuesOnBothSides) as EagerCollection<
+    K,
+    V1 & V2
+  >;
 }

--- a/skipruntime-ts/helpers/src/utils.ts
+++ b/skipruntime-ts/helpers/src/utils.ts
@@ -152,8 +152,9 @@ class MergeJoinFields implements Mapper<JoinObject, JoinObject, Json, Json> {
     if (countLeft > 1 && countRight > 1) {
       if (!this.allowMultipleValuesOnBothSides) {
         throw new Error(
-          "More than one value detected on both sides for key: " +
-            JSON.stringify(key),
+          `Potentially expensive join of ${countLeft} x ${countRight} \
+           values for key: ${JSON.stringify(key)}. \
+           If this is intended, pass allowMultipleValuesOnBothSides = true.`,
         );
       }
     }

--- a/skipruntime-ts/helpers/src/utils.ts
+++ b/skipruntime-ts/helpers/src/utils.ts
@@ -102,19 +102,17 @@ type JoinObject = { value: Json; side: "left" | "right" };
 
 class AddJoinSideField implements Mapper<Json, Json, Json, JoinObject> {
   constructor(private joinSide: "left" | "right") {}
+
   mapEntry(
     key: Json,
     values: NonEmptyIterator<Json>,
   ): Iterable<[Json, JoinObject]> {
-    let result: Array<[Json, JoinObject]> = [];
+    const result: [Json, JoinObject][] = [];
     for (const v of values) {
       if (typeof v !== "object") {
         throw new Error(
           "joinCollection only works on objects, not: " + JSON.stringify(v),
         );
-      }
-      if (v === null) {
-        throw new Error("joinCollection does not accept null");
       }
       result.push([key, { value: v, side: this.joinSide }]);
     }
@@ -125,12 +123,12 @@ class AddJoinSideField implements Mapper<Json, Json, Json, JoinObject> {
 function mergeObjects(object1: JoinObject, object2: JoinObject): Json {
   const v1 = object1.value;
   const v2 = object2.value;
-  if (typeof v1 !== "object" || v1 === null) {
+  if (typeof v1 !== "object") {
     throw new Error(
       "mergeObjects only works with objects, not: " + JSON.stringify(v1),
     );
   }
-  if (typeof v2 !== "object" || v1 === null) {
+  if (typeof v2 !== "object") {
     throw new Error(
       "mergeObjects only works with objects, not: " + JSON.stringify(v2),
     );
@@ -149,11 +147,12 @@ function mergeObjects(object1: JoinObject, object2: JoinObject): Json {
 
 class MergeJoinFields implements Mapper<JoinObject, JoinObject, Json, Json> {
   constructor(private allowNN: boolean) {}
+
   mapEntry(
     key: Json,
     values: NonEmptyIterator<JoinObject>,
   ): Iterable<[Json, Json]> {
-    const result: Array<[Json, Json]> = [];
+    const result: [Json, Json][] = [];
     let countLeft = 0;
     let countRight = 0;
     for (const value of values) {

--- a/skipruntime-ts/helpers/src/utils.ts
+++ b/skipruntime-ts/helpers/src/utils.ts
@@ -5,6 +5,7 @@ import type {
   NonEmptyIterator,
   ReactiveResponse,
   Json,
+  JsonObject,
   EagerCollection,
   Mapper,
 } from "@skipruntime/api";
@@ -173,8 +174,8 @@ class MergeJoinFields implements Mapper<JoinObject, JoinObject, Json, Json> {
 
 export function joinCollections<
   K extends Json,
-  V1 extends Json,
-  V2 extends Json,
+  V1 extends JsonObject,
+  V2 extends JsonObject,
 >(
   col1: EagerCollection<K, V1>,
   col2: EagerCollection<K, V2>,

--- a/skipruntime-ts/helpers/src/utils.ts
+++ b/skipruntime-ts/helpers/src/utils.ts
@@ -72,29 +72,6 @@ export function reactiveResponseHeader(
 }
 
 /*****************************************************************************/
-// Unique collection
-/*****************************************************************************/
-
-export type UniqueEagerCollection<
-  K extends Json,
-  V extends Json,
-> = EagerCollection<K, V> & { unique: true };
-
-class UniqueMapper<K extends Json, V extends Json>
-  implements Mapper<K, V, K, V>
-{
-  mapEntry(key: K, values: NonEmptyIterator<V>): Iterable<[K, V]> {
-    return [[key, values.getUnique()]];
-  }
-}
-
-export function makeUniqueCollection<K extends Json, V extends Json>(
-  col: EagerCollection<K, V>,
-): UniqueEagerCollection<K, V> {
-  return { ...col.map(UniqueMapper<K, V>), unique: true };
-}
-
-/*****************************************************************************/
 // Joins
 /*****************************************************************************/
 

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -16,11 +16,7 @@ import type {
   ReactiveResponse,
 } from "@skipruntime/api";
 import { NonUniqueValueException, OneToOneMapper } from "@skipruntime/api";
-import {
-  Sum,
-  joinCollections,
-  type UniqueEagerCollection,
-} from "@skipruntime/helpers";
+import { Sum, joinCollections } from "@skipruntime/helpers";
 import {
   TimerResource,
   GenericExternalService,
@@ -386,7 +382,7 @@ const mergeReduceService: SkipService = {
 
 class JoinResource implements Resource {
   instantiate(cs: {
-    input1: UniqueEagerCollection<number, JsonObject>;
+    input1: EagerCollection<number, JsonObject>;
     input2: EagerCollection<number, JsonObject>;
   }): EagerCollection<number, JsonObject> {
     return joinCollections(cs.input1, cs.input2);
@@ -837,6 +833,20 @@ export function initTests(
         throw e;
       }
     }
+    // One to many case
+    service.update("input2", [[2, [{ field3: 10 }, { field4: 10 }]]]);
+    // Many to one case
+    service.update("input1", [[1, [{ field1: 2 }]]]);
+    expect(service.getAll(resource).payload.values).toEqual([
+      [1, [{ field1: 2, field2: 20 }]],
+      [
+        2,
+        [
+          { field1: 10, field3: 10 },
+          { field1: 10, field4: 10 },
+        ],
+      ],
+    ]);
   });
 
   it("testJSONExtract", async () => {

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -816,9 +816,7 @@ export function initTests(
       throw new Error("Should not happen");
     } catch (e) {
       if (e instanceof Error) {
-        expect(e.message.includes("More than one value detected")).toEqual(
-          true,
-        );
+        expect(e.message.includes("Potentially expensive join")).toEqual(true);
       } else {
         throw e;
       }

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -817,7 +817,7 @@ export function initTests(
     try {
       service.update("input1", [[1, [{ field1: 10 }, { field1: 11 }]]]);
       service.update("input2", [[1, [{ field2: 13 }, { field2: 14 }]]]);
-      throw null;
+      throw new Error("Should not happen");
     } catch (e) {
       if (e instanceof Error) {
         expect(e.message.includes("More than one value detected")).toEqual(
@@ -829,7 +829,7 @@ export function initTests(
     }
     try {
       service.update("input1", [[1, ["hello"]]]);
-      throw null;
+      throw new Error("Should not happen");
     } catch (e) {
       if (e instanceof Error) {
         expect(e.message.includes("only works on objects")).toEqual(true);


### PR DESCRIPTION
This diff implements the 'join' operation of two collections. It is assumed that:
- both collection values are objects (keys can be of any type)
- there never is more than 1 object on boths sides at any time unless the option allowMultipleValuesOnBothSides is passed (which should be rare).

If both those conditions are met, given a key, if the first collection defines an object of type V1 and the second collection defines an object V2 for the same key, the resulting collection will associate {...V1, ...V2} for that key. No value is associated if either side is missing.