### PR TITLE
[skip/server] Return raw UUIDs for `POST /streams`.

### DIFF
--- a/examples/hackernews/web_service/app.py
+++ b/examples/hackernews/web_service/app.py
@@ -54,7 +54,7 @@ def posts_index():
                 }
             },
         )
-        uuid = resp.json()
+        uuid = resp.text
 
         return redirect(f"/streams/{uuid}", code=307)
 

--- a/skipruntime-ts/helpers/src/remote.ts
+++ b/skipruntime-ts/helpers/src/remote.ts
@@ -51,7 +51,7 @@ export class SkipExternalService implements ExternalService {
         params,
       }),
     })
-      .then((resp) => resp.json())
+      .then((resp) => resp.text())
       .then((uuid) => {
         const evSource = new EventSource(`${this.url}/v1/streams/${uuid}`);
         evSource.addEventListener("init", (e: MessageEvent<string>) => {

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -112,6 +112,6 @@ export class RESTWrapperOfSkipService {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ resource, params }),
-    }).then((res) => res.json() as Promise<string>);
+    }).then((res) => res.text());
   }
 }

--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -15,7 +15,7 @@ export function controlService(service: ServiceInstance): express.Express {
         req.body.resource as string,
         req.body.params as { [param: string]: string },
       );
-      res.status(201).json(uuid);
+      res.status(201).send(uuid);
     } catch (e: unknown) {
       console.log(e);
       res.status(500).json(e instanceof Error ? e.message : e);


### PR DESCRIPTION
This endpoint previously responded with a JSON-encoded string (i.e. including quotes).