### PR TITLE
[skipruntime] Fix packages usage version

### DIFF
--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -15,6 +15,6 @@
   },
   "dependencies": {
     "express": "^4.21.0",
-    "skip-wasm": "^0.0.3"
+    "skip-wasm": "^0.0.4"
   }
 }

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.8",
-    "@skipruntime/tests": "^0.0.3",
+    "@skipruntime/tests": "^0.0.4",
     "mocha": "^10.7.3"
   },
   "dependencies": {


### PR DESCRIPTION
Packages version need to correspond to the project ones to work with npm project management mechanism.