### PR TITLE
[ts] Update version of config packages to match published version.

### DIFF
--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplabs/eslint-config",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Shared ESLint configuration for SkipLabs packages.",
   "main": "src/eslint.config.js",
   "type": "module",

--- a/examples/hackernews/back-end/reactive_service/package.json
+++ b/examples/hackernews/back-end/reactive_service/package.json
@@ -14,6 +14,6 @@
     "@skipruntime/server": "^0.0.1"
   },
   "devDependencies": {
-    "@skiplabs/eslint-config": "^1.0.0"
+    "@skiplabs/eslint-config": "^0.0.1"
   }
 }

--- a/examples/hackernews/front-end/package.json
+++ b/examples/hackernews/front-end/package.json
@@ -22,7 +22,7 @@
     "typescript": "^5.6.3",
     "vite": "^5.4.9",
     "eslint": "^9.14.0",
-    "@skiplabs/eslint-config": "^1.0.0",
+    "@skiplabs/eslint-config": "^0.0.1",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.12"
   }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   ],
   "devDependencies": {
     "@types/node": "^22.6.0",
-    "@skiplabs/eslint-config": "^1.0.0",
-    "@skiplabs/tsconfig": "^1.0.0",
+    "@skiplabs/eslint-config": "^0.0.1",
+    "@skiplabs/tsconfig": "^0.0.1",
     "eslint": "9.14.0",
     "prettier": "^3.3.3",
     "typescript": "^5.6.2"

--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplabs/tsconfig",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Shared tsconfig.json config for SkipLabs packages.",
   "author": "SkipLabs",
   "license": "MIT",


### PR DESCRIPTION
The `@skiplabs/tsconfig` and `@skiplabs/eslint-config` packages are now published on npmjs.com at version `0.0.1`.