### PR TITLE
[skipruntime-ts] Take control over reducer instantiation to avoid capturing/side effects

### DIFF
--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -207,13 +207,32 @@ export interface EagerCollection<K extends Json, V extends Json>
   mapReduce<
     K2 extends Json,
     V2 extends Json,
-    Acc extends Json,
-    Params extends Param[],
+    Accum extends Json,
+    MapperParams extends Param[],
+    ReducerParams extends Param[],
   >(
-    mapper: new (...params: Params) => Mapper<K, V, K2, V2>,
-    reducer: Reducer<V2, Acc>,
-    ...params: Params
-  ): EagerCollection<K2, Acc>;
+    mapper: new (...params: MapperParams) => Mapper<K, V, K2, V2>,
+    reducer: new (...params: ReducerParams) => Reducer<V2, Accum>,
+    mapperParams: MapperParams,
+    reducerParams: ReducerParams,
+  ): EagerCollection<K2, Accum>;
+
+  // Type overloads for `mapReduce`, allowing callers to not pass mapper/reducer parameters
+  // when the mapper/reducer take no parameters
+  mapReduce<
+    K2 extends Json,
+    V2 extends Json,
+    Accum extends Json,
+    MapperParams extends Param[],
+  >(
+    mapper: new (...params: MapperParams) => Mapper<K, V, K2, V2>,
+    reducer: new () => Reducer<V2, Accum>,
+    mapperParams: MapperParams,
+  ): EagerCollection<K2, Accum>;
+  mapReduce<K2 extends Json, V2 extends Json, Accum extends Json>(
+    mapper: new () => Mapper<K, V, K2, V2>,
+    reducer: new () => Reducer<V2, Accum>,
+  ): EagerCollection<K2, Accum>;
 
   /**
    * Create a new eager collection by keeping only the elements whose keys are in

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -199,40 +199,23 @@ export interface EagerCollection<K extends Json, V extends Json>
 
   /**
    * Create a new eager reactive collection by mapping some computation `mapper` over this
-   * one and then reducing the results with `reducer`
+   * one and then reducing the results with `reducer`.
+   * Note that this function is _curried_ so that mapper and reducer rest parameters can be
+   * provided separately, e.g. as `mapReduce(MyMapper, foo, bar)(MyReducer, baz)`
    * @param mapper - function to apply to each element of this collection
-   * @param reducer - function to combine results of the `mapper`
-   * @returns An eager collection containing the output of the reducer
+   * @param mapperParams - parameters to the mapper constructor
+   * @returns A function which takes a `reducer` and corresponding parameters and returns the
+   * resulting eager collection of reduced values.
+   * `reducer` - function to combine results of the `mapper`
+   * `reducerParams` - parameters to the reducer constructor
    */
