### PR TITLE
Improve freeze

### DIFF
--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -20,7 +20,7 @@ export type JsonObject = { [key: string]: Nullable<Json> };
  * value or a Skip-runtime-managed value. In either case, restricting mapper parameters to
  * this type helps developers to ensure that reactive computations can be re-evaluated as
  * needed with consistent semantics.
- * `Constant`s are recursively-frozen objects managed by the Skip runtime; non-Skip objects can be made constant by passing them to `freeze`.
+ * `Constant`s are deep-frozen objects managed by the Skip runtime; non-Skip objects can be made constant by passing them to `deepFreeze`.
  */
 export type Param =
   | null

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -26,7 +26,9 @@ export type Param =
   | null
   | boolean
   | number
+  | bigint
   | string
+  | symbol
   | Constant
   | readonly Param[]
   | { readonly [k: string]: Param };

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -77,13 +77,13 @@ abstract class SkFrozen extends Frozen {
  *
  * The primary use for this function is to satisfy the requirement that all
  * parameters to Skip `Mapper` constructors must be deep-frozen: objects
- * that have not been constructed by Skip can be passed to `freeze()` before
- * passing them to a `Mapper` constructor.
+ * that have not been constructed by Skip can be passed to `deepFreeze()`
+ * before passing them to a `Mapper` constructor.
  *
  * @param value - The object to deep-freeze.
  * @returns The same object that was passed in.
  */
-export function freeze<T>(value: T): (T & Param) | (T & Constant) {
+export function deepFreeze<T>(value: T): (T & Param) | (T & Constant) {
   if (
     typeof value == "string" ||
     typeof value == "number" ||
@@ -101,18 +101,18 @@ export function freeze<T>(value: T): (T & Param) | (T & Constant) {
     } else if (Array.isArray(value)) {
       const length: number = value.length;
       for (let i = 0; i < length; i++) {
-        value[i] = freeze(value[i]);
+        value[i] = deepFreeze(value[i]);
       }
       return Object.freeze(sk_freeze(value));
     } else {
       const jso = value as { [key: string]: any };
       for (const key of Object.keys(jso)) {
-        jso[key] = freeze(jso[key]);
+        jso[key] = deepFreeze(jso[key]);
       }
       return Object.freeze(sk_freeze(jso)) as T & Constant;
     }
   } else {
-    throw new Error(`'${typeof value}' cannot be frozen.`);
+    throw new Error(`'${typeof value}' cannot be deep-frozen.`);
   }
 }
 

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -82,10 +82,10 @@ export function check<T>(value: T): void {
         Object.values(value).forEach(check);
       }
     } else {
-      throw new Error("Invalid object: must be frozen.");
+      throw new Error("Invalid object: must be deep-frozen.");
     }
   } else {
-    throw new Error(`'${typeof value}' cannot be managed by skstore.`);
+    throw new Error(`'${typeof value}' cannot be deep-frozen.`);
   }
 }
 

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -95,7 +95,8 @@ export function check<T>(value: T): void {
  *
  * The argument object and all its properties, recursively, must not already
  * be frozen by `Object.freeze` (or else `deepFreeze` cannot mark them
- * deep-frozen).
+ * deep-frozen). Undefined, function (and hence class) values cannot be
+ * deep-frozen.
  *
  * The primary use for this function is to satisfy the requirement that all
  * parameters to Skip `Mapper` constructors must be deep-frozen: objects
