### PR TITLE
Eagerly interpret arrays (instead of proxying)

### DIFF
--- a/skiplang/prelude/ts/src/sk_types.ts
+++ b/skiplang/prelude/ts/src/sk_types.ts
@@ -928,15 +928,14 @@ export async function run(
   return await start(modules, buffer, env, main);
 }
 
-export const sk_isArrayProxy: unique symbol = Symbol();
 export const sk_isObjectProxy: unique symbol = Symbol();
 
 export function cloneIfProxy<T>(v: T): T {
   if (
     v !== null &&
     typeof v === "object" &&
-    ((sk_isArrayProxy in v && v[sk_isArrayProxy]) ||
-      (sk_isObjectProxy in v && v[sk_isObjectProxy])) &&
+    sk_isObjectProxy in v &&
+    v[sk_isObjectProxy] &&
     "clone" in v
   ) {
     return (v.clone as () => T)();


### PR DESCRIPTION
Get rid of ArrayProxy and eagerly interpret array contents into a plain-old-javascript-array