### PR TITLE
Restrict `Resource` output to string-keyed collections

### DIFF
--- a/examples/hackernews/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/reactive_service/src/hackernews.service.ts
@@ -86,11 +86,11 @@ class SortingMapper {
   mapEntry(
     key: number,
     values: NonEmptyIterator<Upvoted>,
-  ): Iterable<[number, Upvoted]> {
+  ): Iterable<[string, Upvoted]> {
     const posts = values.toArray();
     // Sorting in descending order of upvotes.
     posts.sort((a, b) => b.upvotes - a.upvotes);
-    return posts.map((p) => [key, p]);
+    return posts.map((p) => [key.toString(), p]);
   }
 }
 
@@ -101,7 +101,7 @@ class PostsResource implements Resource<ResourceInputs> {
     this.limit = Number(params["limit"]);
   }
 
-  instantiate(collections: ResourceInputs): EagerCollection<number, Upvoted> {
+  instantiate(collections: ResourceInputs): EagerCollection<string, Upvoted> {
     return collections.postsWithUpvotes.take(this.limit).map(SortingMapper);
   }
 }

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -364,7 +364,7 @@ export interface Resource<
   instantiate(
     collections: Collections,
     context: Context,
-  ): EagerCollection<Json, Json>;
+  ): EagerCollection<string, Json>;
 }
 
 // Initial data for services' initial collections are provided as an object with arrays of

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -23,7 +23,7 @@ class DeparturesResource implements Resource<ResourceInputs> {
   instantiate(
     cs: ResourceInputs,
     context: Context,
-  ): EagerCollection<number, Departure> {
+  ): EagerCollection<string, Departure> {
     const get = (name: string, def: string) => {
       try {
         return cs.config.getUnique(name).join(",");
@@ -58,7 +58,7 @@ const service = await runService(
         departuresFromAPI: new Polled(
           "https://api.unhcr.org/rsq/v1/departures",
           10000,
-          (data: Result) => data.results.map((v, idx) => [idx, [v]]),
+          (data: Result) => data.results.map((v, idx) => [idx.toString(), [v]]),
         ),
       }),
     },


### PR DESCRIPTION
The default REST server implementation passes HTTP path parameters straight through to Skip, which caused me a bit of confusion when resources have non-string keys.

We may avoid putting key parameters straight into the path in the future, but for now this prevents the confusion I ran into (i.e. requesting a path like `/users/1` and getting nothing because the user is keyed on the number `1` and not the string `"1"`) 