### PR TITLE
Use POST payload instead of GET params for synchronous reads

### DIFF
--- a/examples/hackernews/web_service/app.py
+++ b/examples/hackernews/web_service/app.py
@@ -59,9 +59,14 @@ def posts_index():
         return redirect(f"/streams/{uuid}", code=307)
 
     else:
-        resp = requests.get(
-            f"{REACTIVE_SERVICE_URL}/resources/posts",
-            params={ 'limit': 10 },
+        resp = requests.post(
+            f"{REACTIVE_SERVICE_URL}/snapshot",
+            json={
+                'resource': "posts",
+                'params': {
+                    'limit': 10
+                }
+            },
         )
 
         # The reactive service returns an array of (id, values) where

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -509,17 +509,17 @@ class AllChecker<K extends Json, V extends Json> implements Checker {
   }
 }
 
-class OneChecker<V extends Json> implements Checker {
+class OneChecker<K extends Json, V extends Json> implements Checker {
   constructor(
     private readonly service: ServiceInstance,
     private readonly executor: Executor<V[]>,
     private readonly resource: string,
     private readonly params: { [param: string]: string },
-    private readonly key: string | number,
+    private readonly key: K,
   ) {}
 
   check(request: string): void {
-    const result = this.service.getArray<V>(
+    const result = this.service.getArray<K, V>(
       this.resource,
       this.key,
       this.params,
@@ -603,9 +603,9 @@ export class ServiceInstance {
    * @param params - Resource parameters, passed to the resource constructor specified in this `SkipService`'s `resources` field
    * @returns The current value(s) for this key in the specified resource instance
    */
-  getArray<V extends Json>(
+  getArray<K extends Json, V extends Json>(
     resource: string,
-    key: string | number,
+    key: K,
     params: { [param: string]: string } = {},
     request?: string | Executor<V[]>,
   ): GetResult<V[]> {

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -82,13 +82,13 @@ export class SkipServiceBroker {
     resource: string,
     params: { [param: string]: string },
   ): Promise<Entry<K, V>[]> {
-    const qParams = new URLSearchParams(params).toString();
-    const [optValues, _headers] = await fetchJSON<Entry<K, V>[]>(
-      `${this.entrypoint}/v1/resources/${resource}?${qParams}`,
-      "GET",
+    const [data, _headers] = await fetchJSON<Entry<K, V>[]>(
+      `${this.entrypoint}/v1/snapshot`,
+      "POST",
+      {},
+      { resource, params },
     );
-    const values = optValues ?? [];
-    return values;
+    return data ?? [];
   }
 
   /**
@@ -103,10 +103,11 @@ export class SkipServiceBroker {
     params: { [param: string]: string },
     key: string,
   ): Promise<V[]> {
-    const qParams = new URLSearchParams(params).toString();
     const [data, _headers] = await fetchJSON<V[]>(
-      `${this.entrypoint}/v1/resources/${resource}/${key}?${qParams}`,
-      "GET",
+      `${this.entrypoint}/v1/snapshot`,
+      "POST",
+      {},
+      { resource, key, params },
     );
     return data ?? [];
   }

--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -38,37 +38,23 @@ export function controlService(service: ServiceInstance): express.Express {
   });
 
   // READS
-  app.get("/v1/resources/:resource/:key", (req, res) => {
+  app.post("/v1/snapshot", (req, res) => {
     try {
-      service.getArray(
-        req.params.resource,
-        req.params.key,
-        req.query as { [param: string]: string },
-        {
-          resolve: (data: Json[]) => {
-            res.status(200).json(data);
-          },
-          reject: (err: unknown) => {
-            res.status(500).json(err instanceof Error ? err.message : err);
-          },
-        },
-      );
-    } catch (e: unknown) {
-      console.log(e);
-      res.status(500).json(e instanceof Error ? e.message : e);
-    }
-  });
-
-  app.get("/v1/resources/:resource", (req, res) => {
-    try {
-      service.getAll(req.params.resource, req.query as Record<string, string>, {
-        resolve: (data: Entry<Json, Json>[]) => {
+      const resource = req.body.resource as string;
+      const params = req.body.params as { [param: string]: string };
+      const callbacks = {
+        resolve: (data: Json[]) => {
           res.status(200).json(data);
         },
         reject: (err: unknown) => {
           res.status(500).json(err instanceof Error ? err.message : err);
         },
-      });
+      };
+      if (req.body.key) {
+        service.getArray(resource, req.body.key, params, callbacks);
+      } else {
+        service.getAll(resource, params, callbacks);
+      }
     } catch (e: unknown) {
       console.log(e);
       res.status(500).json(e instanceof Error ? e.message : e);

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -25,15 +25,12 @@ export type SkipServer = {
  *
  * The control API responds to the following HTTP requests:
  *
- * - `GET /v1/resources/:resource?param1=value1&...&paramN=valueN`:
- *   Synchronous read of an entire resource.
+ * - `POST /v1/snapshot`:
+ *   Synchronous read of a resource.
  *
- *   Instantiates the named `resource` with parameters `{param1=value1,...,paramN=valueN}` and responds with the entire contents of the resource. The returned data will be a JSON-encoded value of type `[Json, Json[]][]`: an array of entries each of which associates a key to an array of its values.
- *
- * - `GET /v1/resources/:resource/:key?param1=value1&...&paramN=valueN`:
- *   Synchronous read of a single key from a resource.
- *
- *   Instantiates the named `resource` with parameters `{param1=value1,...,paramN=valueN}` and responds with the values associated with the given `key`. The returned data will be a JSON-encoded value of type `Json[]`: an array of the `key`'s values.
+ *   Requires a JSON-encoded request body of the form `{ resource: string; params: { [param: string]: string }; key?: Json }`.
+ *   Instantiates the named `resource` with the given `params`, and responds with the values associated with the given `key` or with the entire contents of the resource if no `key` is provided.
+ *   If `key` is provided, the returned data will be a JSON-encoded value of type `Json[]`: an array of the `key`'s values; otherwise, it will be a JSON-encoded value of type `[Json, Json[]][]`: an array of entries, each of which associates a key to an array of its values.
  *
  * - `PATCH /v1/inputs/:collection`:
  *   Partial write (update only the specified keys) of an input collection.

--- a/www/docs/resources.md
+++ b/www/docs/resources.md
@@ -81,15 +81,18 @@ POST /v1/streams
 DELETE /v1/streams/:uuid
 ```
 
-The `POST` route instantiates a resource according to the JSON-encoded request body (consisting of the resource identifier and any parameters, structured as `{resource: string; params: {[param: string]: string} }`) and returns a UUID identifying the resource, which can then be used in a query to the streaming API.
+The `POST` route instantiates a resource according to the JSON-encoded request body (consisting of the resource identifier and any parameters, structured as `{ resource: string; params: { [param: string]: string } }`) and returns a UUID identifying the resource, which can then be used in a query to the streaming API.
 The `DELETE` route closes and tears down the resource instance identified by its `uuid` parameter, terminating any active streams.
 
-Synchronous reads from reactive resources can either access the resource in its entirety or read the data for a single key, using the following two routes:
+Synchronous reads from reactive resources can either access the resource in its entirety or read the data for a single key, using route:
 
 ```
-GET /v1/resources/:resource
-GET /v1/resources/:resource/:key
+POST /v1/snapshot
 ```
+
+This `POST` route requires a JSON-encoded request body of the form `{ resource: string; params: { [param: string]: string }; key?: any }`.
+It instantiates a resource if needed to according to the `resource` and `params` fields of the request body, then either returns the values indicated by the `key` or _all_ keys/values if no `key` is provided.
+For reads of a specific `key`, data is returned as an array of values associated to that key; for reads of an entire resource, data is returned as an array of key/value entries, with each entry a tuple of the form `[key, [value1, value2, ...]]`.
 
 Lastly, clients can update the input collections of a reactive service:
 


### PR DESCRIPTION
Resolves #535, resolves #517 

This has a few advantages:
 * Allows resources to have arbitrary key types without any string encoding weirdness resulting from shoving them into path parameters (obviating the need for #539)
 * Unifies the handling/specifying of resources/params between different API routes
 * New API makes very clear that the result is a _snapshot_ in time not a reactive value, and that a resource is being instantiated to respond to the synchronous read query
 
 I've tested against a few of the examples under `./skipruntime-ts/examples` and all seems good.  But, I can't check on `./examples/hackernews` until we publish @skipruntime/runtime to NPM.