### PR TITLE
Revert "Add streamURL helper function (#537)"

### DIFF
--- a/skipruntime-ts/examples/database-server.ts
+++ b/skipruntime-ts/examples/database-server.ts
@@ -41,7 +41,7 @@ app.get("/users", (_req, res) => {
   service
     .getStreamUUID("users")
     .then((uuid) => {
-      res.redirect(301, service.streamURL(uuid));
+      res.redirect(301, `http://localhost:8080/v1/streams/${uuid}`);
     })
     .catch((e: unknown) => {
       console.log(e);

--- a/skipruntime-ts/examples/groups-server.ts
+++ b/skipruntime-ts/examples/groups-server.ts
@@ -16,7 +16,7 @@ app.get("/active_friends/:uid", (req, res) => {
   service
     .getStreamUUID("active_friends", { uid: req.params.uid })
     .then((uuid) => {
-      res.redirect(301, service.streamURL(uuid));
+      res.redirect(301, `http://localhost:8080/v1/streams/${uuid}`);
     })
     .catch((e: unknown) => {
       res.status(500).json(e);

--- a/skipruntime-ts/examples/utils.ts
+++ b/skipruntime-ts/examples/utils.ts
@@ -23,7 +23,10 @@ interface Delete {
 export class SkipHttpAccessV1 {
   private service: RESTWrapperOfSkipService;
 
-  constructor(streaming_port: number = 8080, control_port: number = 8081) {
+  constructor(
+    private streaming_port: number = 8080,
+    control_port: number = 8081,
+  ) {
     this.service = new RESTWrapperOfSkipService({
       host: "localhost",
       control_port,
@@ -63,7 +66,9 @@ export class SkipHttpAccessV1 {
     this.service
       .getStreamUUID(resource, params)
       .then((uuid) => {
-        const evSource = new EventSource(this.service.streamURL(uuid));
+        const evSource = new EventSource(
+          `http://localhost:${this.streaming_port}/v1/streams/${uuid}`,
+        );
         evSource.addEventListener("init", (e: MessageEvent<string>) => {
           const updates = JSON.parse(e.data);
           console.log("Init", updates);

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -42,16 +42,16 @@ export async function fetchJSON<V>(
 }
 
 export class RESTWrapperOfSkipService {
-  private controlUrl: string;
+  private entrypoint: string;
 
   constructor(
-    private entrypoint: Entrypoint = {
+    entrypoint: Entrypoint = {
       host: "localhost",
       streaming_port: 8080,
       control_port: 8081,
     },
   ) {
-    this.controlUrl = toHttp(entrypoint);
+    this.entrypoint = toHttp(entrypoint);
   }
 
   async getAll<K extends Json, V extends Json>(
@@ -59,11 +59,12 @@ export class RESTWrapperOfSkipService {
     params: { [param: string]: string },
   ): Promise<Entry<K, V>[]> {
     const qParams = new URLSearchParams(params).toString();
-    const [data, _headers] = await fetchJSON<Entry<K, V>[]>(
-      `${this.controlUrl}/v1/resources/${resource}?${qParams}`,
+    const [optValues, _headers] = await fetchJSON<Entry<K, V>[]>(
+      `${this.entrypoint}/v1/resources/${resource}?${qParams}`,
       "GET",
     );
-    return data ?? [];
+    const values = optValues ?? [];
+    return values;
   }
 
   async getArray<V extends Json>(
@@ -73,7 +74,7 @@ export class RESTWrapperOfSkipService {
   ): Promise<V[]> {
     const qParams = new URLSearchParams(params).toString();
     const [data, _headers] = await fetchJSON<V[]>(
-      `${this.controlUrl}/v1/resources/${resource}/${key}?${qParams}`,
+      `${this.entrypoint}/v1/resources/${resource}/${key}?${qParams}`,
       "GET",
     );
     return data ?? [];
@@ -92,7 +93,7 @@ export class RESTWrapperOfSkipService {
     values: Entry<K, V>[],
   ): Promise<void> {
     await fetchJSON(
-      `${this.controlUrl}/v1/inputs/${collection}`,
+      `${this.entrypoint}/v1/inputs/${collection}`,
       "PATCH",
       {},
       values,
@@ -107,7 +108,7 @@ export class RESTWrapperOfSkipService {
     resource: string,
     params: { [param: string]: string } = {},
   ): Promise<string> {
-    return fetch(`${this.controlUrl}/v1/streams`, {
+    return fetch(`${this.entrypoint}/v1/streams`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ resource, params }),
@@ -115,12 +116,6 @@ export class RESTWrapperOfSkipService {
   }
 
   async deleteUUID(uuid: string): Promise<void> {
-    await fetchJSON(`${this.controlUrl}/v1/streams/${uuid}`, "DELETE");
-  }
-
-  streamURL(uuid: string): string {
-    const host = this.entrypoint.host;
-    const port = this.entrypoint.streaming_port;
-    return `http://${host}:${port}/v1/streams/${uuid}`;
+    await fetchJSON(`${this.entrypoint}/v1/streams/${uuid}`, "DELETE");
   }
 }


### PR DESCRIPTION
In expected usage, the reactive service will not know its own public URL, so
this function does not make sense.

This reverts commit 0f0bd4dcc8f803b23d8c51e9d936e3849c5f730b.