### PR TITLE
Clone object proxies in mapper/resource params

### DIFF
--- a/skiplang/skjson/ts/src/skjson.ts
+++ b/skiplang/skjson/ts/src/skjson.ts
@@ -151,7 +151,9 @@ type ObjectProxy<Base extends { [k: string]: Exportable }> = {
   keys: IterableIterator<keyof Base>;
 } & Base;
 
-function isObjectProxy(x: any): x is ObjectProxy<{ [k: string]: Exportable }> {
+export function isObjectProxy(
+  x: any,
+): x is ObjectProxy<{ [k: string]: Exportable }> {
   return sk_isObjectProxy in x && (x[sk_isObjectProxy] as boolean);
 }
 

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -37,6 +37,7 @@ import { NonUniqueValueException } from "@skipruntime/api";
 import { Frozen, type Constant } from "@skipruntime/api/internals.js";
 
 import type { Exportable, SKJSON } from "@skip-wasm/json";
+import { isObjectProxy } from "@skip-wasm/json";
 import { UnknownCollectionError } from "@skipruntime/helpers/errors.js";
 
 export type Handle<T> = Internal.Opaque<int, { handle_for: T }>;
@@ -64,22 +65,20 @@ abstract class SkFrozen extends Frozen {
   }
 }
 
-export function check<T>(value: T): void {
+function checkOrCloneParam<T>(value: T): T {
   if (
     typeof value == "string" ||
     typeof value == "number" ||
     typeof value == "boolean"
-  ) {
-    return;
-  } else if (typeof value == "object") {
-    if (value === null || isSkFrozen(value)) {
-      return;
-    } else {
-      throw new Error("Invalid object: must be deep-frozen.");
-    }
-  } else {
-    throw new Error(`'${typeof value}' cannot be deep-frozen.`);
+  )
+    return value;
+  if (typeof value == "object") {
+    if (value === null) return value;
+    if (isObjectProxy(value)) return value.clone() as T;
+    if (isSkFrozen(value)) return value;
+    throw new Error("Invalid object: must be deep-frozen.");
   }
+  throw new Error(`'${typeof value}' cannot be deep-frozen.`);
 }
 
 /**
@@ -985,8 +984,8 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     mapper: new (...params: Params) => Mapper<K, V, K2, V2>,
     ...params: Params
   ): EagerCollection<K2, V2> {
-    params.forEach(check);
-    const mapperObj = new mapper(...params);
+    const mapperParams = params.map(checkOrCloneParam) as Params;
+    const mapperObj = new mapper(...mapperParams);
     Object.freeze(mapperObj);
     if (!mapperObj.constructor.name) {
       throw new Error("Mapper classes must be defined at top-level.");
@@ -1011,8 +1010,8 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     reducer: Reducer<V2, V3>,
     ...params: Params
   ) {
-    params.forEach(check);
-    const mapperObj = new mapper(...params);
+    const mapperParams = params.map(checkOrCloneParam) as Params;
+    const mapperObj = new mapper(...mapperParams);
     Object.freeze(mapperObj);
     if (!mapperObj.constructor.name) {
       throw new Error("Mapper classes must be defined at top-level.");
@@ -1116,8 +1115,8 @@ class ContextImpl extends SkFrozen implements Context {
     compute: new (...params: Params) => LazyCompute<K, V>,
     ...params: Params
   ): LazyCollection<K, V> {
-    params.forEach(check);
-    const computeObj = new compute(...params);
+    const mapperParams = params.map(checkOrCloneParam) as Params;
+    const computeObj = new compute(...mapperParams);
     Object.freeze(computeObj);
     if (!computeObj.constructor.name) {
       throw new Error("LazyCompute classes must be defined at top-level.");


### PR DESCRIPTION
This was causing some issues in one of my examples, as pointers copied over through proxy objects were outliving the actual object in the skip heap. Thanks Daniel for the help debugging!