-  mapReduce<
-    K2 extends Json,
-    V2 extends Json,
-    Accum extends Json,
-    MapperParams extends Param[],
-    ReducerParams extends Param[],
-  >(
+  mapReduce<K2 extends Json, V2 extends Json, MapperParams extends Param[]>(
     mapper: new (...params: MapperParams) => Mapper<K, V, K2, V2>,
+    ...mapperParams: MapperParams
+  ): <Accum extends Json, ReducerParams extends Param[]>(
     reducer: new (...params: ReducerParams) => Reducer<V2, Accum>,
-    mapperParams: MapperParams,
-    reducerParams: ReducerParams,
-  ): EagerCollection<K2, Accum>;
-
-  // Type overloads for `mapReduce`, allowing callers to not pass mapper/reducer parameters
-  // when the mapper/reducer take no parameters
-  mapReduce<
-    K2 extends Json,
-    V2 extends Json,
-    Accum extends Json,
-    MapperParams extends Param[],
-  >(
-    mapper: new (...params: MapperParams) => Mapper<K, V, K2, V2>,
-    reducer: new () => Reducer<V2, Accum>,
-    mapperParams: MapperParams,
-  ): EagerCollection<K2, Accum>;
-  mapReduce<K2 extends Json, V2 extends Json, Accum extends Json>(
-    mapper: new () => Mapper<K, V, K2, V2>,
-    reducer: new () => Reducer<V2, Accum>,
-  ): EagerCollection<K2, Accum>;
+    ...reducerParams: ReducerParams
+  ) => EagerCollection<K2, Accum>;
 
   /**
    * Create a new eager collection by keeping only the elements whose keys are in

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -281,7 +281,7 @@ class TestOddEven implements Mapper<number, number, number, number> {
 
 class MapReduceResource implements Resource<Input_NN> {
   instantiate(cs: Input_NN): EagerCollection<number, number> {
-    return cs.input.mapReduce(TestOddEven, Sum);
+    return cs.input.mapReduce(TestOddEven)(Sum);
   }
 }
 
@@ -332,7 +332,7 @@ class OffsetMapper extends OneToOneMapper<number, number, number> {
 
 class MergeReduceResource implements Resource<Input_NN_NN> {
   instantiate(cs: Input_NN_NN): EagerCollection<number, number> {
-    return cs.input1.merge(cs.input2).mapReduce(OffsetMapper, Sum, [5]);
+    return cs.input1.merge(cs.input2).mapReduce(OffsetMapper, 5)(Sum);
   }
 }
 

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -281,7 +281,7 @@ class TestOddEven implements Mapper<number, number, number, number> {
 
 class MapReduceResource implements Resource<Input_NN> {
   instantiate(cs: Input_NN): EagerCollection<number, number> {
-    return cs.input.mapReduce(TestOddEven, new Sum());
+    return cs.input.mapReduce(TestOddEven, Sum);
   }
 }
 
@@ -320,15 +320,19 @@ function sorted(entries: Entry<Json, Json>[]): Entry<Json, Json>[] {
 
 //// testMergeReduce
 
-class IdentityMapper extends OneToOneMapper<number, number, number> {
+class OffsetMapper extends OneToOneMapper<number, number, number> {
+  constructor(private offset: number) {
+    super();
+  }
+
   mapValue(v: number) {
-    return v;
+    return v + this.offset;
   }
 }
 
 class MergeReduceResource implements Resource<Input_NN_NN> {
   instantiate(cs: Input_NN_NN): EagerCollection<number, number> {
-    return cs.input1.merge(cs.input2).mapReduce(IdentityMapper, new Sum());
+    return cs.input1.merge(cs.input2).mapReduce(OffsetMapper, Sum, [5]);
   }
 }
 
@@ -706,17 +710,17 @@ export function initTests(
     const resource = "mergeReduce";
     service.update("input1", [[1, [10]]]);
     service.update("input2", [[1, [20]]]);
-    expect(service.getAll(resource).payload).toEqual([[1, [30]]]);
+    expect(service.getAll(resource).payload).toEqual([[1, [40]]]);
     service.update("input1", [[2, [3]]]);
     service.update("input2", [[2, [7]]]);
     expect(service.getAll(resource).payload).toEqual([
-      [1, [30]],
-      [2, [10]],
+      [1, [40]],
+      [2, [20]],
     ]);
     service.update("input1", [[1, []]]);
     expect(service.getAll(resource).payload).toEqual([
-      [1, [20]],
-      [2, [10]],
+      [1, [25]],
+      [2, [20]],
     ]);
   });
 


### PR DESCRIPTION
It came up in conversation today that reducers ought to be instantiated under skipruntime control like mappers, to prevent accidental capture of mutable state or other side effects in reducers. (users may be particularly likely to capture state there, instead of implementing the purely-functional fold using the accumulator arguments) So, this PR does just that.

The main interesting bit is what to do about the two variable-sized parameter lists (i.e. params to the mapper constructor and the reducer constructor).  The obvious thing to do is to have mapReduce take two explicit arrays which default to empty
`(mapper: new(...mapperParams)=>Mapper<...>, reducer: new(...reducerParams)=>Reducer<...>, mapperParams: MapperParams = [], reducerParams: ReducerParams = [])` but that (rightly) doesn't typecheck, since it would allow to elide params even when MapperParams/ReducerParams are non-empty.  So, we can use overloads to only allow eliding those parameters when the respective constructors take no arguments. But, that's a bit clunky, and leads to the same problem in `map`/`createLazyCollection` if we also take array arguments there for consistency's sake.

Long-winded way of saying: I decided to just curry `mapReduce` so that it can splat out arguments to its mapper and reducer separately.  Seems a nice clean interface to me, but open to other suggestions!



