### PR TITLE
Make `slice` variadic instead of taking an array argument

### DIFF
--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -217,7 +217,7 @@ export interface EagerCollection<K extends Json, V extends Json>
    * Create a new eager collection by keeping only the elements whose keys are in
    * the given ranges.
    */
-  slice(ranges: [K, K][]): EagerCollection<K, V>;
+  slice(...ranges: [K, K][]): EagerCollection<K, V>;
 
   /**
    * Create a new eager collection by keeping the given number of the first elements.

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -217,20 +217,10 @@ const sizeService: SkipService<Input_NN_NN, Input_NN_NN> = {
 class SlicedMap1Resource implements Resource<Input_NN> {
   instantiate(cs: Input_NN): EagerCollection<number, number> {
     return cs.input
-      .slice([
-        [1, 1],
-        [3, 4],
-        [7, 9],
-        [20, 50],
-        [42, 1337],
-      ])
+      .slice([1, 1], [3, 4], [7, 9], [20, 50], [42, 1337])
       .map(SquareValues)
       .take(7)
-      .slice([
-        [0, 7],
-        [8, 15],
-        [19, 2000],
-      ]);
+      .slice([0, 7], [8, 15], [19, 2000]);
   }
 }
 

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -942,7 +942,7 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     );
   };
 
-  slice(ranges: [K, K][]): EagerCollection<K, V> {
+  slice(...ranges: [K, K][]): EagerCollection<K, V> {
     const skcollection = this.refs.fromWasm.SkipRuntime_Collection__slice(
       this.refs.skjson.exportString(this.collection),
       this.refs.skjson.exportJSON(ranges),


### PR DESCRIPTION
Pretty small change, but I noticed while writing out some examples that this could be made a bit lighter-weight syntactically, particularly noticeable when you're slicing out one range, i.e. `foo.slice([x, y])` instead of `foo.slice([[x, y]])`