### PR TITLE
Prefer indexed object types over Record

### DIFF
--- a/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/back-end/reactive_service/src/hackernews.service.ts
@@ -97,7 +97,7 @@ class SortingMapper {
 class PostsResource implements Resource<ResourceInputs> {
   private limit: number;
 
-  constructor(params: Record<string, string>) {
+  constructor(params: { [param: string]: string }) {
     this.limit = Number(params["limit"]);
   }
 

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -268,7 +268,7 @@ export interface Context extends Constant {
   useExternalResource<K extends Json, V extends Json>(resource: {
     service: string;
     identifier: string;
-    params?: Record<string, string | number>;
+    params?: { [param: string]: string | number };
   }): EagerCollection<K, V>;
 
   jsonExtract(value: JsonObject, pattern: string): Json[];
@@ -328,7 +328,7 @@ export interface ExternalService {
    */
   subscribe(
     resource: string,
-    params: Record<string, string | number>,
+    params: { [param: string]: string | number },
     callbacks: {
       update: (updates: Entry<Json, Json>[], isInit: boolean) => void;
       error: (error: Json) => void;
@@ -341,7 +341,10 @@ export interface ExternalService {
    * @param resource - the name of the external resource
    * @param params - the parameters of the external resource
    */
-  unsubscribe(resource: string, params: Record<string, string | number>): void;
+  unsubscribe(
+    resource: string,
+    params: { [param: string]: string | number },
+  ): void;
 
   /**
    * Shutdown the external supplier
@@ -388,12 +391,13 @@ export interface SkipService<
   /** The data used to initially populate the input collections of the service */
   initialData?: InitialData<Inputs>;
   /** The external service dependencies of the service */
-  externalServices?: Record<string, ExternalService>;
+  externalServices?: { [name: string]: ExternalService };
   /** The reactive resources which compose the public interface of this reactive service */
-  resources?: Record<
-    string,
-    new (params: Record<string, string>) => Resource<ResourceInputs>
-  >;
+  resources?: {
+    [name: string]: new (params: {
+      [param: string]: string;
+    }) => Resource<ResourceInputs>;
+  };
 
   /**
    * Build a static reactive compute graph by defining some collections to be passed

--- a/skipruntime-ts/examples/database-server.ts
+++ b/skipruntime-ts/examples/database-server.ts
@@ -26,7 +26,7 @@ app.use(express.urlencoded({ extended: true }));
 
 const run = function (
   query: string,
-  params: Record<string, string>,
+  params: { [param: string]: string },
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     db.run(query, params, (err) => {

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -29,7 +29,7 @@ async function initDB(): Promise<sqlite3.Database> {
   };
   const run = (
     query: string,
-    params: Record<string, string>,
+    params: { [param: string]: string },
   ): Promise<void> => {
     return new Promise((resolve, reject) => {
       db.run(query, params, (err) => {

--- a/skipruntime-ts/examples/utils.ts
+++ b/skipruntime-ts/examples/utils.ts
@@ -21,7 +21,7 @@ interface Delete {
 }
 
 class SkipHttpAccessV1 {
-  private services: Record<number, RESTWrapperOfSkipService>;
+  private services: { [port: number]: RESTWrapperOfSkipService };
   private defaultPort: number;
 
   constructor(ports: number[] = [3587]) {
@@ -62,14 +62,22 @@ class SkipHttpAccessV1 {
     return Promise.allSettled(promises);
   }
 
-  async log(resource: string, params: Record<string, string>, port?: number) {
+  async log(
+    resource: string,
+    params: { [param: string]: string },
+    port?: number,
+  ) {
     const service = this.services[port ?? this.defaultPort];
     if (service === undefined) throw new Error(`Invalid port ${port}`);
     const result = await service.getAll(resource, params);
     console.log(JSON.stringify(result));
   }
 
-  request(resource: string, params: Record<string, string>, port?: number) {
+  request(
+    resource: string,
+    params: { [param: string]: string },
+    port?: number,
+  ) {
     const service = this.services[port ?? this.defaultPort];
     if (service === undefined) throw new Error(`Invalid port ${port}`);
 
@@ -94,7 +102,7 @@ interface RequestQuery {
   type: "request";
   payload: {
     resource: string;
-    params?: Record<string, string>;
+    params?: { [param: string]: string };
     port?: number;
   };
 }
@@ -103,7 +111,7 @@ interface LogQuery {
   type: "log";
   payload: {
     resource: string;
-    params?: Record<string, string>;
+    params?: { [param: string]: string };
     port?: number;
   };
 }
@@ -312,7 +320,7 @@ export function run(scenarios: Step[][], ports: number[] = [3587]) {
           (query: string) => {
             const jsquery = JSON.parse(query) as {
               resource: string;
-              params?: Record<string, string>;
+              params?: { [param: string]: string };
               port?: number;
             };
             access.request(
@@ -327,7 +335,7 @@ export function run(scenarios: Step[][], ports: number[] = [3587]) {
           (query: string) => {
             const jsquery = JSON.parse(query) as {
               resource: string;
-              params?: Record<string, string>;
+              params?: { [param: string]: string };
               port?: number;
             };
             access

--- a/skipruntime-ts/helpers/src/remote.ts
+++ b/skipruntime-ts/helpers/src/remote.ts
@@ -20,7 +20,7 @@ export class SkipExternalService implements ExternalService {
 
   subscribe(
     resource: string,
-    params: Record<string, string>,
+    params: { [param: string]: string },
     callbacks: {
       update: (updates: Entry<Json, Json>[], isInit: boolean) => void;
       // FIXME: What is `error()` used for?
@@ -47,7 +47,7 @@ export class SkipExternalService implements ExternalService {
     this.resources.set(this.toId(resource, params), evSource);
   }
 
-  unsubscribe(resource: string, params: Record<string, string>) {
+  unsubscribe(resource: string, params: { [param: string]: string }) {
     const closable = this.resources.get(this.toId(resource, params));
     if (closable) closable.close();
   }
@@ -58,7 +58,7 @@ export class SkipExternalService implements ExternalService {
     }
   }
 
-  private toId(resource: string, params: Record<string, string>): string {
+  private toId(resource: string, params: { [param: string]: string }): string {
     // TODO: This is equivalent to `querystring.encode(params, ',', ':')`.
     const strparams: string[] = [];
     for (const key of Object.keys(params).sort()) {

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -15,7 +15,7 @@ function toHttp(entrypoint: Entrypoint) {
 export async function fetchJSON<V>(
   url: string,
   method: "POST" | "GET" | "PUT" | "PATCH" | "HEAD" | "DELETE" = "GET",
-  headers: Record<string, string> = {},
+  headers: { [header: string]: string } = {},
   data?: Json,
 ): Promise<[V | null, Headers]> {
   const body = data ? JSON.stringify(data) : undefined;
@@ -54,7 +54,7 @@ export class RESTWrapperOfSkipService {
 
   async getAll<K extends Json, V extends Json>(
     resource: string,
-    params: Record<string, string>,
+    params: { [param: string]: string },
   ): Promise<Entry<K, V>[]> {
     const qParams = new URLSearchParams(params).toString();
     const [optValues, _headers] = await fetchJSON<Entry<K, V>[]>(
@@ -67,7 +67,7 @@ export class RESTWrapperOfSkipService {
 
   async getArray<V extends Json>(
     resource: string,
-    params: Record<string, string>,
+    params: { [param: string]: string },
     key: string,
   ): Promise<V[]> {
     const qParams = new URLSearchParams(params).toString();

--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -17,7 +17,7 @@ export function createRESTServer(service: ServiceInstance): express.Express {
       service.getArray(
         req.params.resource,
         req.params.key,
-        req.query as Record<string, string>,
+        req.query as { [param: string]: string },
         {
           resolve: (data: Json) => {
             res.status(200).json(data);
@@ -39,7 +39,7 @@ export function createRESTServer(service: ServiceInstance): express.Express {
           // (upon reconnecting).
           const resource = service.instantiateResource(
             req.params.resource,
-            req.query as Record<string, string>,
+            req.query as { [param: string]: string },
           );
           res.writeHead(200, {
             Connection: "keep-alive",

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -37,18 +37,21 @@ type GetResult<T> = {
 interface ServiceInstance {
   getAll<K extends Json, V extends Json>(
     resource: string,
-    params?: Record<string, string>,
+    params?: { [param: string]: string },
   ): GetResult<Values<K, V>>;
   getArray<V extends Json>(
     resource: string,
     key: string | number,
-    params?: Record<string, string>,
+    params?: { [param: string]: string },
   ): GetResult<V[]>;
   update<K extends Json, V extends Json>(
     collection: string,
     entries: Entry<K, V>[],
   ): void;
-  closeResourceInstance(resource: string, params: Record<string, string>): void;
+  closeResourceInstance(
+    resource: string,
+    params: { [param: string]: string },
+  ): void;
 }
 
 //// testMap1


### PR DESCRIPTION
The type `Record<K,V>` can be helpful when `K` is a finite union, especially
when named and used elsewhere, to deduplicate definitions, improve
exhaustivity checking, etc. But for cases such as `Record<string,V>`, it is
just an indirect way (using a mapped type) to express an indexed object
type. This PR switches to indexed types, which seem to be more idiomatic,
and subjectively clearer.