### PR TITLE
Allow typechecking and building docs to continue past build failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ check:
 
 .PHONY: check-ts
 check-ts:
-	bun install
+	npm install
 	bin/check-ts.sh
 
 .PHONY: clean
@@ -107,8 +107,9 @@ check-fmt: fmt
 # regenerate api docs served by docs-run from ts sources
 .PHONY: docs
 docs:
-	bun install && npm run build
-	cd www && bun install && npx docusaurus generate-typedoc
+	npm install
+	-npm run build
+	cd www && npm install && npx docusaurus generate-typedoc
 
 # run the docs site locally at http://localhost:3000
 .PHONY: docs-run

--- a/bin/check-ts.sh
+++ b/bin/check-ts.sh
@@ -12,5 +12,5 @@ DIRS=$( jq --raw-output ".workspaces[]" package.json )
 
 for dir in $DIRS
 do
-    "$SCRIPT_DIR"/cd_sh "$dir" "npm run build --if-present && npm run lint --if-present"
+    "$SCRIPT_DIR"/cd_sh "$dir" "npm run build --if-present ; npm run lint --if-present"
 done


### PR DESCRIPTION
These changes are not good, but allow the ts code to be typechecked and the
docs to be built until https://github.com/SkipLabs/skip/issues/595 is fixed.