### PR TITLE
Generic Service/Resource types

### DIFF
--- a/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
@@ -35,9 +35,9 @@ type ResourceInputs = {
 };
 
 export function serviceWithInitialData(
-  posts: Entry<string, Post>[],
-  users: Entry<string, User>[],
-  upvotes: Entry<string, Upvote>[],
+  posts: Entry<number, Post>[],
+  users: Entry<number, User>[],
+  upvotes: Entry<number, Upvote>[],
 ): SkipService<Inputs, ResourceInputs> {
   return {
     initialData: { posts, users, upvotes },

--- a/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
@@ -38,7 +38,7 @@ export function serviceWithInitialData(
   posts: Entry<string, Post>[],
   users: Entry<string, User>[],
   upvotes: Entry<string, Upvote>[],
-): SkipService {
+): SkipService<Inputs, ResourceInputs> {
   return {
     initialData: { posts, users, upvotes },
     resources: { posts: PostsResource },

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -384,12 +384,20 @@ export interface Resource<
   ): EagerCollection<Json, Json>;
 }
 
+// Initial data for services' initial collections are provided as an object with arrays of
+// entries for each input collection
+type InitialData<Inputs extends NamedCollections> = {
+  [Name in keyof Inputs]: Inputs[Name] extends EagerCollection<infer K, infer V>
+    ? Entry<K, V>[]
+    : Entry<Json, Json>[];
+};
+
 export interface SkipService<
   Inputs extends NamedCollections = NamedCollections,
   ResourceInputs extends NamedCollections = NamedCollections,
 > {
   /** The data used to initially populate the input collections of the service */
-  initialData?: { [Name in keyof Inputs]: Entry<Json, Json>[] };
+  initialData?: InitialData<Inputs>;
   /** The external service dependencies of the service */
   externalServices?: Record<string, ExternalService>;
   /** The reactive resources which compose the public interface of this reactive service */

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -358,7 +358,7 @@ export interface ExternalService {
   shutdown(): void;
 }
 
-export type NamedCollections = Record<string, EagerCollection<Json, Json>>;
+export type NamedCollections = { [name: string]: EagerCollection<Json, Json> };
 
 /**
  * `Resource`s make up the public interface of a SkipService, specifying how to respond

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -74,10 +74,11 @@ async function initDB(): Promise<sqlite3.Database> {
 
 type User = { name: string; country: string };
 
-class UsersResource implements Resource {
-  instantiate(cs: {
-    users: EagerCollection<string, User>;
-  }): EagerCollection<string, User> {
+type UsersCollection = {
+  users: EagerCollection<string, User>;
+};
+class UsersResource implements Resource<UsersCollection> {
+  instantiate(cs: UsersCollection): UsersCollection["users"] {
     return cs.users;
   }
 }
@@ -86,12 +87,13 @@ class UsersResource implements Resource {
 // Setting up the service
 /*****************************************************************************/
 
-function serviceWithInitialData(users: Entry<string, User>[]): SkipService {
+function serviceWithInitialData(
+  users: Entry<string, User>[],
+): SkipService<UsersCollection, UsersCollection> {
   return {
     initialData: { users },
     resources: { users: UsersResource },
-    createGraph: (inputCollections: { users: EagerCollection<string, User> }) =>
-      inputCollections,
+    createGraph: (inputCollections) => inputCollections,
   };
 }
 

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -63,22 +63,19 @@ class CallCompute extends OneToOneMapper<string, Json, Json> {
   }
 }
 
+type Inputs = { cells: EagerCollection<string, Json> };
+type Outputs = { output: EagerCollection<string, Json> };
+
 class ComputedCells implements Resource {
-  instantiate(collections: {
-    output: EagerCollection<string, Json>;
-  }): EagerCollection<string, Json> {
+  instantiate(collections: Outputs): EagerCollection<string, Json> {
     return collections.output;
   }
 }
-
-const service = await runService(
+const service = await runService<Inputs, Outputs>(
   {
     initialData: { cells: [] },
     resources: { computed: ComputedCells },
-    createGraph(
-      inputCollections: { cells: EagerCollection<string, Json> },
-      context: Context,
-    ): Record<string, EagerCollection<Json, Json>> {
+    createGraph(inputCollections: Inputs, context: Context): Outputs {
       const cells = inputCollections.cells;
       // Create evaluation dependency graph as _lazy_ collection, calling itself to access other cells
       const evaluator = context.createLazyCollection(ComputeExpression, cells);

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -23,25 +23,24 @@ class Minus extends ManyToOneMapper<string, number, number> {
   }
 }
 
-class Add implements Resource {
-  instantiate(cs: {
-    input1: EagerCollection<string, number>;
-    input2: EagerCollection<string, number>;
-  }): EagerCollection<string, number> {
+type Collections = {
+  input1: EagerCollection<string, number>;
+  input2: EagerCollection<string, number>;
+};
+
+class Add implements Resource<Collections> {
+  instantiate(cs: Collections): EagerCollection<string, number> {
     return cs.input1.merge(cs.input2).map(Plus);
   }
 }
 
-class Sub implements Resource {
-  instantiate(cs: {
-    input1: EagerCollection<string, number>;
-    input2: EagerCollection<string, number>;
-  }): EagerCollection<string, number> {
+class Sub implements Resource<Collections> {
+  instantiate(cs: Collections): EagerCollection<string, number> {
     return cs.input1.merge(cs.input2).map(Minus);
   }
 }
 
-const closable = await runService(
+const closable = await runService<Collections, Collections>(
   {
     initialData: { input1: [], input2: [] },
     resources: { add: Add, sub: Sub },

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -1,11 +1,18 @@
 import { WebSocketServer } from "ws";
 import * as http from "http";
-import { initService, type SkipService } from "skip-wasm";
+import {
+  initService,
+  type SkipService,
+  type NamedCollections,
+} from "skip-wasm";
 import { createRESTServer } from "./rest.js";
 import { ReplicationServer } from "./replication.js";
 
-export async function runService(
-  service: SkipService,
+export async function runService<
+  Inputs extends NamedCollections,
+  Outputs extends NamedCollections,
+>(
+  service: SkipService<Inputs, Outputs>,
   port: number = 443,
 ): Promise<{ close: () => void }> {
   const runtime = await initService(service);

--- a/skipruntime-ts/wasm/src/skip-runtime.ts
+++ b/skipruntime-ts/wasm/src/skip-runtime.ts
@@ -19,6 +19,7 @@ export type {
   CollectionUpdate,
   Watermark,
   SubscriptionID,
+  NamedCollections,
 } from "@skipruntime/api";
 
 export type {


### PR DESCRIPTION
This PR adds type parameters to the SkipService and Resource types, allowing to give more precise types and stricter checking that keys/types match between `initialData`, `SkipService#createGraph`, and `Resource#instantiate`.

E.G. where before we had 
```
initialData?: Record<string, Entry<Json, Json>[]>
resources?: Record<string, new (params: Record<string, string>) => Resource>;
createGraph(
  inputCollections: Record<string, EagerCollection<Json, Json>>,
  context: Context,
): Record<string, EagerCollection<Json, Json>>;
```
and care was required to match up the keys of the various records, as well as the more-precise-than-`Json` types of keys/values, now you can write something like

```
type Inputs = { input1 : EagerCollection<K1, V1>, input2: EagerCollection<K2, V2> }
type Outputs = { output1 : EagerCollection<K3, V3>, output2: EagerCollection<K4, V4> }
```

and define your service as `SkipService<Inputs, Outputs>` to get static checking that the various records agree and that the keys/values have the right type.
