### PR TITLE
Add OneToManyMapper and tweak groups example to use it

### DIFF
--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -74,6 +74,31 @@ export abstract class OneToOneMapper<
 }
 
 /**
+ * A specialized form of `Mapper` which maps values one-to-many, reusing the
+ * input collection's key structure in the output collection. Use this form
+ * to map each value associated with a key to any number of values for that
+ * same key. This saves some boilerplate: instead of writing the fully
+ * general `mapEntry` that potentially modifies, adds, or removes keys,
+ * just implement the simpler `mapValue` to transform the values associated
+ * with each key.
+ */
+export abstract class OneToManyMapper<
+  K extends Json,
+  V1 extends Json,
+  V2 extends Json,
+> implements Mapper<K, V1, K, V2>
+{
+  abstract mapValue(value: V1, key: K): V2[];
+
+  mapEntry(key: K, values: NonEmptyIterator<V1>): Iterable<[K, V2]> {
+    const res: [K, V2][] = [];
+    for (const v1 of values)
+      for (const v2 of this.mapValue(v1, key)) res.push([key, v2]);
+    return res;
+  }
+}
+
+/**
  * A specialized form of `Mapper` which maps values many-to-one, reusing the
  * input collection's key structure in the output collection. Use this form
  * to map all the values associated with a key to a single output value for

--- a/skipruntime-ts/examples/groups.ts
+++ b/skipruntime-ts/examples/groups.ts
@@ -1,9 +1,8 @@
-import type {
-  EagerCollection,
-  InitialData,
-  Mapper,
-  NonEmptyIterator,
-  Resource,
+import {
+  type EagerCollection,
+  type InitialData,
+  type Resource,
+  OneToOneMapper,
 } from "@skipruntime/api";
 
 import { runService } from "@skipruntime/server";
@@ -36,37 +35,28 @@ type ServiceInputs = {
 // Type alias for inputs to the active friends resource
 type ResourceInputs = {
   users: EagerCollection<UserID, User>;
-  actives: EagerCollection<GroupID, UserID>;
+  actives: EagerCollection<GroupID, UserID[]>;
 };
 
 // Mapper function to compute the active users of each group
-class ActiveUsers implements Mapper<GroupID, Group, GroupID, UserID> {
-  constructor(private users: EagerCollection<UserID, User>) {}
+class ActiveUsers extends OneToOneMapper<GroupID, Group, UserID[]> {
+  constructor(private users: EagerCollection<UserID, User>) {
+    super();
+  }
 
-  mapEntry(
-    gid: GroupID,
-    group: NonEmptyIterator<Group>,
-  ): Iterable<[GroupID, UserID]> {
-    return group
-      .getUnique()
-      .members.filter((uid) => this.users.getUnique(uid).active)
-      .map((uid) => [gid, uid]);
+  mapValue(group: Group): UserID[] {
+    return group.members.filter((uid) => this.users.getUnique(uid).active);
   }
 }
 
 // Mapper function to filter out those active users who are also friends with `user`
-class FilterFriends implements Mapper<GroupID, UserID, GroupID, UserID> {
-  constructor(private readonly user: User) {}
+class FilterFriends extends OneToOneMapper<GroupID, UserID[], UserID[]> {
+  constructor(private readonly user: User) {
+    super();
+  }
 
-  mapEntry(
-    gid: GroupID,
-    uids: NonEmptyIterator<UserID>,
-  ): Iterable<[GroupID, UserID]> {
-    return uids
-      .toArray()
-      .reduce<
-        [GroupID, UserID][]
-      >((acc, uid) => (this.user.friends.includes(uid) ? [...acc, [gid, uid]] : acc), []);
+  mapValue(uids: UserID[]): UserID[] {
+    return uids.filter((uid) => this.user.friends.includes(uid));
   }
 }
 
@@ -78,7 +68,7 @@ class ActiveFriends implements Resource<ResourceInputs> {
     this.uid = params["uid"];
   }
 
-  instantiate(inputs: ResourceInputs): EagerCollection<GroupID, UserID> {
+  instantiate(inputs: ResourceInputs): EagerCollection<GroupID, UserID[]> {
     const user = inputs.users.getUnique(this.uid);
     return inputs.actives.map(FilterFriends, user);
   }


### PR DESCRIPTION
Updating the getting-started examples to use the now-available array operations (filter, includes, etc.) now that arrays aren't proxied.  Also tightened up syntax a bit using OneToOneMapper