@@ -107,9 +108,11 @@ export function check<T>(value: T): void {
  */
 export function deepFreeze<T>(value: T): T & Param {
   if (
-    typeof value == "string" ||
+    typeof value == "bigint" ||
+    typeof value == "boolean" ||
     typeof value == "number" ||
-    typeof value == "boolean"
+    typeof value == "string" ||
+    typeof value == "symbol"
   ) {
     return value;
   } else if (typeof value == "object") {
@@ -131,7 +134,8 @@ export function deepFreeze<T>(value: T): T & Param {
       return Object.freeze(sk_freeze(value));
     }
   } else {
-    throw new Error(`'${typeof value}' cannot be deep-frozen.`);
+    // typeof value == "function" || typeof value == "undefined"
+    throw new Error(`'${typeof value}' values cannot be deep-frozen.`);
   }
 }
 

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -74,13 +74,6 @@ export function check<T>(value: T): void {
   } else if (typeof value == "object") {
     if (value === null || isSkFrozen(value)) {
       return;
-    }
-    if (Object.isFrozen(value)) {
-      if (Array.isArray(value)) {
-        value.forEach(check);
-      } else {
-        Object.values(value).forEach(check);
-      }
     } else {
       throw new Error("Invalid object: must be deep-frozen.");
     }
@@ -99,6 +92,10 @@ export function check<T>(value: T): void {
  * _constant_. Note that as a result all objects reachable from the
  * parameter will be frozen and no longer mutable or extensible, even from
  * other references.
+ *
+ * The argument object and all its properties, recursively, must not already
+ * be frozen by `Object.freeze` (or else `deepFreeze` cannot mark them
+ * deep-frozen).
  *
  * The primary use for this function is to satisfy the requirement that all
  * parameters to Skip `Mapper` constructors must be deep-frozen: objects
@@ -121,8 +118,7 @@ export function deepFreeze<T>(value: T): T & Param {
     } else if (isSkFrozen(value)) {
       return value;
     } else if (Object.isFrozen(value)) {
-      check(value);
-      return value as T & Param;
+      throw new Error(`Cannot deep-freeze an Object.frozen value.`);
     } else if (Array.isArray(value)) {
       for (const elt of value) {
         deepFreeze(elt);

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -83,7 +83,7 @@ abstract class SkFrozen extends Frozen {
  * @param value - The object to deep-freeze.
  * @returns The same object that was passed in.
  */
-export function deepFreeze<T>(value: T): (T & Param) | (T & Constant) {
+export function deepFreeze<T>(value: T): T & Param {
   if (
     typeof value == "string" ||
     typeof value == "number" ||
@@ -99,17 +99,15 @@ export function deepFreeze<T>(value: T): (T & Param) | (T & Constant) {
       check(value);
       return value as T & Param;
     } else if (Array.isArray(value)) {
-      const length: number = value.length;
-      for (let i = 0; i < length; i++) {
-        value[i] = deepFreeze(value[i]);
+      for (const elt of value) {
+        deepFreeze(elt);
       }
       return Object.freeze(sk_freeze(value));
     } else {
-      const jso = value as { [key: string]: any };
-      for (const key of Object.keys(jso)) {
-        jso[key] = deepFreeze(jso[key]);
+      for (const val of Object.values(value)) {
+        deepFreeze(val);
       }
-      return Object.freeze(sk_freeze(jso)) as T & Constant;
+      return Object.freeze(sk_freeze(value));
     }
   } else {
     throw new Error(`'${typeof value}' cannot be deep-frozen.`);

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -64,6 +64,31 @@ abstract class SkFrozen extends Frozen {
   }
 }
 
+export function check<T>(value: T): void {
+  if (
+    typeof value == "string" ||
+    typeof value == "number" ||
+    typeof value == "boolean"
+  ) {
+    return;
+  } else if (typeof value == "object") {
+    if (value === null || isSkFrozen(value)) {
+      return;
+    }
+    if (Object.isFrozen(value)) {
+      if (Array.isArray(value)) {
+        value.forEach(check);
+      } else {
+        Object.values(value).forEach(check);
+      }
+    } else {
+      throw new Error("Invalid object: must be frozen.");
+    }
+  } else {
+    throw new Error(`'${typeof value}' cannot be managed by skstore.`);
+  }
+}
+
 /**
  * _Deep-freeze_ an object, returning the same object that was passed in.
  *
@@ -1128,31 +1153,6 @@ class ContextImpl extends SkFrozen implements Context {
         this.refs.skjson.exportString(pattern),
       ),
     ) as Json[];
-  }
-}
-
-export function check<T>(value: T): void {
-  if (
-    typeof value == "string" ||
-    typeof value == "number" ||
-    typeof value == "boolean"
-  ) {
-    return;
-  } else if (typeof value == "object") {
-    if (value === null || isSkFrozen(value)) {
-      return;
-    }
-    if (Object.isFrozen(value)) {
-      if (Array.isArray(value)) {
-        value.forEach(check);
-      } else {
-        Object.values(value).forEach(check);
-      }
-    } else {
-      throw new Error("Invalid object: must be frozen.");
-    }
-  } else {
-    throw new Error(`'${typeof value}' cannot be managed by skstore.`);
   }
 }
 

--- a/skipruntime-ts/wasm/src/skip-runtime.ts
+++ b/skipruntime-ts/wasm/src/skip-runtime.ts
@@ -28,7 +28,7 @@ export type {
 } from "./internals/skipruntime_module.js";
 export { UnknownCollectionError } from "@skipruntime/helpers/errors.js";
 export { OneToOneMapper, ManyToOneMapper } from "@skipruntime/api";
-export { freeze } from "./internals/skipruntime_module.js";
+export { deepFreeze } from "./internals/skipruntime_module.js";
 export {
   Sum,
   Min,


### PR DESCRIPTION
- Rename freeze to deepFreeze

  To emphasize that it modifies the entire object graph reachable from a
  value, unlike `Object.freeze`, and it is not expected to be used very
  frequently.

- Remove redundancy from return type.

- Remove assignments that are superfluous since deepFreeze returns its
  argument.

- Move `check` near to other operations related to frozen

- Improve `check` error messages
 
- Do not support manually deep-frozen values

  Supporting values that are manually deep-frozen rather than using
  `deepFreeze` is a complication, though slight, and a hidden latent
  performance foot-gun. Without use cases that need it, this PR simplifies the
  API and implementation by removing this support, requiring users to call
  `deepFreeze` instead.

- Treat bigint and symbol types as primitives in deepFreeze

  Also clarify that undefined and function values are not supported.