### PR TITLE
Convert SkipService-implementing classes to object literals in examples

### DIFF
--- a/examples/hackernews/back-end/reactive_service/server.js
+++ b/examples/hackernews/back-end/reactive_service/server.js
@@ -1,6 +1,6 @@
 import sqlite3 from "sqlite3";
 import { runService } from "@skipruntime/server";
-import HackerNewsService from "./dist/hackernews.service.js";
+import serviceWithInitialData from "./dist/hackernews.service.js";
 
 async function selectAll(db, table) {
   return new Promise((resolve, reject) => {
@@ -23,4 +23,4 @@ const upvotes = await selectAll(db, "upvotes");
 
 // Spawn a local HTTP server to support reading/writing and creating
 // reactive requests.
-runService(new HackerNewsService(posts, users, upvotes), 8080);
+runService(serviceWithInitialData(posts, users, upvotes), 8080);

--- a/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
@@ -26,38 +26,28 @@ type Upvote = {
 
 type Upvoted = Post & { upvotes: number; author: User };
 
-export default class HackerNewsService implements SkipService {
-  initialData: {
-    posts: Entry<string, Post>[];
-    users: Entry<string, User>[];
-    upvotes: Entry<string, Upvote>[];
+export function serviceWithInitialData(
+  posts: Entry<string, Post>[],
+  users: Entry<string, User>[],
+  upvotes: Entry<string, Upvote>[],
+): SkipService {
+  return {
+    initialData: { posts, users, upvotes },
+    resources: { posts: PostsResource },
+    createGraph: (inputCollections: {
+      posts: EagerCollection<number, Post>;
+      users: EagerCollection<number, User>;
+      upvotes: EagerCollection<number, Upvote>;
+    }) => {
+      return {
+        postsWithUpvotes: inputCollections.posts.map(
+          PostsMapper,
+          inputCollections.users,
+          inputCollections.upvotes.map(UpvotesMapper),
+        ),
+      };
+    },
   };
-  resources = { posts: PostsResource };
-
-  constructor(
-    posts: Entry<string, Post>[],
-    users: Entry<string, User>[],
-    upvotes: Entry<string, Upvote>[],
-  ) {
-    this.initialData = { posts, users, upvotes };
-  }
-
-  createGraph(inputCollections: {
-    posts: EagerCollection<number, Post>;
-    users: EagerCollection<number, User>;
-    upvotes: EagerCollection<number, Upvote>;
-  }): Record<string, EagerCollection<Json, Json>> {
-    const upvotes = inputCollections.upvotes.map(UpvotesMapper);
-    const postsWithUpvotes = inputCollections.posts.map(
-      PostsMapper,
-      inputCollections.users,
-      upvotes,
-    );
-
-    return {
-      postsWithUpvotes,
-    };
-  }
 }
 
 class UpvotesMapper {

--- a/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
@@ -30,7 +30,7 @@ type Inputs = {
   users: EagerCollection<number, User>;
   upvotes: EagerCollection<number, Upvote>;
 };
-type Outputs = {
+type ResourceInputs = {
   postsWithUpvotes: EagerCollection<number, Upvoted>;
 };
 
@@ -42,7 +42,7 @@ export function serviceWithInitialData(
   return {
     initialData: { posts, users, upvotes },
     resources: { posts: PostsResource },
-    createGraph: (inputCollections: Inputs) => {
+    createGraph: (inputCollections: Inputs): ResourceInputs => {
       return {
         postsWithUpvotes: inputCollections.posts.map(
           PostsMapper,
@@ -101,7 +101,7 @@ class PostsResource implements Resource {
     this.limit = Number(params["limit"]);
   }
 
-  instantiate(collections: Outputs): EagerCollection<number, Upvoted> {
+  instantiate(collections: ResourceInputs): EagerCollection<number, Upvoted> {
     return collections.postsWithUpvotes.take(this.limit).map(SortingMapper);
   }
 }

--- a/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
@@ -1,6 +1,5 @@
 import type {
   Entry,
-  Json,
   EagerCollection,
   NonEmptyIterator,
   SkipService,

--- a/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
@@ -25,6 +25,15 @@ type Upvote = {
 
 type Upvoted = Post & { upvotes: number; author: User };
 
+type Inputs = {
+  posts: EagerCollection<number, Post>;
+  users: EagerCollection<number, User>;
+  upvotes: EagerCollection<number, Upvote>;
+};
+type Outputs = {
+  postsWithUpvotes: EagerCollection<number, Upvoted>;
+};
+
 export function serviceWithInitialData(
   posts: Entry<string, Post>[],
   users: Entry<string, User>[],
@@ -33,11 +42,7 @@ export function serviceWithInitialData(
   return {
     initialData: { posts, users, upvotes },
     resources: { posts: PostsResource },
-    createGraph: (inputCollections: {
-      posts: EagerCollection<number, Post>;
-      users: EagerCollection<number, User>;
-      upvotes: EagerCollection<number, Upvote>;
-    }) => {
+    createGraph: (inputCollections: Inputs) => {
       return {
         postsWithUpvotes: inputCollections.posts.map(
           PostsMapper,
@@ -96,9 +101,7 @@ class PostsResource implements Resource {
     this.limit = Number(params["limit"]);
   }
 
-  instantiate(collections: {
-    postsWithUpvotes: EagerCollection<number, Upvoted>;
-  }): EagerCollection<number, Upvoted> {
+  instantiate(collections: Outputs): EagerCollection<number, Upvoted> {
     return collections.postsWithUpvotes.take(this.limit).map(SortingMapper);
   }
 }

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -86,22 +86,13 @@ class UsersResource implements Resource {
 // Setting up the service
 /*****************************************************************************/
 
-class Service implements SkipService {
-  initialData: { users: Entry<string, User>[] };
-
-  constructor(users: Entry<string, User>[]) {
-    this.initialData = { users };
-  }
-
-  resources = {
-    users: UsersResource,
+function serviceWithInitialData(users: Entry<string, User>[]): SkipService {
+  return {
+    initialData: { users },
+    resources: { users: UsersResource },
+    createGraph: (inputCollections: { users: EagerCollection<string, User> }) =>
+      inputCollections,
   };
-
-  createGraph(inputCollections: {
-    users: EagerCollection<string, User>;
-  }): Record<string, EagerCollection<string, User>> {
-    return inputCollections;
-  }
 }
 
 // Command that starts the service
@@ -124,7 +115,7 @@ const data = await new Promise<Entry<string, User>[]>(function (
 });
 db.close();
 
-const closable = await runService(new Service(data), 8081);
+const closable = await runService(serviceWithInitialData(data), 8081);
 
 function shutdown() {
   closable.close();

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -50,12 +50,12 @@ class DeparturesResource implements Resource {
   }
 }
 
-class Service implements SkipService {
-  initialData = { config: [] };
-  resources = {
+const service: SkipService = {
+  initialData: { config: [] },
+  resources: {
     departures: DeparturesResource,
-  };
-  externalServices = {
+  },
+  externalServices: {
     externalDeparturesAPI: new GenericExternalService({
       departuresFromAPI: new Polled(
         "https://api.unhcr.org/rsq/v1/departures",
@@ -63,14 +63,14 @@ class Service implements SkipService {
         (data: Result) => data.results.map((v, idx) => [idx, [v]]),
       ),
     }),
-  };
+  },
 
   createGraph(ic: { config: EagerCollection<string, string[]> }) {
     return ic;
-  }
-}
+  },
+};
 
-const closable = await runService(new Service(), 3590);
+const closable = await runService(service, 3590);
 
 function shutdown() {
   closable.close();

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -1,9 +1,4 @@
-import type {
-  SkipService,
-  EagerCollection,
-  Context,
-  Resource,
-} from "@skipruntime/api";
+import type { EagerCollection, Context, Resource } from "@skipruntime/api";
 import { runService } from "@skipruntime/server";
 import { GenericExternalService, Polled } from "@skipruntime/helpers";
 

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -34,23 +34,24 @@ class MultResource implements Resource {
   }
 }
 
-const service: SkipService = {
-  resources: { data: MultResource },
-  externalServices: {
-    sumexample: SkipExternalService.direct({ host: "localhost", port: 3587 }),
-  },
+const service = await runService(
+  {
+    resources: { data: MultResource },
+    externalServices: {
+      sumexample: SkipExternalService.direct({ host: "localhost", port: 3587 }),
+    },
 
-  createGraph(
-    inputCollections: Record<string, EagerCollection<string, number>>,
-  ) {
-    return inputCollections;
+    createGraph(
+      inputCollections: Record<string, EagerCollection<string, number>>,
+    ) {
+      return inputCollections;
+    },
   },
-};
-
-const closable = await runService(service, 3588);
+  3588,
+);
 
 function shutdown() {
-  closable.close();
+  service.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -34,20 +34,20 @@ class MultResource implements Resource {
   }
 }
 
-class Service implements SkipService {
-  resources = { data: MultResource };
-  externalServices = {
+const service: SkipService = {
+  resources: { data: MultResource },
+  externalServices: {
     sumexample: SkipExternalService.direct({ host: "localhost", port: 3587 }),
-  };
+  },
 
   createGraph(
     inputCollections: Record<string, EagerCollection<string, number>>,
   ) {
     return inputCollections;
-  }
-}
+  },
+};
 
-const closable = await runService(new Service(), 3588);
+const closable = await runService(service, 3588);
 
 function shutdown() {
   closable.close();

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -2,7 +2,6 @@ import type {
   Context,
   EagerCollection,
   NonEmptyIterator,
-  SkipService,
   Resource,
   Json,
 } from "@skipruntime/api";

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -4,7 +4,6 @@ import type {
   EagerCollection,
   LazyCollection,
   Json,
-  SkipService,
   Resource,
 } from "@skipruntime/api";
 

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -72,26 +72,26 @@ class ComputedCells implements Resource {
   }
 }
 
-const service: SkipService = {
-  initialData: { cells: [] },
-  resources: { computed: ComputedCells },
-
-  createGraph(
-    inputCollections: { cells: EagerCollection<string, Json> },
-    context: Context,
-  ): Record<string, EagerCollection<Json, Json>> {
-    const cells = inputCollections.cells;
-    // Create evaluation dependency graph as _lazy_ collection, calling itself to access other cells
-    const evaluator = context.createLazyCollection(ComputeExpression, cells);
-    // Produce eager collection for output resource
-    return { output: cells.map(CallCompute, evaluator) };
+const service = await runService(
+  {
+    initialData: { cells: [] },
+    resources: { computed: ComputedCells },
+    createGraph(
+      inputCollections: { cells: EagerCollection<string, Json> },
+      context: Context,
+    ): Record<string, EagerCollection<Json, Json>> {
+      const cells = inputCollections.cells;
+      // Create evaluation dependency graph as _lazy_ collection, calling itself to access other cells
+      const evaluator = context.createLazyCollection(ComputeExpression, cells);
+      // Produce eager collection for output resource
+      return { output: cells.map(CallCompute, evaluator) };
+    },
   },
-};
-
-const closable = await runService(service, 9998);
+  9998,
+);
 
 function shutdown() {
-  closable.close();
+  service.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -42,12 +42,14 @@ class Sub implements Resource {
   }
 }
 
-const service: SkipService = {
-  initialData: { input1: [], input2: [] },
-  resources: { add: Add, sub: Sub },
-  createGraph: (inputs) => inputs,
-};
-const closable = await runService(service, 3587);
+const closable = await runService(
+  {
+    initialData: { input1: [], input2: [] },
+    resources: { add: Add, sub: Sub },
+    createGraph: (inputs) => inputs,
+  },
+  3587,
+);
 
 function shutdown() {
   closable.close();

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -1,7 +1,6 @@
 import type {
   EagerCollection,
   NonEmptyIterator,
-  SkipService,
   Resource,
 } from "@skipruntime/api";
 

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -42,18 +42,12 @@ class Sub implements Resource {
   }
 }
 
-class Service implements SkipService {
-  initialData = { input1: [], input2: [] };
-  resources = { add: Add, sub: Sub };
-
-  createGraph(
-    inputCollections: Record<string, EagerCollection<string, number>>,
-  ) {
-    return inputCollections;
-  }
-}
-
-const closable = await runService(new Service(), 3587);
+const service: SkipService = {
+  initialData: { input1: [], input2: [] },
+  resources: { add: Add, sub: Sub },
+  createGraph: (inputs) => inputs,
+};
+const closable = await runService(service, 3587);
 
 function shutdown() {
   closable.close();

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -69,14 +69,14 @@ class Map1Resource implements Resource {
   }
 }
 
-class Map1Service implements SkipService {
-  initialData = { input: [] };
-  resources = { map1: Map1Resource };
+const map1Service: SkipService = {
+  initialData: { input: [] },
+  resources: { map1: Map1Resource },
 
   createGraph(inputCollections: { input: EagerCollection<number, number> }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 //// testMap2
 
@@ -107,17 +107,17 @@ class Map2Resource implements Resource {
   }
 }
 
-class Map2Service implements SkipService {
-  initialData = { input1: [], input2: [] };
-  resources = { map2: Map2Resource };
+const map2Service: SkipService = {
+  initialData: { input1: [], input2: [] },
+  resources: { map2: Map2Resource },
 
   createGraph(inputCollections: {
     input1: EagerCollection<string, number>;
     input2: EagerCollection<string, number>;
   }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 //// testMap3
 
@@ -139,17 +139,17 @@ class Map3Resource implements Resource {
   }
 }
 
-class Map3Service implements SkipService {
-  initialData = { input1: [], input2: [] };
-  resources = { map3: Map3Resource };
+const map3Service: SkipService = {
+  initialData: { input1: [], input2: [] },
+  resources: { map3: Map3Resource },
 
   createGraph(inputCollections: {
     input1: EagerCollection<number, number>;
     input2: EagerCollection<number, number>;
   }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 //// testOneToOneMapper
 
@@ -173,14 +173,14 @@ class OneToOneMapperResource implements Resource {
   }
 }
 
-class OneToOneMapperService implements SkipService {
-  initialData = { input: [] };
-  resources = { valueMapper: OneToOneMapperResource };
+const oneToOneMapperService: SkipService = {
+  initialData: { input: [] },
+  resources: { valueMapper: OneToOneMapperResource },
 
   createGraph(inputCollections: { input: EagerCollection<number, number> }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 //// testSize
 
@@ -204,17 +204,17 @@ class SizeResource implements Resource {
   }
 }
 
-class SizeService implements SkipService {
-  initialData = { input1: [], input2: [] };
-  resources = { size: SizeResource };
+const sizeService: SkipService = {
+  initialData: { input1: [], input2: [] },
+  resources: { size: SizeResource },
 
   createGraph(inputCollections: {
     input1: EagerCollection<number, number>;
     input2: EagerCollection<number, number>;
   }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 //// testSlicedMap1
 
@@ -240,14 +240,14 @@ class SlicedMap1Resource implements Resource {
   }
 }
 
-class SlicedMap1Service implements SkipService {
-  initialData = { input: [] };
-  resources = { slice: SlicedMap1Resource };
+const slicedMap1Service: SkipService = {
+  initialData: { input: [] },
+  resources: { slice: SlicedMap1Resource },
 
   createGraph(inputCollections: { input: EagerCollection<number, number> }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 //// testLazy
 
@@ -282,14 +282,14 @@ class LazyResource implements Resource {
   }
 }
 
-class LazyService implements SkipService {
-  initialData = { input: [] };
-  resources = { lazy: LazyResource };
+const lazyService: SkipService = {
+  initialData: { input: [] },
+  resources: { lazy: LazyResource },
 
   createGraph(inputCollections: { input: EagerCollection<number, number> }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 //// testMapReduce
 
@@ -310,14 +310,14 @@ class MapReduceResource implements Resource {
   }
 }
 
-class MapReduceService implements SkipService {
-  initialData = { input: [] };
-  resources = { mapReduce: MapReduceResource };
+const mapReduceService: SkipService = {
+  initialData: { input: [] },
+  resources: { mapReduce: MapReduceResource },
 
   createGraph(inputCollections: { input: EagerCollection<number, number> }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 //// testMerge1
 
@@ -330,17 +330,17 @@ class Merge1Resource implements Resource {
   }
 }
 
-class Merge1Service implements SkipService {
-  initialData = { input1: [], input2: [] };
-  resources = { merge1: Merge1Resource };
+const merge1Service: SkipService = {
+  initialData: { input1: [], input2: [] },
+  resources: { merge1: Merge1Resource },
 
   createGraph(inputCollections: {
     input1: EagerCollection<number, number>;
     input2: EagerCollection<number, number>;
   }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 function sorted(entries: Entry<Json, Json>[]): Entry<Json, Json>[] {
   for (const entry of entries) {
@@ -366,17 +366,17 @@ class MergeReduceResource implements Resource {
   }
 }
 
-class MergeReduceService implements SkipService {
-  initialData = { input1: [], input2: [] };
-  resources = { mergeReduce: MergeReduceResource };
+const mergeReduceService: SkipService = {
+  initialData: { input1: [], input2: [] },
+  resources: { mergeReduce: MergeReduceResource },
 
   createGraph(inputCollections: {
     input1: EagerCollection<number, number>;
     input2: EagerCollection<number, number>;
   }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 // testJSONExtract
 
@@ -407,16 +407,16 @@ class JSONExtractResource implements Resource {
   }
 }
 
-class JSONExtractService implements SkipService {
-  initialData = { input: [] };
-  resources = { jsonExtract: JSONExtractResource };
+const jsonExtractService: SkipService = {
+  initialData: { input: [] },
+  resources: { jsonExtract: JSONExtractResource },
 
   createGraph(inputCollections: {
     input: EagerCollection<number, { value: JsonObject; pattern: string }>;
   }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 //// testExternalService
 
@@ -509,18 +509,18 @@ class MockExternalResource implements Resource {
   }
 }
 
-class TestExternalService implements SkipService {
-  initialData = { input1: [], input2: [] };
-  resources = { external: MockExternalResource };
-  externalServices = { external: new MockExternal() };
+const testExternalService: SkipService = {
+  initialData: { input1: [], input2: [] },
+  resources: { external: MockExternalResource },
+  externalServices: { external: new MockExternal() },
 
   createGraph(inputCollections: {
     input1: EagerCollection<number, number>;
     input2: EagerCollection<number, number>;
   }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 //// testCloseSession
 
@@ -541,15 +541,15 @@ class TokensResource implements Resource {
 
 const system = new GenericExternalService({ timer: new TimerResource() });
 
-class TokensService implements SkipService {
-  initialData = { input: [] };
-  resources = { tokens: TokensResource };
-  externalServices = { system };
+const tokensService: SkipService = {
+  initialData: { input: [] },
+  resources: { tokens: TokensResource },
+  externalServices: { system },
 
   createGraph() {
     return {};
-  }
-}
+  },
+};
 
 //// testMultipleResources
 
@@ -569,29 +569,29 @@ class Resource2 implements Resource {
   }
 }
 
-class MultipleResourcesService implements SkipService {
-  initialData = { input1: [], input2: [] };
-  resources = { resource1: Resource1, resource2: Resource2 };
+const multipleResourcesService: SkipService = {
+  initialData: { input1: [], input2: [] },
+  resources: { resource1: Resource1, resource2: Resource2 },
 
   createGraph(inputCollections: {
     input1: EagerCollection<number, number>;
     input2: EagerCollection<number, number>;
   }) {
     return inputCollections;
-  }
-}
+  },
+};
 
 export function initTests(
   initService: (service: SkipService) => Promise<ServiceInstance>,
 ) {
   it("testMap1", async () => {
-    const service = await initService(new Map1Service());
+    const service = await initService(map1Service);
     service.update("input", [["1", [10]]]);
     expect(service.getArray("map1", "1").payload).toEqual([12]);
   });
 
   it("testMap2", async () => {
-    const service = await initService(new Map2Service());
+    const service = await initService(map2Service);
     const resource = "map2";
     service.update("input1", [["1", [10]]]);
     service.update("input2", [["1", [20]]]);
@@ -605,7 +605,7 @@ export function initTests(
   });
 
   it("testMap3", async () => {
-    const service = await initService(new Map3Service());
+    const service = await initService(map3Service);
     const resource = "map3";
     service.update("input1", [["1", [1, 2, 3]]]);
     service.update("input2", [["1", [10]]]);
@@ -619,7 +619,7 @@ export function initTests(
   });
 
   it("valueMapper", async () => {
-    const service = await initService(new OneToOneMapperService());
+    const service = await initService(oneToOneMapperService);
     const resource = "valueMapper";
     service.update("input", [
       [1, [1]],
@@ -636,7 +636,7 @@ export function initTests(
   });
 
   it("testSize", async () => {
-    const service = await initService(new SizeService());
+    const service = await initService(sizeService);
     const resource = "size";
     service.update("input1", [
       [1, [0]],
@@ -662,7 +662,7 @@ export function initTests(
   });
 
   it("testSlicedMap1", async () => {
-    const service = await initService(new SlicedMap1Service());
+    const service = await initService(slicedMap1Service);
     const resource = "slice";
     // Inserts [[0, 0], ..., [30, 30]
     const values = Array.from({ length: 31 }, (_, i): Entry<number, number> => {
@@ -681,7 +681,7 @@ export function initTests(
   });
 
   it("testLazy", async () => {
-    const service = await initService(new LazyService());
+    const service = await initService(lazyService);
     const resource = "lazy";
     service.update("input", [
       [0, [10]],
@@ -705,7 +705,7 @@ export function initTests(
   });
 
   it("testMapReduce", async () => {
-    const service = await initService(new MapReduceService());
+    const service = await initService(mapReduceService);
     const resource = "mapReduce";
     service.update("input", [
       [0, [1]],
@@ -738,7 +738,7 @@ export function initTests(
   });
 
   it("testMerge1", async () => {
-    const service = await initService(new Merge1Service());
+    const service = await initService(merge1Service);
     const resource = "merge1";
     service.update("input1", [[1, [10]]]);
     service.update("input2", [[1, [20]]]);
@@ -759,7 +759,7 @@ export function initTests(
   });
 
   it("testMergeReduce", async () => {
-    const service = await initService(new MergeReduceService());
+    const service = await initService(mergeReduceService);
     const resource = "mergeReduce";
     service.update("input1", [[1, [10]]]);
     service.update("input2", [[1, [20]]]);
@@ -778,7 +778,7 @@ export function initTests(
   });
 
   it("testJSONExtract", async () => {
-    const service = await initService(new JSONExtractService());
+    const service = await initService(jsonExtractService);
     const resource = "jsonExtract";
     service.update("input", [
       [
@@ -837,7 +837,7 @@ export function initTests(
 
   it("testExternal", async () => {
     const resource = "external";
-    const service = await initService(new TestExternalService());
+    const service = await initService(testExternalService);
     service.update("input1", [
       [0, [10]],
       [1, [20]],
@@ -875,7 +875,7 @@ export function initTests(
   });
 
   it("testCloseSession", async () => {
-    const service = await initService(new TokensService());
+    const service = await initService(tokensService);
     const resource = "tokens";
     const start = service.getArray(resource, "5ms").payload;
     await timeout(2);
@@ -890,7 +890,7 @@ export function initTests(
   });
 
   it("testMultipleResources", async () => {
-    const service = await initService(new MultipleResourcesService());
+    const service = await initService(multipleResourcesService);
     service.update("input1", [["1", [10]]]);
     expect(service.getArray("resource1", "1").payload).toEqual([10]);
     service.update("input2", [["1", [20]]]);


### PR DESCRIPTION
This is a change we discussed at the offsite and mostly agreed was an improvement, since it makes more clear that the object is an "initial config" / "definition of the service" and not an OO representation that could keep being updated/interacted with over the life of the program.

What do you guys think, seeing it in better context here?  I also inlined the object literal to some `runService` calls where it made sense -- I expect that will be a common way of using these interfaces, and it looks pretty good/ergonomic to me FWIW.