### PR TITLE
Change EagerCollection `slice` behavior to match JS `Array.prototype.slice`

### DIFF
--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -217,9 +217,13 @@ export interface EagerCollection<K extends Json, V extends Json>
 
   /**
    * Create a new eager collection by keeping only the elements whose keys are in
-   * the given ranges.
+   * the given range.
    */
-  slice(...ranges: [K, K][]): EagerCollection<K, V>;
+  slice(start: K, end: K): EagerCollection<K, V>;
+  /**
+   * Same as `slice`, but accepts multiple ranges.
+   */
+  slices(...ranges: [K, K][]): EagerCollection<K, V>;
 
   /**
    * Create a new eager collection by keeping the given number of the first elements.

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -211,10 +211,11 @@ const sizeService: SkipService<Input_NN_NN, Input_NN_NN> = {
 class SlicedMap1Resource implements Resource<Input_NN> {
   instantiate(cs: Input_NN): EagerCollection<number, number> {
     return cs.input
-      .slice([1, 1], [3, 4], [7, 9], [20, 50], [42, 1337])
+      .slices([1, 1], [3, 4], [7, 9], [20, 50], [42, 1337])
       .map(SquareValues)
       .take(7)
-      .slice([0, 7], [8, 15], [19, 2000]);
+      .slices([0, 7], [8, 15], [19, 2000])
+      .slice(0, 2000);
   }
 }
 

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -963,7 +963,11 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     );
   };
 
-  slice(...ranges: [K, K][]): EagerCollection<K, V> {
+  slice(start: K, end: K): EagerCollection<K, V> {
+    return this.slices([start, end]);
+  }
+
+  slices(...ranges: [K, K][]): EagerCollection<K, V> {
     const skcollection = this.refs.fromWasm.SkipRuntime_Collection__slice(
       this.refs.skjson.exportString(this.collection),
       this.refs.skjson.exportJSON(ranges),


### PR DESCRIPTION
Julien mentioned running into some user confusion on this, so this renames our previous `slice` (which offered general skstore power of multiple key ranges) to `slices` and gives `slice` the simpler semantics of JS arrays' `slice` method.