### PR TITLE
Make `resources` field non-optional on SkipService

### DIFF
--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -388,7 +388,7 @@ export interface SkipService<
   /** The external service dependencies of the service */
   externalServices?: { [name: string]: ExternalService };
   /** The reactive resources which compose the public interface of this reactive service */
-  resources?: {
+  resources: {
     [name: string]: new (params: {
       [param: string]: string;
     }) => Resource<ResourceInputs>;

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -891,17 +891,15 @@ class LinksImpl implements Links {
       }
       const skresources =
         this.fromWasm.SkipRuntime_ResourceBuilderMap__create();
-      if (service.resources) {
-        for (const [name, builder] of Object.entries(service.resources)) {
-          const skbuilder = this.fromWasm.SkipRuntime_createResourceBuilder(
-            this.handles.register(new ResourceBuilder(builder)),
-          );
-          this.fromWasm.SkipRuntime_ResourceBuilderMap__add(
-            skresources,
-            skjson.exportString(name),
-            skbuilder,
-          );
-        }
+      for (const [name, builder] of Object.entries(service.resources)) {
+        const skbuilder = this.fromWasm.SkipRuntime_createResourceBuilder(
+          this.handles.register(new ResourceBuilder(builder)),
+        );
+        this.fromWasm.SkipRuntime_ResourceBuilderMap__add(
+          skresources,
+          skjson.exportString(name),
+          skbuilder,
+        );
       }
       const skservice = this.fromWasm.SkipRuntime_createService(
         this.handles.register(service),


### PR DESCRIPTION
As it says on the tin.

I noticed this while writing up resource/service docs, and couldn't think of any case where it makes sense to have a service with no output resources.  Nor does any such case exist in our examples.