### PR TITLE
Rename RESTWrapperOfSkipService to SkipServiceBroker and document it

### DIFF
--- a/skipruntime-ts/examples/database-server.ts
+++ b/skipruntime-ts/examples/database-server.ts
@@ -1,4 +1,4 @@
-import { RESTWrapperOfSkipService } from "@skipruntime/helpers";
+import { SkipServiceBroker } from "@skipruntime/helpers";
 
 import express from "express";
 
@@ -6,7 +6,7 @@ import express from "express";
   This is the user facing server of the database example
 */
 
-const service = new RESTWrapperOfSkipService({
+const service = new SkipServiceBroker({
   host: "localhost",
   control_port: 8081,
   streaming_port: 8080,

--- a/skipruntime-ts/examples/groups-server.ts
+++ b/skipruntime-ts/examples/groups-server.ts
@@ -1,8 +1,8 @@
-import { RESTWrapperOfSkipService } from "@skipruntime/helpers/rest.js";
+import { SkipServiceBroker } from "@skipruntime/helpers/rest.js";
 
 import express from "express";
 
-const service = new RESTWrapperOfSkipService({
+const service = new SkipServiceBroker({
   host: "localhost",
   control_port: 8081,
   streaming_port: 8080,

--- a/skipruntime-ts/examples/utils.ts
+++ b/skipruntime-ts/examples/utils.ts
@@ -2,7 +2,7 @@
 // in nodejs LTS.
 import EventSource from "eventsource";
 import type { Json, Entry } from "@skipruntime/api";
-import { RESTWrapperOfSkipService } from "@skipruntime/helpers";
+import { SkipServiceBroker } from "@skipruntime/helpers";
 import { createInterface } from "readline";
 
 export interface ClientDefinition {
@@ -21,13 +21,13 @@ interface Delete {
 }
 
 export class SkipHttpAccessV1 {
-  private service: RESTWrapperOfSkipService;
+  private service: SkipServiceBroker;
 
   constructor(
     private streaming_port: number = 8080,
     control_port: number = 8081,
   ) {
-    this.service = new RESTWrapperOfSkipService({
+    this.service = new SkipServiceBroker({
       host: "localhost",
       control_port,
       streaming_port,

--- a/skipruntime-ts/helpers/src/index.ts
+++ b/skipruntime-ts/helpers/src/index.ts
@@ -5,4 +5,4 @@ export {
   Polled,
 } from "./external.js";
 export { Sum, Min, Max, CountMapper } from "./utils.js";
-export { fetchJSON, RESTWrapperOfSkipService } from "./rest.js";
+export { fetchJSON, SkipServiceBroker } from "./rest.js";

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -41,7 +41,7 @@ export async function fetchJSON<V>(
   return [responseJSON, response.headers];
 }
 
-export class RESTWrapperOfSkipService {
+export class SkipServiceBroker {
   private entrypoint: string;
 
   constructor(

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -41,9 +41,20 @@ export async function fetchJSON<V>(
   return [responseJSON, response.headers];
 }
 
+/**
+ * Wrapper providing a method-call interface to the Skip service HTTP APIs.
+ *
+ * Skip services, as started by `runService`, support an HTTP interface for reading from resources and writing to input collections.
+ * `SkipServiceBroker` provides a method-call interface to the backing HTTP interface.
+ */
 export class SkipServiceBroker {
   private entrypoint: string;
 
+  /**
+   * Construct a broker for a Skip service at the given entry point.
+   * @param entrypoint - entry point of backing service
+   * @returns - method-call broker to service
+   */
   constructor(
     entrypoint: Entrypoint = {
       host: "localhost",
@@ -54,6 +65,13 @@ export class SkipServiceBroker {
     this.entrypoint = toHttp(entrypoint);
   }
 
+  /**
+   * Read the entire contents of a resource.
+   *
+   * @param resource - name of resource, must be a key of the `resources` field of the `SkipService` running at `entrypoint`
+   * @param params - resource instance parameters
+   * @returns - all entries in resource
+   */
   async getAll<K extends Json, V extends Json>(
     resource: string,
     params: { [param: string]: string },
@@ -67,6 +85,13 @@ export class SkipServiceBroker {
     return values;
   }
 
+  /**
+   * Read the values a resource associates with a single key.
+   * @param resource - name of resource, must be a key of the `resources` field of the `SkipService` running at `entrypoint`
+   * @param params - resource instance parameters
+   * @param key - key to read
+   * @returns - the values associated to the key
+   */
   async getArray<V extends Json>(
     resource: string,
     params: { [param: string]: string },
@@ -80,30 +105,55 @@ export class SkipServiceBroker {
     return data ?? [];
   }
 
+  /**
+   * Write the values for a single key in a collection.
+   * @param collection - name of the input collection to update, must be a key of the `Inputs` type parameter of the `SkipService` running at `entrypoint`
+   * @param key - key of entry to write
+   * @param values - values of entry to write
+   * @returns {void}
+   */
   async put<K extends Json, V extends Json>(
     collection: string,
     key: K,
-    value: V[],
+    values: V[],
   ): Promise<void> {
-    return await this.patch(collection, [[key, value]]);
+    return await this.patch(collection, [[key, values]]);
   }
 
+  /**
+   * Write multiple entries to a collection.
+   * @param collection - name of the input collection to update, must be a key of the `Inputs` type parameter of the `SkipService` running at `entrypoint`
+   * @param entries - entries to write
+   * @returns {void}
+   */
   async patch<K extends Json, V extends Json>(
     collection: string,
-    values: Entry<K, V>[],
+    entries: Entry<K, V>[],
   ): Promise<void> {
     await fetchJSON(
       `${this.entrypoint}/v1/inputs/${collection}`,
       "PATCH",
       {},
-      values,
+      entries,
     );
   }
 
+  /**
+   * Remove all values associated with a key in a collection.
+   * @param collection - name of the input collection to update, must be a key of the `Inputs` type parameter of the `SkipService` running at `entrypoint`
+   * @param key - key of entry to delete
+   * @returns {void}
+   */
   async deleteKey<K extends Json>(collection: string, key: K): Promise<void> {
     return await this.patch(collection, [[key, []]]);
   }
 
+  /**
+   * Create a resource instance UUID.
+   * @param resource - name of resource, must be a key of the `resources` field of the `SkipService` running at `entrypoint`
+   * @param params - resource instance parameters
+   * @returns - UUID that can be used to subscribe to updates to resource instance
+   */
   async getStreamUUID(
     resource: string,
     params: { [param: string]: string } = {},
@@ -115,6 +165,11 @@ export class SkipServiceBroker {
     }).then((res) => res.text());
   }
 
+  /**
+   * Destroy a resource instance.
+   * @param uuid - resource instance UUID
+   * @returns {void}
+   */
   async deleteUUID(uuid: string): Promise<void> {
     await fetchJSON(`${this.entrypoint}/v1/streams/${uuid}`, "DELETE");
   }

--- a/skipruntime-ts/wasm/src/skip-runtime.ts
+++ b/skipruntime-ts/wasm/src/skip-runtime.ts
@@ -38,6 +38,6 @@ export {
 
 export {
   fetchJSON,
-  RESTWrapperOfSkipService,
+  SkipServiceBroker,
   type Entrypoint,
 } from "@skipruntime/helpers/rest.js";


### PR DESCRIPTION
- Rename RESTWrapperOfSkipService to SkipServiceBroker

This class provides methods that mirror and have thin implementations over
the skip service HTTP interface. This class is providing a method-call
interface for the HTTP interface. In this context, the term "broker" seems
more appropriate and clear.

- Document SkipServiceBroker