### PR TITLE
Constant/Param/NonEmptyIterator type renamings

### DIFF
--- a/examples/hackernews/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/reactive_service/src/hackernews.service.ts
@@ -2,7 +2,7 @@ import type {
   EagerCollection,
   Entry,
   Json,
-  NonEmptyIterator,
+  Values,
   Resource,
   SkipService,
 } from "@skipruntime/runtime";
@@ -56,10 +56,7 @@ export function serviceWithInitialData(
 }
 
 class UpvotesMapper {
-  mapEntry(
-    key: number,
-    values: NonEmptyIterator<Upvote>,
-  ): Iterable<[number, number]> {
+  mapEntry(key: number, values: Values<Upvote>): Iterable<[number, number]> {
     const value = values.getUnique().post_id;
     return [[value, key]];
   }
@@ -71,10 +68,7 @@ class PostsMapper {
     private upvotes: EagerCollection<number, number>,
   ) {}
 
-  mapEntry(
-    key: number,
-    values: NonEmptyIterator<Post>,
-  ): Iterable<[number, Upvoted]> {
+  mapEntry(key: number, values: Values<Post>): Iterable<[number, Upvoted]> {
     const post: Post = values.getUnique();
     const upvotes = this.upvotes.getArray(key).length;
     const author = this.users.getUnique(post.author_id);
@@ -84,10 +78,7 @@ class PostsMapper {
 }
 
 class SortingMapper {
-  mapEntry(
-    key: number,
-    values: NonEmptyIterator<Upvoted>,
-  ): Iterable<[number, Upvoted]> {
+  mapEntry(key: number, values: Values<Upvoted>): Iterable<[number, Upvoted]> {
     const posts = values.toArray();
     // Sorting in descending order of upvotes.
     posts.sort((a, b) => b.upvotes - a.upvotes);

--- a/skiplang/skjson/ts/binding/src/index.ts
+++ b/skiplang/skjson/ts/binding/src/index.ts
@@ -47,20 +47,28 @@ export abstract class SkManaged extends Frozen {
 }
 
 /**
- * A `Param` is a valid parameter to a Skip runtime mapper function: either a constant JS
- * value or a Skip-runtime-managed value. In either case, restricting mapper parameters to
- * this type helps developers to ensure that reactive computations can be reevaluated as
- * needed with consistent semantics.
- * `Constant`s are deep-frozen objects managed by the Skip runtime; non-Skip objects can be made constant by passing them to `deepFreeze`.
+ * A `DepSafe` value is _dependency-safe_ and can be used safely in reactive computations.
+ *
+ * This is either because it is:
+ * (1) a primitive JavaScript value (boolean, number, string, etc.)
+ * (2) a Skip-runtime-managed object with tracked dependencies, or
+ * (3) a deep-frozen and therefore immutable JavaScript object.
+ *
+ * Values used in reactive computations must be dependency-safe so that reactive computations
+ * can be reevaluated as needed with consistent semantics.
+ *
+ * All objects/values that come _out_ of the Skip runtime are dependency-safe by default;
+ * non-Skip objects can be made dependency-safe by passing them to `deepFreeze`, which
+ * recursively freezes their fields and returns an immutable `Managed` object.
  */
-export type Param =
+export type DepSafe =
   | null
   | boolean
   | number
   | bigint
   | string
   | symbol
-  | Constant;
+  | Managed;
 
 export function checkOrCloneParam<T>(value: T): T {
   if (
@@ -102,7 +110,7 @@ export function checkOrCloneParam<T>(value: T): T {
  * @param value - The object to deep-freeze.
  * @returns The same object that was passed in.
  */
-export function deepFreeze<T>(value: T): T & Param {
+export function deepFreeze<T>(value: T): T & DepSafe {
   if (
     typeof value == "bigint" ||
     typeof value == "boolean" ||

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -32,7 +32,7 @@ export interface Mapper<
   K2 extends Json,
   V2 extends Json,
 > {
-  mapEntry(key: K1, values: NonEmptyIterator<V1>): Iterable<[K2, V2]>;
+  mapEntry(key: K1, values: Values<V1>): Iterable<[K2, V2]>;
 }
 
 /**
@@ -51,7 +51,7 @@ export abstract class OneToOneMapper<
 {
   abstract mapValue(value: V1 & DepSafe, key: K): V2;
 
-  mapEntry(key: K, values: NonEmptyIterator<V1>): Iterable<[K, V2]> {
+  mapEntry(key: K, values: Values<V1>): Iterable<[K, V2]> {
     return values.toArray().map((v) => [key, this.mapValue(v, key)]);
   }
 }
@@ -73,7 +73,7 @@ export abstract class OneToManyMapper<
 {
   abstract mapValue(value: V1 & DepSafe, key: K): V2[];
 
-  mapEntry(key: K, values: NonEmptyIterator<V1>): Iterable<[K, V2]> {
+  mapEntry(key: K, values: Values<V1>): Iterable<[K, V2]> {
     const res: [K, V2][] = [];
     for (const v1 of values)
       for (const v2 of this.mapValue(v1, key)) res.push([key, v2]);
@@ -96,9 +96,9 @@ export abstract class ManyToOneMapper<
   V2 extends Json,
 > implements Mapper<K, V1, K, V2>
 {
-  abstract mapValues(values: NonEmptyIterator<V1>, key: K): V2;
+  abstract mapValues(values: Values<V1>, key: K): V2;
 
-  mapEntry(key: K, values: NonEmptyIterator<V1>): Iterable<[K, V2]> {
+  mapEntry(key: K, values: Values<V1>): Iterable<[K, V2]> {
     return [[key, this.mapValues(values, key)]];
   }
 }
@@ -132,9 +132,9 @@ export interface Reducer<T extends Json, V extends Json> {
 export class NonUniqueValueException extends Error {}
 
 /**
- * A mutable iterator with at least one element
+ * A mutable iterator of dependency-safe values with at least one element
  */
-export interface NonEmptyIterator<T> extends Iterable<T & DepSafe> {
+export interface Values<T> extends Iterable<T & DepSafe> {
   /**
    * Return the next element of the iteration.
    * `first` cannot be called after `next`

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -1,6 +1,6 @@
 import type { int, Nullable, Opaque } from "@skiplang/std";
-import type { Constant, Json, JsonObject, Param } from "@skiplang/json";
-export type { Constant, Json, JsonObject, Opaque, Param };
+import type { Managed, Json, JsonObject, Param } from "@skiplang/json";
+export type { Managed, Json, JsonObject, Opaque, Param };
 export { deepFreeze } from "@skiplang/json";
 
 /**
@@ -165,7 +165,7 @@ export interface NonEmptyIterator<T> extends Iterable<T & Param> {
  * A _Lazy_ reactive collection, whose values are computed only when queried
  */
 export interface LazyCollection<K extends Json, V extends Json>
-  extends Constant {
+  extends Managed {
   /**
    * Get (and potentially compute) all values mapped to by some key.
    */
@@ -183,7 +183,7 @@ export interface LazyCollection<K extends Json, V extends Json>
  * to date whenever inputs are changed
  */
 export interface EagerCollection<K extends Json, V extends Json>
-  extends Constant {
+  extends Managed {
   /**
    * Get all values mapped to by some key.
    */
@@ -269,7 +269,7 @@ export interface LazyCompute<K extends Json, V extends Json> {
 /**
  * Skip Runtime internal state.
  */
-export interface Context extends Constant {
+export interface Context extends Managed {
   /**
    * Creates a lazy reactive collection.
    * @param compute - the function to compute entries of the lazy collection

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -23,7 +23,7 @@ import {
   type LazyCompute,
   type Mapper,
   type NamedCollections,
-  type NonEmptyIterator,
+  type Values,
   type DepSafe,
   type Reducer,
   type Resource,
@@ -668,7 +668,7 @@ export class ServiceInstance {
   }
 }
 
-export class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
+class ValuesImpl<T> implements Values<T> {
   constructor(
     private readonly skjson: JsonConverter,
     private readonly binding: FromBinding,
@@ -698,7 +698,7 @@ export class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
   };
 
   [Symbol.iterator](): Iterator<T & DepSafe> {
-    const cloned_iter = new NonEmptyIteratorImpl<T & DepSafe>(
+    const cloned_iter = new ValuesImpl<T & DepSafe>(
       this.skjson,
       this.binding,
       this.binding.SkipRuntime_NonEmptyIterator__clone(this.pointer),
@@ -767,7 +767,7 @@ export class ToBinding {
     const mapper = this.handles.get(skmapper);
     const result = mapper.mapEntry(
       skjson.importJSON(key) as Json,
-      new NonEmptyIteratorImpl<Json>(skjson, this.binding, values),
+      new ValuesImpl<Json>(skjson, this.binding, values),
     );
     return skjson.exportJSON(Array.from(result) as [[Json, Json]]);
   }

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -7,8 +7,8 @@ import type {
 } from "@skiplang/json";
 import {
   sk_freeze,
-  isSkFrozen,
-  SkFrozen,
+  isSkManaged,
+  SkManaged,
   checkOrCloneParam,
 } from "@skiplang/json";
 import type * as Internal from "./internal.js";
@@ -41,7 +41,7 @@ import {
   type FromBinding,
 } from "./binding.js";
 
-export { UnknownCollectionError, sk_freeze, isSkFrozen };
+export { UnknownCollectionError, sk_freeze, isSkManaged };
 export { SkipExternalService } from "./remote.js";
 export { Sum, Min, Max, Count, CountMapper } from "./utils.js";
 
@@ -117,7 +117,7 @@ export class Refs {
 }
 
 class LazyCollectionImpl<K extends Json, V extends Json>
-  extends SkFrozen
+  extends SkManaged
   implements LazyCollection<K, V>
 {
   constructor(
@@ -150,7 +150,7 @@ class LazyCollectionImpl<K extends Json, V extends Json>
 }
 
 class EagerCollectionImpl<K extends Json, V extends Json>
-  extends SkFrozen
+  extends SkManaged
   implements EagerCollection<K, V>
 {
   constructor(
@@ -350,7 +350,7 @@ class CollectionWriter<K extends Json, V extends Json> {
   }
 }
 
-class ContextImpl extends SkFrozen implements Context {
+class ContextImpl extends SkManaged implements Context {
   constructor(private readonly refs: Refs) {
     super();
     Object.freeze(this);

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -24,7 +24,7 @@ import {
   type Mapper,
   type NamedCollections,
   type NonEmptyIterator,
-  type Param,
+  type DepSafe,
   type Reducer,
   type Resource,
   type SkipService,
@@ -128,22 +128,22 @@ class LazyCollectionImpl<K extends Json, V extends Json>
     Object.freeze(this);
   }
 
-  getArray(key: K): (V & Param)[] {
+  getArray(key: K): (V & DepSafe)[] {
     return this.refs.skjson.importJSON(
       this.refs.binding.SkipRuntime_LazyCollection__getArray(
         this.lazyCollection,
         this.refs.skjson.exportJSON(key),
       ),
-    ) as (V & Param)[];
+    ) as (V & DepSafe)[];
   }
 
-  getUnique(key: K): V & Param {
+  getUnique(key: K): V & DepSafe {
     const v = this.refs.skjson.importOptJSON(
       this.refs.binding.SkipRuntime_LazyCollection__getUnique(
         this.lazyCollection,
         this.refs.skjson.exportJSON(key),
       ),
-    ) as Nullable<V & Param>;
+    ) as Nullable<V & DepSafe>;
     if (v == null) throw new NonUniqueValueException();
     return v;
   }
@@ -161,22 +161,22 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     Object.freeze(this);
   }
 
-  getArray(key: K): (V & Param)[] {
+  getArray(key: K): (V & DepSafe)[] {
     return this.refs.skjson.importJSON(
       this.refs.binding.SkipRuntime_Collection__getArray(
         this.collection,
         this.refs.skjson.exportJSON(key),
       ),
-    ) as (V & Param)[];
+    ) as (V & DepSafe)[];
   }
 
-  getUnique(key: K): V & Param {
+  getUnique(key: K): V & DepSafe {
     const v = this.refs.skjson.importOptJSON(
       this.refs.binding.SkipRuntime_Collection__getUnique(
         this.collection,
         this.refs.skjson.exportJSON(key),
       ),
-    ) as Nullable<V & Param>;
+    ) as Nullable<V & DepSafe>;
     if (v == null) throw new NonUniqueValueException();
     return v;
   }
@@ -207,7 +207,7 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     return this.derive<K, V>(skcollection);
   }
 
-  map<K2 extends Json, V2 extends Json, Params extends Param[]>(
+  map<K2 extends Json, V2 extends Json, Params extends DepSafe[]>(
     mapper: new (...params: Params) => Mapper<K, V, K2, V2>,
     ...params: Params
   ): EagerCollection<K2, V2> {
@@ -227,11 +227,11 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     return this.derive<K2, V2>(mapped);
   }
 
-  mapReduce<K2 extends Json, V2 extends Json, MapperParams extends Param[]>(
+  mapReduce<K2 extends Json, V2 extends Json, MapperParams extends DepSafe[]>(
     mapper: new (...params: MapperParams) => Mapper<K, V, K2, V2>,
     ...mapperParams: MapperParams
   ) {
-    return <Accum extends Json, ReducerParams extends Param[]>(
+    return <Accum extends Json, ReducerParams extends DepSafe[]>(
       reducer: new (...params: ReducerParams) => Reducer<V2, Accum>,
       ...reducerParams: ReducerParams
     ) => {
@@ -267,7 +267,7 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     };
   }
 
-  reduce<Accum extends Json, Params extends Param[]>(
+  reduce<Accum extends Json, Params extends DepSafe[]>(
     reducer: new (...params: Params) => Reducer<V, Accum>,
     ...params: Params
   ): EagerCollection<K, Accum> {
@@ -356,7 +356,11 @@ class ContextImpl extends SkManaged implements Context {
     Object.freeze(this);
   }
 
-  createLazyCollection<K extends Json, V extends Json, Params extends Param[]>(
+  createLazyCollection<
+    K extends Json,
+    V extends Json,
+    Params extends DepSafe[],
+  >(
     compute: new (...params: Params) => LazyCompute<K, V>,
     ...params: Params
   ): LazyCollection<K, V> {
@@ -675,26 +679,26 @@ export class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
     this.pointer = pointer;
   }
 
-  next(): Nullable<T & Param> {
+  next(): Nullable<T & DepSafe> {
     return this.skjson.importOptJSON(
       this.binding.SkipRuntime_NonEmptyIterator__next(this.pointer),
-    ) as Nullable<T & Param>;
+    ) as Nullable<T & DepSafe>;
   }
 
-  getUnique(): T & Param {
+  getUnique(): T & DepSafe {
     const value = this.skjson.importOptJSON(
       this.binding.SkipRuntime_NonEmptyIterator__uniqueValue(this.pointer),
-    ) as Nullable<T & Param>;
+    ) as Nullable<T & DepSafe>;
     if (value == null) throw new NonUniqueValueException();
     return value;
   }
 
-  toArray: () => (T & Param)[] = () => {
+  toArray: () => (T & DepSafe)[] = () => {
     return Array.from(this);
   };
 
-  [Symbol.iterator](): Iterator<T & Param> {
-    const cloned_iter = new NonEmptyIteratorImpl<T & Param>(
+  [Symbol.iterator](): Iterator<T & DepSafe> {
+    const cloned_iter = new NonEmptyIteratorImpl<T & DepSafe>(
       this.skjson,
       this.binding,
       this.binding.SkipRuntime_NonEmptyIterator__clone(this.pointer),
@@ -703,12 +707,12 @@ export class NonEmptyIteratorImpl<T> implements NonEmptyIterator<T> {
     return {
       next() {
         const value = cloned_iter.next();
-        return { value, done: value == null } as IteratorResult<T & Param>;
+        return { value, done: value == null } as IteratorResult<T & DepSafe>;
       },
     };
   }
 
-  map<U>(f: (value: T & Param, index: number) => U, thisObj?: any): U[] {
+  map<U>(f: (value: T & DepSafe, index: number) => U, thisObj?: any): U[] {
     return this.toArray().map(f, thisObj);
   }
 }
@@ -915,7 +919,7 @@ export class ToBinding {
     return skjson.exportJSON(
       reducer.add(
         skacc ? (skjson.importJSON(skacc) as Json) : null,
-        skjson.importJSON(skvalue) as Json & Param,
+        skjson.importJSON(skvalue) as Json & DepSafe,
       ),
     );
   }
@@ -930,7 +934,7 @@ export class ToBinding {
     return skjson.exportJSON(
       reducer.remove(
         skjson.importJSON(skacc) as Json,
-        skjson.importJSON(skvalue) as Json & Param,
+        skjson.importJSON(skvalue) as Json & DepSafe,
       ),
     );
   }

--- a/skipruntime-ts/core/src/utils.ts
+++ b/skipruntime-ts/core/src/utils.ts
@@ -1,6 +1,6 @@
 import type { Nullable } from "@skip-wasm/std";
 import { ManyToOneMapper } from "@skipruntime/api";
-import type { Reducer, NonEmptyIterator, Json } from "@skipruntime/api";
+import type { Reducer, Values, Json } from "@skipruntime/api";
 
 /**
  * `Reducer` to maintain the sum of input values.
@@ -82,7 +82,7 @@ export class CountMapper<
   K extends Json,
   V extends Json,
 > extends ManyToOneMapper<K, V, number> {
-  mapValues(values: NonEmptyIterator<V>): number {
+  mapValues(values: Values<V>): number {
     return values.toArray().length;
   }
 }

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -1,7 +1,7 @@
 import type {
   Context,
   EagerCollection,
-  NonEmptyIterator,
+  Values,
   NamedCollections,
   Resource,
 } from "@skipruntime/api";
@@ -11,7 +11,7 @@ import { SkipExternalService } from "@skipruntime/core";
 import { runService } from "@skipruntime/server";
 
 class Mult extends ManyToOneMapper<string, number, number> {
-  mapValues(values: NonEmptyIterator<number>): number {
+  mapValues(values: Values<number>): number {
     return values.toArray().reduce((p, c) => p * c, 1);
   }
 }

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -1,21 +1,17 @@
-import type {
-  EagerCollection,
-  NonEmptyIterator,
-  Resource,
-} from "@skipruntime/api";
+import type { EagerCollection, Values, Resource } from "@skipruntime/api";
 
 import { ManyToOneMapper } from "@skipruntime/api";
 
 import { runService } from "@skipruntime/server";
 
 class Plus extends ManyToOneMapper<string, number, number> {
-  mapValues(values: NonEmptyIterator<number>): number {
+  mapValues(values: Values<number>): number {
     return values.toArray().reduce((p, c) => p + c, 0);
   }
 }
 
 class Minus extends ManyToOneMapper<string, number, number> {
-  mapValues(values: NonEmptyIterator<number>): number {
+  mapValues(values: Values<number>): number {
     const acc = (p: number | null, c: number) => {
       return p !== null ? p - c : c;
     };

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -7,7 +7,7 @@ import type {
   JsonObject,
   LazyCompute,
   LazyCollection,
-  NonEmptyIterator,
+  Values,
   NamedCollections,
   SkipService,
   Resource,
@@ -50,10 +50,7 @@ interface ServiceInstance {
 //// testMap1
 
 class Map1 implements Mapper<string, number, string, number> {
-  mapEntry(
-    key: string,
-    values: NonEmptyIterator<number>,
-  ): Iterable<[string, number]> {
+  mapEntry(key: string, values: Values<number>): Iterable<[string, number]> {
     return Array([key, values.getUnique() + 2]);
   }
 }
@@ -80,10 +77,7 @@ const map1Service: SkipService<Input_SN, Input_SN> = {
 class Map2 implements Mapper<string, number, string, number> {
   constructor(private readonly other: EagerCollection<string, number>) {}
 
-  mapEntry(
-    key: string,
-    values: NonEmptyIterator<number>,
-  ): Iterable<[string, number]> {
+  mapEntry(key: string, values: Values<number>): Iterable<[string, number]> {
     const result: [string, number][] = [];
     const other_values = this.other.getArray(key);
     for (const v of values.toArray()) {
@@ -118,10 +112,7 @@ const map2Service: SkipService<Input_SN_SN, Input_SN_SN> = {
 //// testMap3
 
 class Map3 implements Mapper<string, number, string, number> {
-  mapEntry(
-    key: string,
-    values: NonEmptyIterator<number>,
-  ): Iterable<[string, number]> {
+  mapEntry(key: string, values: Values<number>): Iterable<[string, number]> {
     return [[key, values.toArray().reduce((x, y) => x + y, 0)]];
   }
 }
@@ -177,10 +168,7 @@ const oneToOneMapperService: SkipService<Input_NN, Input_NN> = {
 class SizeMapper implements Mapper<number, number, number, number> {
   constructor(private readonly other: EagerCollection<number, number>) {}
 
-  mapEntry(
-    key: number,
-    values: NonEmptyIterator<number>,
-  ): Iterable<[number, number]> {
+  mapEntry(key: number, values: Values<number>): Iterable<[number, number]> {
     return [[key, values.getUnique() + this.other.size()]];
   }
 }
@@ -240,10 +228,7 @@ class TestLazyAdd implements LazyCompute<number, number> {
 class MapLazy implements Mapper<number, number, number, number> {
   constructor(private readonly other: LazyCollection<number, number>) {}
 
-  mapEntry(
-    key: number,
-    values: NonEmptyIterator<number>,
-  ): Iterable<[number, number]> {
+  mapEntry(key: number, values: Values<number>): Iterable<[number, number]> {
     return Array([key, this.other.getUnique(key) - values.getUnique()]);
   }
 }
@@ -267,10 +252,7 @@ const lazyService: SkipService<Input_NN, Input_NN> = {
 //// testMapReduce
 
 class TestOddEven implements Mapper<number, number, number, number> {
-  mapEntry(
-    key: number,
-    values: NonEmptyIterator<number>,
-  ): Iterable<[number, number]> {
+  mapEntry(key: number, values: Values<number>): Iterable<[number, number]> {
     return Array([key % 2, values.getUnique()]);
   }
 }
@@ -388,7 +370,7 @@ class JSONExtract
 
   mapEntry(
     key: number,
-    values: NonEmptyIterator<{ value: JsonObject; pattern: string }>,
+    values: Values<{ value: JsonObject; pattern: string }>,
   ): Iterable<[number, Json[]]> {
     const value = values.getUnique();
     const result = this.context.jsonExtract(value.value, value.pattern);
@@ -468,10 +450,7 @@ class MockExternal implements ExternalService {
 class MockExternalCheck implements Mapper<number, number, number, number[]> {
   constructor(private readonly external: EagerCollection<number, number>) {}
 
-  mapEntry(
-    key: number,
-    values: NonEmptyIterator<number>,
-  ): Iterable<[number, number[]]> {
+  mapEntry(key: number, values: Values<number>): Iterable<[number, number[]]> {
     try {
       const result = this.external.getUnique(key);
       return [[key, [...values, result]]];


### PR DESCRIPTION
See #578 -- this PR aims to make the names of our types and symbols for frozen/skip-managed values a bit more accurate and descriptive. Doc comments are updated in the PR, but high-level is:

 * `Constant` becomes `DepSafeObj`: these objects are _either_ deep-frozen or managed by the skip runtime (in which case they're not constant) but the key feature is that they can safely be used within reactive computations without incurring untracked dependencies
 * `Param` becomes `DepSafeValue`: these values are similarly dependency-safe; this type is relevant in other contexts than mapper/reducer params, and `Param` doesn't tell you much about what the type actually means in any case.
 * `NonEmptyIterator` becomes `Values` -- see https://github.com/SkipLabs/skip/pull/582#discussion_r1876054925 for some context.  This is the name I'm least sure about; `Values` makes clear that it's not meant as a general-use data structure but instead for use in our API, but isn't super descriptive otherwise.  I didn't want to use `DepSafeValues` as the "dependency-safe-ness" is not necessarily the primary characteristic -- they're just the values you get in a mapper! (which so happen to be dependency safe)

Of course, these are just what I was able to come up with -- if people are opposed or have better options, happy to change things around!