### PR TITLE
Tighten type in http get key implementation

### DIFF
--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -40,7 +40,7 @@ export function controlService(service: ServiceInstance): express.Express {
         req.params.key,
         req.query as { [param: string]: string },
         {
-          resolve: (data: Json) => {
+          resolve: (data: Json[]) => {
             res.status(200).json(data);
           },
           reject: (err: unknown) => {


### PR DESCRIPTION
Noticed while documenting, the data returned by ServiceInstance.getArray
will be an array of Json values.