### PR TITLE
Allow arbitrary `Json` values as resource parameters

### DIFF
--- a/examples/hackernews/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/reactive_service/src/hackernews.service.ts
@@ -1,9 +1,10 @@
 import type {
-  Entry,
   EagerCollection,
+  Entry,
+  Json,
   NonEmptyIterator,
-  SkipService,
   Resource,
+  SkipService,
 } from "@skipruntime/runtime";
 
 type Post = {
@@ -97,7 +98,7 @@ class SortingMapper {
 class PostsResource implements Resource<ResourceInputs> {
   private limit: number;
 
-  constructor(params: { [param: string]: string }) {
+  constructor(params: { [param: string]: Json }) {
     this.limit = Number(params["limit"]);
   }
 

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -292,7 +292,7 @@ export interface Context extends Constant {
   useExternalResource<K extends Json, V extends Json>(resource: {
     service: string;
     identifier: string;
-    params?: { [param: string]: string | number };
+    params?: { [param: string]: Json };
   }): EagerCollection<K, V>;
 
   jsonExtract(value: JsonObject, pattern: string): Json[];
@@ -341,7 +341,7 @@ export interface ExternalService {
    */
   subscribe(
     resource: string,
-    params: { [param: string]: string | number },
+    params: { [param: string]: Json },
     callbacks: {
       update: (updates: Entry<Json, Json>[], isInit: boolean) => void;
       error: (error: Json) => void;
@@ -354,10 +354,7 @@ export interface ExternalService {
    * @param resource - the name of the external resource
    * @param params - the parameters of the external resource
    */
-  unsubscribe(
-    resource: string,
-    params: { [param: string]: string | number },
-  ): void;
+  unsubscribe(resource: string, params: { [param: string]: Json }): void;
 
   /**
    * Shutdown the external supplier
@@ -408,7 +405,7 @@ export interface SkipService<
   /** The reactive resources which compose the public interface of this reactive service */
   resources: {
     [name: string]: new (params: {
-      [param: string]: string;
+      [param: string]: Json;
     }) => Resource<ResourceInputs>;
   };
 

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -16,11 +16,11 @@ export type Handle<T> = Internal.Opaque<number, { handle_for: T }>;
 export class ResourceBuilder {
   constructor(
     private readonly builder: new (params: {
-      [param: string]: string;
+      [param: string]: Json;
     }) => Resource,
   ) {}
 
-  build(parameters: { [param: string]: string }): Resource {
+  build(parameters: { [param: string]: Json }): Resource {
     const builder = this.builder;
     return new builder(parameters);
   }

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -377,7 +377,7 @@ class ContextImpl extends SkFrozen implements Context {
   useExternalResource<K extends Json, V extends Json>(resource: {
     service: string;
     identifier: string;
-    params?: { [param: string]: string | number };
+    params?: { [param: string]: Json };
   }): EagerCollection<K, V> {
     const collection =
       this.refs.binding.SkipRuntime_Context__useExternalResource(
@@ -422,7 +422,7 @@ class AllChecker<K extends Json, V extends Json> implements Checker {
     private readonly service: ServiceInstance,
     private readonly executor: Executor<Entry<K, V>[]>,
     private readonly resource: string,
-    private readonly params: { [param: string]: string },
+    private readonly params: { [param: string]: Json },
   ) {}
 
   check(request: string): void {
@@ -444,7 +444,7 @@ class OneChecker<K extends Json, V extends Json> implements Checker {
     private readonly service: ServiceInstance,
     private readonly executor: Executor<V[]>,
     private readonly resource: string,
-    private readonly params: { [param: string]: string },
+    private readonly params: { [param: string]: Json },
     private readonly key: K,
   ) {}
 
@@ -479,7 +479,7 @@ export class ServiceInstance {
   instantiateResource(
     identifier: string,
     resource: string,
-    params: { [param: string]: string },
+    params: { [param: string]: Json },
   ): void {
     const errorHdl = this.refs.runWithGC(() => {
       return this.refs.binding.SkipRuntime_Runtime__createResource(
@@ -499,7 +499,7 @@ export class ServiceInstance {
    */
   getAll<K extends Json, V extends Json>(
     resource: string,
-    params: { [param: string]: string } = {},
+    params: { [param: string]: Json } = {},
     request?: string | Executor<Entry<K, V>[]>,
   ): GetResult<Entry<K, V>[]> {
     const get_ = () => {
@@ -536,7 +536,7 @@ export class ServiceInstance {
   getArray<K extends Json, V extends Json>(
     resource: string,
     key: K,
-    params: { [param: string]: string } = {},
+    params: { [param: string]: Json } = {},
     request?: string | Executor<V[]>,
   ): GetResult<V[]> {
     const get_ = () => {
@@ -825,7 +825,7 @@ export class ToBinding {
     const skjson = this.getJsonConverter();
     const builder = this.handles.get(skbuilder);
     const resource = builder.build(
-      skjson.importJSON(skparams) as { [param: string]: string },
+      skjson.importJSON(skparams) as { [param: string]: Json },
     );
     return this.binding.SkipRuntime_createResource(
       this.handles.register(resource),
@@ -953,7 +953,7 @@ export class ToBinding {
     const supplier = this.handles.get(sksupplier);
     const writer = new CollectionWriter(writerId, this.refs());
     const params = skjson.importJSON(skparams, true) as {
-      [param: string]: string;
+      [param: string]: Json;
     };
     supplier.subscribe(resource, params, {
       update: writer.update.bind(writer),
@@ -970,7 +970,7 @@ export class ToBinding {
     const skjson = this.getJsonConverter();
     const supplier = this.handles.get(sksupplier);
     const params = skjson.importJSON(skparams, true) as {
-      [param: string]: string;
+      [param: string]: Json;
     };
     supplier.unsubscribe(resource, params);
   }

--- a/skipruntime-ts/core/src/remote.ts
+++ b/skipruntime-ts/core/src/remote.ts
@@ -31,7 +31,7 @@ export class SkipExternalService implements ExternalService {
 
   subscribe(
     resource: string,
-    params: { [param: string]: string },
+    params: { [param: string]: Json },
     callbacks: {
       update: (updates: Entry<Json, Json>[], isInitial: boolean) => void;
       // FIXME: What is `error()` used for?
@@ -72,7 +72,7 @@ export class SkipExternalService implements ExternalService {
       });
   }
 
-  unsubscribe(resource: string, params: { [param: string]: string }) {
+  unsubscribe(resource: string, params: { [param: string]: Json }) {
     const closable = this.resources.get(this.toId(resource, params));
     if (closable) closable.close();
   }
@@ -83,11 +83,11 @@ export class SkipExternalService implements ExternalService {
     }
   }
 
-  private toId(resource: string, params: { [param: string]: string }): string {
+  private toId(resource: string, params: { [param: string]: Json }): string {
     // TODO: This is equivalent to `querystring.encode(params, ',', ':')`.
     const strparams: string[] = [];
     for (const key of Object.keys(params).sort()) {
-      strparams.push(`${key}:${params[key]}`);
+      strparams.push(`${key}:${btoa(JSON.stringify(params[key]))}`);
     }
     return `${resource}[${strparams.join(",")}]`;
   }

--- a/skipruntime-ts/examples/groups.ts
+++ b/skipruntime-ts/examples/groups.ts
@@ -1,6 +1,7 @@
 import {
   type EagerCollection,
   type InitialData,
+  type Json,
   type Resource,
   OneToManyMapper,
 } from "@skipruntime/api";
@@ -63,8 +64,9 @@ class FilterFriends extends OneToManyMapper<GroupID, UserID, UserID> {
 class ActiveFriends implements Resource<ResourceInputs> {
   private readonly uid: UserID;
 
-  constructor(params: { [param: string]: string }) {
-    if (!params["uid"]) throw new Error("Missing required parameter 'uid'");
+  constructor(params: { [param: string]: Json }) {
+    if (!params["uid"] || typeof params["uid"] != "string")
+      throw new Error("Missing required string parameter 'uid'");
     this.uid = params["uid"];
   }
 

--- a/skipruntime-ts/examples/utils.ts
+++ b/skipruntime-ts/examples/utils.ts
@@ -57,12 +57,12 @@ export class SkipHttpAccessV1 {
     return Promise.allSettled(promises);
   }
 
-  async log(resource: string, params: { [param: string]: string }) {
+  async log(resource: string, params: { [param: string]: Json }) {
     const result = await this.service.getAll(resource, params);
     console.log(JSON.stringify(result));
   }
 
-  request(resource: string, params: { [param: string]: string }) {
+  request(resource: string, params: { [param: string]: Json }) {
     this.service
       .getStreamUUID(resource, params)
       .then((uuid) => {
@@ -91,7 +91,7 @@ interface RequestQuery {
   type: "request";
   payload: {
     resource: string;
-    params?: { [param: string]: string };
+    params?: { [param: string]: Json };
     port?: number;
   };
 }
@@ -100,7 +100,7 @@ interface LogQuery {
   type: "log";
   payload: {
     resource: string;
-    params?: { [param: string]: string };
+    params?: { [param: string]: Json };
     port?: number;
   };
 }
@@ -300,7 +300,7 @@ export function run(
           (query: string) => {
             const jsquery = JSON.parse(query) as {
               resource: string;
-              params?: { [param: string]: string };
+              params?: { [param: string]: Json };
             };
             access.request(jsquery.resource, jsquery.params ?? {});
           },
@@ -310,7 +310,7 @@ export function run(
           (query: string) => {
             const jsquery = JSON.parse(query) as {
               resource: string;
-              params?: { [param: string]: string };
+              params?: { [param: string]: Json };
             };
             access
               .log(jsquery.resource, jsquery.params ?? {})

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -69,7 +69,7 @@ export class SkipServiceBroker {
    */
   async getAll<K extends Json, V extends Json>(
     resource: string,
-    params: { [param: string]: string },
+    params: { [param: string]: Json },
   ): Promise<Entry<K, V>[]> {
     const [data, _headers] = await fetchJSON<Entry<K, V>[]>(
       `${this.entrypoint}/v1/snapshot`,
@@ -89,7 +89,7 @@ export class SkipServiceBroker {
    */
   async getArray<V extends Json>(
     resource: string,
-    params: { [param: string]: string },
+    params: { [param: string]: Json },
     key: string,
   ): Promise<V[]> {
     const [data, _headers] = await fetchJSON<V[]>(
@@ -111,7 +111,7 @@ export class SkipServiceBroker {
    */
   async getUnique<V extends Json>(
     resource: string,
-    params: { [param: string]: string },
+    params: { [param: string]: Json },
     key: string,
   ): Promise<V> {
     return this.getArray<V>(resource, params, key).then((values) => {
@@ -172,7 +172,7 @@ export class SkipServiceBroker {
    */
   async getStreamUUID(
     resource: string,
-    params: { [param: string]: string } = {},
+    params: { [param: string]: Json } = {},
   ): Promise<string> {
     return fetch(`${this.entrypoint}/v1/streams`, {
       method: "POST",

--- a/skipruntime-ts/native/src/BaseTypes.sk
+++ b/skipruntime-ts/native/src/BaseTypes.sk
@@ -41,26 +41,14 @@ base class LazyCompute {
   fun compute(self: LazyCollection, key: SKJSON.CJSON): Array<SKJSON.CJSON>;
 }
 
-base class PValue uses Show, Orderable {
-  children =
-  | PInt(Int)
-  | PFloat(Float)
-  | PString(String)
-
-  fun toString(): String
-  | PInt(v) -> v.toString()
-  | PFloat(v) -> v.toString()
-  | PString(v) -> v
-}
-
 base class ExternalService {
   fun subscribe(
     collection: CollectionWriter,
     resource: String,
-    params: Map<String, PValue>,
+    params: Params,
   ): void;
 
-  fun unsubscribe(resource: String, params: Map<String, PValue>): void;
+  fun unsubscribe(resource: String, params: Params): void;
 
   fun shutdown(): void;
 }
@@ -70,7 +58,7 @@ base class Resource {
 }
 
 base class ResourceBuilder {
-  fun build(parameters: Map<String, PValue>): Resource;
+  fun build(parameters: Params): Resource;
 }
 
 base class Service(

--- a/skipruntime-ts/native/src/Extern.sk
+++ b/skipruntime-ts/native/src/Extern.sk
@@ -178,7 +178,7 @@ class ExternExternalService(
   fun subscribe(
     collection: CollectionWriter,
     resource: String,
-    params: Map<String, PValue>,
+    params: Params,
   ): void {
     subscribeOfExternalService(
       this.eptr.value,
@@ -188,7 +188,7 @@ class ExternExternalService(
     )
   }
 
-  fun unsubscribe(resource: String, params: Map<String, PValue>): void {
+  fun unsubscribe(resource: String, params: Params): void {
     unsubscribeOfExternalService(this.eptr.value, resource, jsonParams(params))
   }
 
@@ -290,7 +290,7 @@ fun createResourceBuilder(resourceBuilder: UInt32): ExternResourceBuilder {
 class ExternResourceBuilder(
   eptr: SKStore.ExternalPointer,
 ) extends ResourceBuilder {
-  fun build(params: Map<String, PValue>): Resource {
+  fun build(params: Params): Resource {
     buildOfResourceBuilder(this.eptr.value, jsonParams(params))
   }
 }
@@ -765,9 +765,9 @@ fun jsonExtractOfContext(
 fun useExternalResource(
   service: String,
   identifier: String,
-  jsonparams: SKJSON.CJObject,
+  jsonParams: SKJSON.CJObject,
 ): String {
-  useExternalCollection(service, identifier, params(jsonparams)).getId()
+  useExternalCollection(service, identifier, params(jsonParams)).getId()
 }
 
 /************ initService ****************/

--- a/skipruntime-ts/native/src/Extern.sk
+++ b/skipruntime-ts/native/src/Extern.sk
@@ -611,7 +611,12 @@ fun createResourceOfRuntime(
   jsonParams: SKJSON.CJObject,
 ): Float {
   SKStore.runWithResult(context ~> {
-    createReactiveResource(context, identifier, resource, params(jsonParams))
+    createReactiveResource(
+      context,
+      identifier,
+      resource,
+      Params::create(jsonParams),
+    )
   }) match {
   | Success _ -> 0.0
   | Failure(err) -> getErrorHdl(err)
@@ -627,13 +632,13 @@ fun getAllOfRuntime(
   (getContext() match {
   | Some(context) ->
     try {
-      Success(getAll(context, resource, params(jsonParams), optRequest))
+      Success(getAll(context, resource, Params::create(jsonParams), optRequest))
     } catch {
     | ex -> Failure(ex)
     }
   | _ ->
     SKStore.runWithResult(context ~> {
-      getAll(context, resource, params(jsonParams), optRequest)
+      getAll(context, resource, Params::create(jsonParams), optRequest)
     })
   }) match {
   | Success(result) ->
@@ -668,13 +673,21 @@ fun getForKeyOfRuntime(
   (getContext() match {
   | Some(context) ->
     try {
-      Success(getForKey(context, resource, params(jsonParams), key, optRequest))
+      Success(
+        getForKey(
+          context,
+          resource,
+          Params::create(jsonParams),
+          key,
+          optRequest,
+        ),
+      )
     } catch {
     | ex -> Failure(ex)
     }
   | _ ->
     SKStore.runWithResult(context ~> {
-      getForKey(context, resource, params(jsonParams), key, optRequest)
+      getForKey(context, resource, Params::create(jsonParams), key, optRequest)
     })
   }) match {
   | Success(result) ->
@@ -767,7 +780,7 @@ fun useExternalResource(
   identifier: String,
   jsonParams: SKJSON.CJObject,
 ): String {
-  useExternalCollection(service, identifier, params(jsonParams)).getId()
+  useExternalCollection(service, identifier, Params::create(jsonParams)).getId()
 }
 
 /************ initService ****************/

--- a/skipruntime-ts/native/src/Runtime.sk
+++ b/skipruntime-ts/native/src/Runtime.sk
@@ -22,14 +22,15 @@ class ExistingSubscriptionException() extends Exception {
   }
 }
 
-class Params(value: Map<String, PValue>) extends SKStore.File uses Orderable {
+class Params private (
+  sortedKeys: Array<String>,
+  sortedVals: Array<SKJSON.CJSON>,
+) extends SKStore.File uses Orderable {
   fun compare(other: Params): Order {
-    keys = this.value.keys().collect(Array).sorted();
-    okeys = other.value.keys().collect(Array).sorted();
-    kcomp = keys.compare(okeys);
+    kcomp = this.sortedKeys.compare(other.sortedKeys);
     if (kcomp == EQ()) {
-      for (key in keys) {
-        vcomp = this.value.get(key).compare(other.value.get(key));
+      for ((v1, v2) in this.sortedVals.zip(other.sortedVals)) {
+        vcomp = v1.compare(v2);
         if (vcomp != EQ()) {
           break vcomp
         }
@@ -39,6 +40,18 @@ class Params(value: Map<String, PValue>) extends SKStore.File uses Orderable {
     } else {
       kcomp
     }
+  }
+  fun items(): mutable Iterator<(String, SKJSON.CJSON)> {
+    for (i in Range(0, this.sortedKeys.size())) {
+      yield (this.sortedKeys[i], this.sortedVals[i])
+    }
+  }
+  fun toString(): String {
+    vec = mutable Vector[];
+    for ((k, v) in this.items()) {
+      vec.push(`${k}:${v.prettyPrint()}`);
+    };
+    `{${vec.join(",")}}`
   }
 }
 
@@ -86,7 +99,7 @@ class ResourceDef(
 ) extends SKStore.File, SKStore.Key {
   //
   fun toString(): String {
-    `${this.name}:${paramsToString(this.params.value)}`
+    `${this.name}:${this.params.toString()}`
   }
 }
 
@@ -298,7 +311,7 @@ fun buildResourcesGraph(
       };
       pushContext(context);
       try {
-        resourceId = toResourceId(key.name, key.params.value);
+        resourceId = toResourceId(key.name, key.params);
         statusRef = dirname.sub(resourceId);
         // Status graph
         sStatusHdl = context
@@ -348,7 +361,7 @@ fun buildResourcesGraph(
             },
           );
         resourceBuilder = resources.get(key.name);
-        resource = resourceBuilder.build(key.params.value);
+        resource = resourceBuilder.build(key.params);
         collections = servicesHdl.get(context, SKStore.SID(runId)).value;
         collection = resource.instantiate(collections);
         // Ensure the name of the resource result
@@ -525,7 +538,7 @@ class LinkToResource(
   supplier: ExternalService,
   writer: CollectionWriter,
   name: String,
-  params: Map<String, PValue>,
+  params: Params,
 ) extends SKStore.Postponable {
   //
   fun perform(context: mutable SKStore.Context): void {
@@ -539,7 +552,7 @@ class LinkToResource(
 class CloseResource(
   supplier: ExternalService,
   name: String,
-  params: Map<String, PValue>,
+  params: Params,
 ) extends SKStore.Postponable {
   fun perform(context: mutable SKStore.Context): void {
     pushContext(context);
@@ -607,7 +620,7 @@ fun jsonExtract(from: SKJSON.CJObject, pattern: String): Array<SKJSON.CJSON> {
 fun useExternalCollection(
   supplier: String,
   resource: String,
-  params: Map<String, PValue>,
+  params: Params,
 ): Collection {
   getContext() match {
   | Some(context) ->
@@ -629,7 +642,7 @@ fun useExternalCollection(
       SKStore.IID::keyType,
       Params::type,
       paramsDir,
-      Array[(SKStore.IID(0), Params(params))],
+      Array[(SKStore.IID(0), params)],
     );
     collectionHdl = hdl.map(
       SKStore.IID::keyType,
@@ -637,8 +650,11 @@ fun useExternalCollection(
       context,
       dirName,
       (context, writer, key, it) ~> {
+        resource_params = it.first;
         name = mutable Vector<String>[];
-        it.first.value.each((k, v) -> name.push(`${k}:${v}`));
+        resource_params.items().each((kv) ->
+          name.push(`${kv.i0}:${kv.i1.prettyPrint()}`)
+        );
         storeDir = dirName.sub(base64(name.join("|")));
         store = context.mkdir(
           kKeyToKey,
@@ -651,10 +667,10 @@ fun useExternalCollection(
               externalSupplier,
               CollectionWriter(storeDir),
               resource,
-              it.first.value,
+              resource_params,
             ),
           ),
-          Some(CloseResource(externalSupplier, resource, it.first.value)),
+          Some(CloseResource(externalSupplier, resource, resource_params)),
         );
         writer.set(key, Handle(store));
       },
@@ -1200,7 +1216,7 @@ fun createReactiveResource(
 fun getAll(
   context: mutable SKStore.Context,
   resourceName: String,
-  params: Map<String, PValue>,
+  params: Params,
   optRequest: ?Request,
 ): GetResult<Values> {
   resourceInstanceId = Ksuid::create().toString();
@@ -1232,7 +1248,7 @@ fun getAll(
 fun getForKey(
   context: mutable SKStore.Context,
   resourceName: String,
-  params: Map<String, PValue>,
+  params: Params,
   key: SKJSON.CJSON,
   optRequest: ?Request,
 ): GetResult<Array<SKJSON.CJSON>> {
@@ -1442,9 +1458,9 @@ private fun createResource_(
   context: mutable SKStore.Context,
   identifier: String,
   resource: String,
-  params: Map<String, PValue>,
+  params: Params,
 ): ResourceInfo {
-  definition = ResourceDef(resource, Params(params));
+  definition = ResourceDef(resource, params);
   resourceHdl = SKStore.EHandle(
     SKStore.SID::keyType,
     ResourceDef::type,

--- a/skipruntime-ts/native/src/Runtime.sk
+++ b/skipruntime-ts/native/src/Runtime.sk
@@ -1204,15 +1204,6 @@ value class GetResult<T>(
   }
 }
 
-fun createReactiveResource(
-  context: mutable SKStore.Context,
-  identifier: String,
-  resource: String,
-  params: Map<String, PValue>,
-): void {
-  _ = createResource_(context, identifier, resource, params);
-}
-
 fun getAll(
   context: mutable SKStore.Context,
   resourceName: String,
@@ -1220,7 +1211,12 @@ fun getAll(
   optRequest: ?Request,
 ): GetResult<Values> {
   resourceInstanceId = Ksuid::create().toString();
-  resource = createResource_(context, resourceInstanceId, resourceName, params);
+  resource = createReactiveResource(
+    context,
+    resourceInstanceId,
+    resourceName,
+    params,
+  );
   // create requests
   request = optRequest match {
   | Some(checker @ Checker _) -> resource.createRequest(context, Some(checker))
@@ -1253,7 +1249,12 @@ fun getForKey(
   optRequest: ?Request,
 ): GetResult<Array<SKJSON.CJSON>> {
   resourceInstanceId = Ksuid::create().toString();
-  resource = createResource_(context, resourceInstanceId, resourceName, params);
+  resource = createReactiveResource(
+    context,
+    resourceInstanceId,
+    resourceName,
+    params,
+  );
   // create requests
   request = optRequest match {
   | Some(checker @ Checker _) -> resource.createRequest(context, Some(checker))
@@ -1454,7 +1455,7 @@ fun delete(
   updateContext(context);
 }
 
-private fun createResource_(
+fun createReactiveResource(
   context: mutable SKStore.Context,
   identifier: String,
   resource: String,

--- a/skipruntime-ts/native/src/Runtime.sk
+++ b/skipruntime-ts/native/src/Runtime.sk
@@ -26,11 +26,18 @@ class Params private (
   sortedKeys: Array<String>,
   sortedVals: Array<SKJSON.CJSON>,
 ) extends SKStore.File uses Orderable {
+  static fun create(jsonObj: SKJSON.CJObject): this {
+    jsonObj match {
+    | SKJSON.CJObject(fields) ->
+      sortedItems = fields.items().collect(Array).sortedBy(x ~> x.i0);
+      Params(sortedItems.map(kv ~> kv.i0), sortedItems.map(kv ~> kv.i1))
+    };
+  }
   fun compare(other: Params): Order {
     kcomp = this.sortedKeys.compare(other.sortedKeys);
     if (kcomp == EQ()) {
-      for ((v1, v2) in this.sortedVals.zip(other.sortedVals)) {
-        vcomp = v1.compare(v2);
+      for (i in Range(0, this.sortedVals.size())) {
+        vcomp = this.sortedVals[i].compare(other.sortedVals[i]);
         if (vcomp != EQ()) {
           break vcomp
         }

--- a/skipruntime-ts/native/src/Utils.sk
+++ b/skipruntime-ts/native/src/Utils.sk
@@ -177,13 +177,6 @@ fun collectionsByName(collections: Map<String, Collection>): SKJSON.CJObject {
   SKJSON.CJObject(SKJSON.CJFields::create(fields.toArray(), x -> x));
 }
 
-fun params(params: SKJSON.CJObject): Params {
-  params match {
-  | SKJSON.CJObject(fields) ->
-    sortedItems = fields.items().collect(Array).sortedBy(x ~> x.i0);
-    Params(sortedItems.map(kv ~> kv.i0), sortedItems.map(kv ~> kv.i1))
-  };
-}
 fun jsonParams(params: Params): SKJSON.CJObject {
   SKJSON.CJObject(
     SKJSON.CJFields::create(params.items().collect(Array), x -> x),

--- a/skipruntime-ts/native/src/Utils.sk
+++ b/skipruntime-ts/native/src/Utils.sk
@@ -151,22 +151,14 @@ fun base64<T: Show>(toEncode: T): String {
   | None() -> ""
   }
 }
-
-fun paramsToString(params: Map<String, PValue>): String {
-  vec = mutable Vector[];
-  params.each((k, v) -> vec.push(`${k}:${v}`));
-  `{${vec.join(",")}}`
-}
-
-fun toResourceId(resource: String, params: Map<String, PValue>): String {
-  strParams = base64(paramsToString(params));
-  `${resource}_${strParams}`;
+fun toResourceId(resource: String, params: Params): String {
+  `${resource}_${base64(params.toString())}`
 }
 
 fun toSuppliedResourceId(
   supplier: String,
   resource: String,
-  params: Map<String, PValue>,
+  params: Params,
 ): String {
   `${supplier}_${toResourceId(resource, params)}`;
 }
@@ -185,37 +177,17 @@ fun collectionsByName(collections: Map<String, Collection>): SKJSON.CJObject {
   SKJSON.CJObject(SKJSON.CJFields::create(fields.toArray(), x -> x));
 }
 
-fun params(params: SKJSON.CJObject): Map<String, PValue> {
-  map = mutable Map[];
+fun params(params: SKJSON.CJObject): Params {
   params match {
   | SKJSON.CJObject(fields) ->
-    for (fieldName => field in fields) {
-      map![fieldName] = field match {
-      | SKJSON.CJString(v) -> PString(v)
-      | SKJSON.CJInt(v) -> PInt(v)
-      | SKJSON.CJFloat(v) -> PFloat(v)
-      | _ -> invariant_violation("Invalid parameter value.")
-      }
-    }
+    sortedItems = fields.items().collect(Array).sortedBy(x ~> x.i0);
+    Params(sortedItems.map(kv ~> kv.i0), sortedItems.map(kv ~> kv.i1))
   };
-  map.chill()
 }
-
-fun jsonParams(params: Map<String, PValue>): SKJSON.CJObject {
-  fields = mutable Vector[];
-  params.each((k, v) ->
-    fields.push(
-      (
-        k,
-        v match {
-        | PString(sv) -> SKJSON.CJString(sv)
-        | PInt(iv) -> SKJSON.CJInt(iv)
-        | PFloat(fv) -> SKJSON.CJFloat(fv)
-        },
-      ),
-    )
-  );
-  SKJSON.CJObject(SKJSON.CJFields::create(fields.toArray(), x -> x))
+fun jsonParams(params: Params): SKJSON.CJObject {
+  SKJSON.CJObject(
+    SKJSON.CJFields::create(params.items().collect(Array), x -> x),
+  )
 }
 
 module end;

--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -18,7 +18,7 @@ export function controlService(service: ServiceInstance): express.Express {
       service.instantiateResource(
         uuid,
         req.body.resource as string,
-        req.body.params as { [param: string]: string },
+        req.body.params as { [param: string]: Json },
       );
       res.status(201).send(uuid);
     } catch (e: unknown) {
@@ -41,7 +41,7 @@ export function controlService(service: ServiceInstance): express.Express {
   app.post("/v1/snapshot", (req, res) => {
     try {
       const resource = req.body.resource as string;
-      const params = req.body.params as { [param: string]: string };
+      const params = req.body.params as { [param: string]: Json };
       const callbacks = {
         resolve: (data: Json[]) => {
           res.status(200).json(data);

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -28,7 +28,7 @@ export type SkipServer = {
  * - `POST /v1/snapshot`:
  *   Synchronous read of a resource.
  *
- *   Requires a JSON-encoded request body of the form `{ resource: string; params: { [param: string]: string }; key?: Json }`.
+ *   Requires a JSON-encoded request body of the form `{ resource: string; params: { [param: string]: Json }; key?: Json }`.
  *   Instantiates the named `resource` with the given `params`, and responds with the values associated with the given `key` or with the entire contents of the resource if no `key` is provided.
  *   If `key` is provided, the returned data will be a JSON-encoded value of type `Json[]`: an array of the `key`'s values; otherwise, it will be a JSON-encoded value of type `[Json, Json[]][]`: an array of entries, each of which associates a key to an array of its values.
  *
@@ -43,7 +43,7 @@ export type SkipServer = {
  *   Instantiate a resource and return a UUID to subscribe to updates.
  *
  *   Requires the request to have a `Content-Type: application/json` header.
- *   The body of the request must be a JSON-encoded value of type `{ resource: string, params: { [param: string]: string } }`.
+ *   The body of the request must be a JSON-encoded value of type `{ resource: string, params: { [param: string]: Json } }`.
  *   Instantiates the named `resource` with parameters `params` and responds with a UUID that can be used to subscribe to updates.
  *
  * - `DELETE /v1/streams/:uuid`:

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -31,12 +31,12 @@ type GetResult<T> = {
 interface ServiceInstance {
   getAll<K extends Json, V extends Json>(
     resource: string,
-    params?: { [param: string]: string },
+    params?: { [param: string]: Json },
   ): GetResult<Entry<K, V>[]>;
   getArray<V extends Json>(
     resource: string,
     key: string | number,
-    params?: { [param: string]: string },
+    params?: { [param: string]: Json },
   ): GetResult<V[]>;
   update<K extends Json, V extends Json>(
     collection: string,
@@ -45,7 +45,7 @@ interface ServiceInstance {
   instantiateResource(
     identifier: string,
     resource: string,
-    params: { [param: string]: string },
+    params: { [param: string]: Json },
   ): void;
   closeResourceInstance(resourceInstanceId: string): void;
   close(): void;

--- a/www/docs/getting_started.md
+++ b/www/docs/getting_started.md
@@ -140,7 +140,7 @@ class FilterFriends extends OneToOneMapper<GroupID, UserID[], UserID[]> {
 class ActiveFriends implements Resource<ResourceInputs> {
   private readonly uid: UserID;
 
-  constructor(params: { [param: string]: string }) {
+  constructor(params: { [param: string]: Json }) {
     if (!params["uid"]) throw new Error("Missing required parameter 'uid'");
     this.uid = params["uid"];
   }

--- a/www/docs/resources.md
+++ b/www/docs/resources.md
@@ -34,7 +34,7 @@ The service has two input collections `"users"` and `"groups"` (populated here w
 class ActiveFriends implements Resource<ResourceInputs> {
   private uid: UserID;
 
-  constructor(params: { [param: string]: string }) {
+  constructor(params: { [param: string]: Json }) {
     if (!params["uid"]) throw new Error("Missing required parameter 'uid'");
     this.uid = params["uid"];
   }
@@ -81,7 +81,7 @@ POST /v1/streams
 DELETE /v1/streams/:uuid
 ```
 
-The `POST` route instantiates a resource according to the JSON-encoded request body (consisting of the resource identifier and any parameters, structured as `{ resource: string; params: { [param: string]: string } }`) and returns a UUID identifying the resource, which can then be used in a query to the streaming API.
+The `POST` route instantiates a resource according to the JSON-encoded request body (consisting of the resource identifier and any parameters, structured as `{ resource: string; params: { [param: string]: any } }`) and returns a UUID identifying the resource, which can then be used in a query to the streaming API.
 The `DELETE` route closes and tears down the resource instance identified by its `uuid` parameter, terminating any active streams.
 
 Synchronous reads from reactive resources can either access the resource in its entirety or read the data for a single key, using route:
@@ -90,7 +90,7 @@ Synchronous reads from reactive resources can either access the resource in its 
 POST /v1/snapshot
 ```
 
-This `POST` route requires a JSON-encoded request body of the form `{ resource: string; params: { [param: string]: string }; key?: any }`.
+This `POST` route requires a JSON-encoded request body of the form `{ resource: string; params: { [param: string]: any }; key?: any }`.
 It instantiates a resource if needed to according to the `resource` and `params` fields of the request body, then either returns the values indicated by the `key` or _all_ keys/values if no `key` is provided.
 For reads of a specific `key`, data is returned as an array of values associated to that key; for reads of an entire resource, data is returned as an array of key/value entries, with each entry a tuple of the form `[key, [value1, value2, ...]]`.
 


### PR DESCRIPTION
Not directly enabled by but related to #587 , this PR loosens the constraints we place on resource parameters, from `{ [param: string]: string }` to `{ [param: string]: Json }`, allowing for more richly structured data there. The typescript-side changes are pretty minimal, but I also changed the Skip-lang representation of parameters and cleaned up some things there.

~~This heightens the salience of #565 -- I've kept the logic there as is, but this means that communicating with non-Skip external services may entail JSON->string->JSON encoding/decoding and all the potential fun that comes with that~~ EDIT: actually just decided to do this, resolves #565