### PR TITLE
Strengthen typing of SkipService.initialData vs createGraph

### DIFF
--- a/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
@@ -2,6 +2,7 @@ import type {
   Entry,
   EagerCollection,
   NonEmptyIterator,
+  CollectionsOf,
   SkipService,
   Resource,
 } from "skip-wasm";
@@ -25,20 +26,21 @@ type Upvote = {
 
 type Upvoted = Post & { upvotes: number; author: User };
 
-type Inputs = {
-  posts: EagerCollection<number, Post>;
-  users: EagerCollection<number, User>;
-  upvotes: EagerCollection<number, Upvote>;
+type InputTypes = {
+  posts: [number, Post];
+  users: [number, User];
+  upvotes: [number, Upvote];
 };
-type ResourceInputs = {
-  postsWithUpvotes: EagerCollection<number, Upvoted>;
-};
+type Inputs = CollectionsOf<InputTypes>;
+
+type ResourceInputTypes = { postsWithUpvotes: [number, Upvoted] };
+type ResourceInputs = CollectionsOf<ResourceInputTypes>;
 
 export function serviceWithInitialData(
   posts: Entry<number, Post>[],
   users: Entry<number, User>[],
   upvotes: Entry<number, Upvote>[],
-): SkipService<Inputs, ResourceInputs> {
+): SkipService<InputTypes, ResourceInputTypes> {
   return {
     initialData: { posts, users, upvotes },
     resources: { posts: PostsResource },

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -1,5 +1,5 @@
 import type {
-  EagerCollection,
+  CollectionsOf,
   SkipService,
   Resource,
   Entry,
@@ -74,10 +74,10 @@ async function initDB(): Promise<sqlite3.Database> {
 
 type User = { name: string; country: string };
 
-type UsersCollection = {
-  users: EagerCollection<string, User>;
-};
-class UsersResource implements Resource<UsersCollection> {
+type UsersCollectionType = { users: [string, User] };
+type UsersCollection = CollectionsOf<UsersCollectionType>;
+
+class UsersResource implements Resource<UsersCollectionType> {
   instantiate(cs: UsersCollection): UsersCollection["users"] {
     return cs.users;
   }
@@ -89,7 +89,7 @@ class UsersResource implements Resource<UsersCollection> {
 
 function serviceWithInitialData(
   users: Entry<string, User>[],
-): SkipService<UsersCollection, UsersCollection> {
+): SkipService<UsersCollectionType, UsersCollectionType> {
   return {
     initialData: { users },
     resources: { users: UsersResource },

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -5,6 +5,7 @@ import type {
   LazyCollection,
   Json,
   Resource,
+  CollectionsOf,
 } from "@skipruntime/api";
 
 import { OneToOneMapper } from "@skipruntime/api";
@@ -63,15 +64,18 @@ class CallCompute extends OneToOneMapper<string, Json, Json> {
   }
 }
 
-type Inputs = { cells: EagerCollection<string, Json> };
-type Outputs = { output: EagerCollection<string, Json> };
+type InputTypes = { cells: [string, Json] };
+type Inputs = CollectionsOf<InputTypes>;
+
+type OutputTypes = { output: [string, Json] };
+type Outputs = CollectionsOf<OutputTypes>;
 
 class ComputedCells implements Resource {
   instantiate(collections: Outputs): EagerCollection<string, Json> {
     return collections.output;
   }
 }
-const service = await runService<Inputs, Outputs>(
+const service = await runService<InputTypes, OutputTypes>(
   {
     initialData: { cells: [] },
     resources: { computed: ComputedCells },

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -2,6 +2,7 @@ import type {
   EagerCollection,
   NonEmptyIterator,
   Resource,
+  CollectionsOf,
 } from "@skipruntime/api";
 
 import { ManyToOneMapper } from "@skipruntime/api";
@@ -23,24 +24,25 @@ class Minus extends ManyToOneMapper<string, number, number> {
   }
 }
 
-type Collections = {
-  input1: EagerCollection<string, number>;
-  input2: EagerCollection<string, number>;
+type CollectionTypes = {
+  input1: [string, number];
+  input2: [string, number];
 };
+type Collections = CollectionsOf<CollectionTypes>;
 
-class Add implements Resource<Collections> {
+class Add implements Resource<CollectionTypes> {
   instantiate(cs: Collections): EagerCollection<string, number> {
     return cs.input1.merge(cs.input2).map(Plus);
   }
 }
 
-class Sub implements Resource<Collections> {
+class Sub implements Resource<CollectionTypes> {
   instantiate(cs: Collections): EagerCollection<string, number> {
     return cs.input1.merge(cs.input2).map(Minus);
   }
 }
 
-const closable = await runService<Collections, Collections>(
+const closable = await runService<CollectionTypes, CollectionTypes>(
   {
     initialData: { input1: [], input2: [] },
     resources: { add: Add, sub: Sub },

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -1,16 +1,12 @@
 import { WebSocketServer } from "ws";
 import * as http from "http";
-import {
-  initService,
-  type SkipService,
-  type NamedCollections,
-} from "skip-wasm";
+import { initService, type SkipService, type CollectionTypes } from "skip-wasm";
 import { createRESTServer } from "./rest.js";
 import { ReplicationServer } from "./replication.js";
 
 export async function runService<
-  Inputs extends NamedCollections,
-  Outputs extends NamedCollections,
+  Inputs extends CollectionTypes,
+  Outputs extends CollectionTypes,
 >(
   service: SkipService<Inputs, Outputs>,
   port: number = 443,

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -73,7 +73,7 @@ const map1Service: SkipService = {
   initialData: { input: [] },
   resources: { map1: Map1Resource },
 
-  createGraph(inputCollections: { input: EagerCollection<number, number> }) {
+  createGraph(inputCollections: { input: EagerCollection<string, number> }) {
     return inputCollections;
   },
 };

--- a/skipruntime-ts/wasm/src/skip-runtime.ts
+++ b/skipruntime-ts/wasm/src/skip-runtime.ts
@@ -19,7 +19,9 @@ export type {
   CollectionUpdate,
   Watermark,
   SubscriptionID,
-  NamedCollections,
+  CollectionTypes,
+  EntrysOf,
+  CollectionsOf,
 } from "@skipruntime/api";
 
 export type {


### PR DESCRIPTION
This diff changes the type parameters of SkipService so that they only
specify corresponding collection names, key types and value types, without
already instantiating the EagerCollection type. This type "signature" can
then be used to construct the instantiations of Entry for the type of
initialData as well as the instantiations of EagerCollection for the type of
e.g. createGraph.

This uses typescript's "mapped" and "indexed access" types but does not need
the machinery of "conditional" or "infer" types.