### PR TITLE
Tighten Param type to enforce deep-freezing

### DIFF
--- a/examples/hackernews/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/reactive_service/src/hackernews.service.ts
@@ -74,7 +74,7 @@ class PostsMapper {
     key: number,
     values: NonEmptyIterator<Post>,
   ): Iterable<[number, Upvoted]> {
-    const post = values.getUnique();
+    const post: Post = values.getUnique();
     const upvotes = this.upvotes.getArray(key).length;
     const author = this.users.getUnique(post.author_id);
     // Projecting all posts on key 0 so that they can later be sorted.

--- a/skiplang/skjson/ts/src/skjson.ts
+++ b/skiplang/skjson/ts/src/skjson.ts
@@ -107,9 +107,16 @@ function interpretPointer<T extends Internal.CJSON>(
     case Type.Array: {
       const aPtr = hdl.access.SKIP_SKJSON_asArray(ptr);
       const length = hdl.access.SKIP_SKJSON_arraySize(aPtr);
-      return Array.from({ length }, (_, idx) =>
+      const array = Array.from({ length }, (_, idx) =>
         interpretPointer(hdl, hdl.access.SKIP_SKJSON_at(aPtr, idx)),
       );
+      return Object.freeze(
+        Object.defineProperty(array, sk_frozen, {
+          enumerable: false,
+          writable: false,
+          value: true,
+        }),
+      ) as Exportable;
     }
     case Type.Object: {
       const oPtr = hdl.access.SKIP_SKJSON_asObject(ptr);
@@ -272,7 +279,7 @@ export type Exportable =
   | null
   | undefined
   | ObjectProxy<{ [k: string]: Exportable }>
-  | Exportable[];
+  | (readonly Exportable[] & { [sk_frozen]: true });
 
 export interface SKJSON extends Shared {
   importJSON(value: ptr<Internal.CJSON>, copy?: boolean): Exportable;

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -65,7 +65,7 @@ export abstract class OneToOneMapper<
   V2 extends Json,
 > implements Mapper<K, V1, K, V2>
 {
-  abstract mapValue(value: V1, key: K): V2;
+  abstract mapValue(value: V1 & Param, key: K): V2;
 
   mapEntry(key: K, values: NonEmptyIterator<V1>): Iterable<[K, V2]> {
     return values.toArray().map((v) => [key, this.mapValue(v, key)]);
@@ -87,7 +87,7 @@ export abstract class OneToManyMapper<
   V2 extends Json,
 > implements Mapper<K, V1, K, V2>
 {
-  abstract mapValue(value: V1, key: K): V2[];
+  abstract mapValue(value: V1 & Param, key: K): V2[];
 
   mapEntry(key: K, values: NonEmptyIterator<V1>): Iterable<[K, V2]> {
     const res: [K, V2][] = [];
@@ -131,7 +131,7 @@ export interface Reducer<T extends Json, V extends Json> {
    * @param value - the added value
    * @returns the resulting accumulated value
    */
-  add(acc: Nullable<V>, value: T): V;
+  add(acc: Nullable<V>, value: T & Param): V;
 
   /**
    * The computation to perform when an input value is removed
@@ -139,7 +139,7 @@ export interface Reducer<T extends Json, V extends Json> {
    * @param value - the removed value
    * @returns the resulting accumulated value
    */
-  remove(acc: V, value: T): Nullable<V>;
+  remove(acc: V, value: T & Param): Nullable<V>;
 }
 
 /**
@@ -150,23 +150,23 @@ export class NonUniqueValueException extends Error {}
 /**
  * A mutable iterator with at least one element
  */
-export interface NonEmptyIterator<T> extends Iterable<T> {
+export interface NonEmptyIterator<T> extends Iterable<T & Param> {
   /**
    * Return the next element of the iteration.
    * `first` cannot be called after `next`
    */
-  next(): Nullable<T>;
+  next(): Nullable<T & Param>;
 
   /**
    * Return the first element of the iteration iff it contains exactly one element.
    * Otherwise, throw a `NonUniqueValueException`.
    */
-  getUnique(): T;
+  getUnique(): T & Param;
 
   /**
    * Returns an array containing all values of the iterator
    */
-  toArray(): T[];
+  toArray(): (T & Param)[];
 
   /**
    * Calls a defined callback function on each element of an array, and returns an array
@@ -174,7 +174,7 @@ export interface NonEmptyIterator<T> extends Iterable<T> {
    * @param f - A function to apply to each element
    * @param thisObj - An object to bind as `this` within the `f` invocations
    */
-  map<U>(f: (value: T, index: number) => U, thisObj?: any): U[];
+  map<U>(f: (value: T & Param, index: number) => U, thisObj?: any): U[];
 }
 
 /**
@@ -185,13 +185,13 @@ export interface LazyCollection<K extends Json, V extends Json>
   /**
    * Get (and potentially compute) all values mapped to by some key.
    */
-  getArray(key: K): V[];
+  getArray(key: K): (V & Param)[];
 
   /**
    * Get (and potentially compute) the singleton value mapped to by some key.
    * @throws {NonUniqueValueException} when the key maps to either zero or multiple values
    */
-  getUnique(key: K): V;
+  getUnique(key: K): V & Param;
 }
 
 /**
@@ -203,13 +203,13 @@ export interface EagerCollection<K extends Json, V extends Json>
   /**
    * Get all values mapped to by some key.
    */
-  getArray(key: K): V[];
+  getArray(key: K): (V & Param)[];
 
   /**
    * Get the singleton value mapped to by some key.
    * @throws {NonUniqueValueException} when the key maps to either zero or multiple values
    */
-  getUnique(key: K): V;
+  getUnique(key: K): V & Param;
 
   /**
    * Create a new eager collection by mapping some computation over this one

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -30,9 +30,7 @@ export type Param =
   | bigint
   | string
   | symbol
-  | Constant
-  | readonly Param[]
-  | { readonly [k: string]: Param };
+  | Constant;
 
 /**
  * The type of a reactive function mapping over an arbitrary collection.

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -41,11 +41,13 @@ import { UnknownCollectionError } from "@skipruntime/helpers/errors.js";
 
 export type Handle<T> = Internal.Opaque<int, { handle_for: T }>;
 
-const sk_frozen: unique symbol = Symbol.for("Skip.frozen");
-
 type JSONMapper = Mapper<Json, Json, Json, Json>;
 type JSONLazyCompute = LazyCompute<Json, Json>;
 
+/* NB: `sk_frozen` and `sk_freeze` are both duplicated in skjson.ts to avoid
+ * circular module dependencies. Make sure to mirror any changes there!
+ */
+const sk_frozen: unique symbol = Symbol.for("Skip.frozen");
 export function sk_freeze<T extends object>(x: T): T & Constant {
   return Object.defineProperty(x, sk_frozen, {
     enumerable: false,

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -935,22 +935,22 @@ class LazyCollectionImpl<K extends Json, V extends Json>
     Object.freeze(this);
   }
 
-  getArray(key: K): V[] {
+  getArray(key: K): (V & Param)[] {
     return this.refs.skjson.importJSON(
       this.refs.fromWasm.SkipRuntime_LazyCollection__getArray(
         this.refs.skjson.exportString(this.lazyCollection),
         this.refs.skjson.exportJSON(key),
       ),
-    ) as V[];
+    ) as (V & Param)[];
   }
 
-  getUnique(key: K): V {
+  getUnique(key: K): V & Param {
     const v = this.refs.skjson.importOptJSON(
       this.refs.fromWasm.SkipRuntime_LazyCollection__getUnique(
         this.refs.skjson.exportString(this.lazyCollection),
         this.refs.skjson.exportJSON(key),
       ),
-    ) as Nullable<V>;
+    ) as Nullable<V & Param>;
     if (v == null) throw new NonUniqueValueException();
     return v;
   }
@@ -968,22 +968,22 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     Object.freeze(this);
   }
 
-  getArray(key: K): V[] {
+  getArray(key: K): (V & Param)[] {
     return this.refs.skjson.importJSON(
       this.refs.fromWasm.SkipRuntime_Collection__getArray(
         this.refs.skjson.exportString(this.collection),
         this.refs.skjson.exportJSON(key),
       ),
-    ) as V[];
+    ) as (V & Param)[];
   }
 
-  getUnique(key: K): V {
+  getUnique(key: K): V & Param {
     const v = this.refs.skjson.importOptJSON(
       this.refs.fromWasm.SkipRuntime_Collection__getUnique(
         this.refs.skjson.exportString(this.collection),
         this.refs.skjson.exportJSON(key),
       ),
-    ) as Nullable<V>;
+    ) as Nullable<V & Param>;
     if (v == null) throw new NonUniqueValueException();
     return v;
   }
@@ -1520,25 +1520,25 @@ class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
     private readonly pointer: ptr<Internal.NonEmptyIterator>,
   ) {}
 
-  next(): Nullable<T> {
+  next(): Nullable<T & Param> {
     return this.skjson.importOptJSON(
       this.exports.SkipRuntime_NonEmptyIterator__next(this.pointer),
-    ) as Nullable<T>;
+    ) as Nullable<T & Param>;
   }
 
-  getUnique(): T {
+  getUnique(): T & Param {
     const value = this.skjson.importOptJSON(
       this.exports.SkipRuntime_NonEmptyIterator__uniqueValue(this.pointer),
-    ) as Nullable<T>;
+    ) as Nullable<T & Param>;
     if (value == null) throw new NonUniqueValueException();
     return value;
   }
 
-  toArray: () => T[] = () => {
+  toArray: () => (T & Param)[] = () => {
     return Array.from(this);
   };
 
-  [Symbol.iterator](): Iterator<T> {
+  [Symbol.iterator](): Iterator<T & Param> {
     const cloned_iter = new NonEmptyIteratorImpl<T>(
       this.skjson,
       this.exports,
@@ -1548,12 +1548,12 @@ class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
     return {
       next() {
         const value = cloned_iter.next();
-        return { value, done: value == null } as IteratorResult<T>;
+        return { value, done: value == null } as IteratorResult<T & Param>;
       },
     };
   }
 
-  map<U>(f: (value: T, index: number) => U, thisObj?: any): U[] {
+  map<U>(f: (value: T & Param, index: number) => U, thisObj?: any): U[] {
     return this.toArray().map(f, thisObj);
   }
 }

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -624,7 +624,11 @@ class LinksImpl implements Links {
     const mapper = this.handles.get(skmapper);
     const result = mapper.mapEntry(
       skjson.importJSON(key) as Json,
-      new NonEmptyIteratorImpl(skjson, this.fromWasm, values),
+      new NonEmptyIteratorImpl(
+        skjson,
+        this.fromWasm,
+        values,
+      ) as NonEmptyIterator<Json>,
     );
     return skjson.exportJSON(Array.from(result) as [[Json, Json]]);
   }
@@ -676,7 +680,10 @@ class LinksImpl implements Links {
       this.needGC.bind(this),
     );
     for (const [key, name] of Object.entries(keysIds)) {
-      collections[key] = new EagerCollectionImpl(name, refs);
+      collections[key] = new EagerCollectionImpl(name, refs) as EagerCollection<
+        Json,
+        Json
+      >;
     }
     const collection = resource.instantiate(collections, new ContextImpl(refs));
     const res = (collection as EagerCollectionImpl<Json, Json>).collection;
@@ -726,7 +733,10 @@ class LinksImpl implements Links {
       this.needGC.bind(this),
     );
     for (const [key, name] of Object.entries(keysIds)) {
-      collections[key] = new EagerCollectionImpl(name, refs);
+      collections[key] = new EagerCollectionImpl(name, refs) as EagerCollection<
+        Json,
+        Json
+      >;
     }
     // TODO: Manage skstore
     const result = service.createGraph(collections, new ContextImpl(refs));
@@ -792,8 +802,8 @@ class LinksImpl implements Links {
     const reducer = this.handles.get(skreducer);
     return skjson.exportJSON(
       reducer.add(
-        skacc ? (skjson.importJSON(skacc) as Json) : null,
-        skjson.importJSON(skvalue) as Json,
+        skacc ? (skjson.importJSON(skacc) as Json & Param) : null,
+        skjson.importJSON(skvalue) as Json & Param,
       ),
     );
   }
@@ -807,8 +817,8 @@ class LinksImpl implements Links {
     const reducer = this.handles.get(skreducer);
     return skjson.exportJSON(
       reducer.remove(
-        skjson.importJSON(skacc) as Json,
-        skjson.importJSON(skvalue) as Json,
+        skjson.importJSON(skacc) as Json & Param,
+        skjson.importJSON(skvalue) as Json & Param,
       ),
     );
   }


### PR DESCRIPTION
See #577: `readonly` modifiers on some Params only ensures that those arrays/objects aren't mutated _within_ mappers; they can still be mutated outside. This PR tightens the Param type, requiring that any objects/arrays are `sk_frozen`, allowing better runtime enforcement of immutability.

@jberdine and I spoke a bunch about this offline and agreed about the general problem/fix.  @mbouaziz , do you agree?  And @skiplabsdaniel , does this seem reasonable to you? Anything we're failing to consider? 


This also makes #578 more urgent -- I'll try to improve the naming in another PR, but thought it'd be better to keep this separate for now.
