### PR TITLE
Resources as path parameters

### DIFF
--- a/examples/hackernews/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/reactive_service/src/hackernews.service.ts
@@ -98,8 +98,9 @@ class SortingMapper {
 class PostsResource implements Resource<ResourceInputs> {
   private limit: number;
 
-  constructor(params: { [param: string]: Json }) {
-    this.limit = Number(params["limit"]);
+  constructor(param: Json) {
+    if (typeof param == "number") this.limit = param;
+    else this.limit = 25;
   }
 
   instantiate(collections: ResourceInputs): EagerCollection<number, Upvoted> {

--- a/examples/hackernews/web_service/app.py
+++ b/examples/hackernews/web_service/app.py
@@ -46,13 +46,8 @@ def posts_index():
 
     if 'text/event-stream' in request.accept_mimetypes:
         resp = requests.post(
-            f"{REACTIVE_SERVICE_URL}/streams",
-            json={
-                'resource': "posts",
-                'params': {
-                    'limit': 10
-                }
-            },
+            f"{REACTIVE_SERVICE_URL}/streams/posts",
+            json={ 'limit': 10 },
         )
         uuid = resp.text
 
@@ -60,13 +55,8 @@ def posts_index():
 
     else:
         resp = requests.post(
-            f"{REACTIVE_SERVICE_URL}/snapshot",
-            json={
-                'resource': "posts",
-                'params': {
-                    'limit': 10
-                }
-            },
+            f"{REACTIVE_SERVICE_URL}/snapshot/posts",
+            json={ 'limit': 10 },
         )
 
         # The reactive service returns an array of (id, values) where

--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -292,7 +292,7 @@ export interface Context extends Constant {
   useExternalResource<K extends Json, V extends Json>(resource: {
     service: string;
     identifier: string;
-    params?: { [param: string]: Json };
+    params?: Json;
   }): EagerCollection<K, V>;
 
   jsonExtract(value: JsonObject, pattern: string): Json[];
@@ -341,7 +341,7 @@ export interface ExternalService {
    */
   subscribe(
     resource: string,
-    params: { [param: string]: Json },
+    params: Json,
     callbacks: {
       update: (updates: Entry<Json, Json>[], isInit: boolean) => void;
       error: (error: Json) => void;
@@ -354,7 +354,7 @@ export interface ExternalService {
    * @param resource - the name of the external resource
    * @param params - the parameters of the external resource
    */
-  unsubscribe(resource: string, params: { [param: string]: Json }): void;
+  unsubscribe(resource: string, params: Json): void;
 
   /**
    * Shutdown the external supplier
@@ -404,9 +404,7 @@ export interface SkipService<
   externalServices?: { [name: string]: ExternalService };
   /** The reactive resources which compose the public interface of this reactive service */
   resources: {
-    [name: string]: new (params: {
-      [param: string]: Json;
-    }) => Resource<ResourceInputs>;
+    [name: string]: new (params: Json) => Resource<ResourceInputs>;
   };
 
   /**

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -14,13 +14,9 @@ import {
 export type Handle<T> = Internal.Opaque<number, { handle_for: T }>;
 
 export class ResourceBuilder {
-  constructor(
-    private readonly builder: new (params: {
-      [param: string]: Json;
-    }) => Resource,
-  ) {}
+  constructor(private readonly builder: new (params: Json) => Resource) {}
 
-  build(parameters: { [param: string]: Json }): Resource {
+  build(parameters: Json): Resource {
     const builder = this.builder;
     return new builder(parameters);
   }

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -377,7 +377,7 @@ class ContextImpl extends SkFrozen implements Context {
   useExternalResource<K extends Json, V extends Json>(resource: {
     service: string;
     identifier: string;
-    params?: { [param: string]: Json };
+    params?: Json;
   }): EagerCollection<K, V> {
     const collection =
       this.refs.binding.SkipRuntime_Context__useExternalResource(
@@ -422,7 +422,7 @@ class AllChecker<K extends Json, V extends Json> implements Checker {
     private readonly service: ServiceInstance,
     private readonly executor: Executor<Entry<K, V>[]>,
     private readonly resource: string,
-    private readonly params: { [param: string]: Json },
+    private readonly params: Json,
   ) {}
 
   check(request: string): void {
@@ -444,7 +444,7 @@ class OneChecker<K extends Json, V extends Json> implements Checker {
     private readonly service: ServiceInstance,
     private readonly executor: Executor<V[]>,
     private readonly resource: string,
-    private readonly params: { [param: string]: Json },
+    private readonly params: Json,
     private readonly key: K,
   ) {}
 
@@ -479,7 +479,7 @@ export class ServiceInstance {
   instantiateResource(
     identifier: string,
     resource: string,
-    params: { [param: string]: Json },
+    params: Json,
   ): void {
     const errorHdl = this.refs.runWithGC(() => {
       return this.refs.binding.SkipRuntime_Runtime__createResource(
@@ -499,7 +499,7 @@ export class ServiceInstance {
    */
   getAll<K extends Json, V extends Json>(
     resource: string,
-    params: { [param: string]: Json } = {},
+    params: Json = {},
     request?: string | Executor<Entry<K, V>[]>,
   ): GetResult<Entry<K, V>[]> {
     const get_ = () => {
@@ -536,7 +536,7 @@ export class ServiceInstance {
   getArray<K extends Json, V extends Json>(
     resource: string,
     key: K,
-    params: { [param: string]: Json } = {},
+    params: Json = {},
     request?: string | Executor<V[]>,
   ): GetResult<V[]> {
     const get_ = () => {
@@ -824,9 +824,7 @@ export class ToBinding {
   ): Pointer<Internal.Resource> {
     const skjson = this.getJsonConverter();
     const builder = this.handles.get(skbuilder);
-    const resource = builder.build(
-      skjson.importJSON(skparams) as { [param: string]: Json },
-    );
+    const resource = builder.build(skjson.importJSON(skparams) as Json);
     return this.binding.SkipRuntime_createResource(
       this.handles.register(resource),
     );
@@ -952,9 +950,7 @@ export class ToBinding {
     const skjson = this.getJsonConverter();
     const supplier = this.handles.get(sksupplier);
     const writer = new CollectionWriter(writerId, this.refs());
-    const params = skjson.importJSON(skparams, true) as {
-      [param: string]: Json;
-    };
+    const params = skjson.importJSON(skparams, true) as Json;
     supplier.subscribe(resource, params, {
       update: writer.update.bind(writer),
       error: writer.error.bind(writer),
@@ -969,9 +965,7 @@ export class ToBinding {
   ): void {
     const skjson = this.getJsonConverter();
     const supplier = this.handles.get(sksupplier);
-    const params = skjson.importJSON(skparams, true) as {
-      [param: string]: Json;
-    };
+    const params = skjson.importJSON(skparams, true) as Json;
     supplier.unsubscribe(resource, params);
   }
 

--- a/skipruntime-ts/core/src/remote.ts
+++ b/skipruntime-ts/core/src/remote.ts
@@ -31,7 +31,7 @@ export class SkipExternalService implements ExternalService {
 
   subscribe(
     resource: string,
-    params: { [param: string]: Json },
+    params: Json,
     callbacks: {
       update: (updates: Entry<Json, Json>[], isInitial: boolean) => void;
       // FIXME: What is `error()` used for?
@@ -72,7 +72,7 @@ export class SkipExternalService implements ExternalService {
       });
   }
 
-  unsubscribe(resource: string, params: { [param: string]: Json }) {
+  unsubscribe(resource: string, params: Json) {
     const closable = this.resources.get(this.toId(resource, params));
     if (closable) closable.close();
   }
@@ -83,12 +83,12 @@ export class SkipExternalService implements ExternalService {
     }
   }
 
-  private toId(resource: string, params: { [param: string]: Json }): string {
-    // TODO: This is equivalent to `querystring.encode(params, ',', ':')`.
-    const strparams: string[] = [];
-    for (const key of Object.keys(params).sort()) {
-      strparams.push(`${key}:${btoa(JSON.stringify(params[key]))}`);
-    }
-    return `${resource}[${strparams.join(",")}]`;
+  private toId(resource: string, params: Json): string {
+    if (typeof params == "object") {
+      const strparams = Object.entries(params)
+        .map(([key, value]) => `${key}:${btoa(JSON.stringify(value))}`)
+        .sort();
+      return `${resource}[${strparams.join(",")}]`;
+    } else return `${resource}[${btoa(JSON.stringify(params))}]`;
   }
 }

--- a/skipruntime-ts/examples/groups-client.ts
+++ b/skipruntime-ts/examples/groups-client.ts
@@ -15,8 +15,7 @@ async function sleep(ms: number) {
 /*****************************************************/
 
 console.log("Listening for Bob's active friends in each group...");
-const evSource = new EventSource(`${url}/active_friends/bob`);
-
+const evSource = new EventSource(`${url}/active_friends/0`);
 evSource.addEventListener("init", (e: MessageEvent<string>) => {
   const initial_data = JSON.parse(e.data);
   console.log("Initial data: ", initial_data);
@@ -34,37 +33,37 @@ evSource.onerror = console.error;
 await sleep(1000);
 console.log("Setting Carol to active...");
 await fetchJSON(
-  `${url}/users/carol`,
+  `${url}/users/2`,
   "PUT",
   {},
-  { name: "Carol", active: true, friends: ["bob", "alice"] },
+  { name: "Carol", active: true, friends: [0, 1] },
 );
 
 await sleep(1000);
 console.log("Setting Alice to inactive...");
 await fetchJSON(
-  `${url}/users/alice`,
+  `${url}/users/1`,
   "PUT",
   {},
-  { name: "Alice", active: false, friends: ["bob", "carol"] },
+  { name: "Alice", active: false, friends: [0, 2] },
 );
 
 await sleep(1000);
 console.log("Setting Eve as Bob's friend...");
 await fetchJSON(
-  `${url}/users/bob`,
+  `${url}/users/0`,
   "PUT",
   {},
-  { name: "Bob", active: true, friends: ["alice", "carol", "eve"] },
+  { name: "Bob", active: true, friends: [1, 2, 3] },
 );
 
 await sleep(1000);
 console.log("Removing Carol and adding Eve to group 2...");
 await fetchJSON(
-  `${url}/groups/group2`,
+  `${url}/groups/1002`,
   "PUT",
   {},
-  { name: "Group 2", members: ["bob", "eve"] },
+  { name: "Group 2", members: [0, 3] },
 );
 
 await sleep(1000);

--- a/skipruntime-ts/examples/groups-server.ts
+++ b/skipruntime-ts/examples/groups-server.ts
@@ -14,7 +14,7 @@ app.use(express.json());
 
 app.get("/active_friends/:uid", (req, res) => {
   service
-    .getStreamUUID("active_friends", { uid: req.params.uid })
+    .getStreamUUID("active_friends", Number(req.params.uid))
     .then((uuid) => {
       res.redirect(301, `http://localhost:8080/v1/streams/${uuid}`);
     })
@@ -25,7 +25,7 @@ app.get("/active_friends/:uid", (req, res) => {
 
 app.put("/users/:uid", (req, res) => {
   service
-    .put("users", req.params.uid, [req.body])
+    .put("users", Number(req.params.uid), [req.body])
     .then(() => {
       res.status(200).json({});
     })
@@ -37,7 +37,7 @@ app.put("/users/:uid", (req, res) => {
 
 app.put("/groups/:gid", (req, res) => {
   service
-    .put("groups", req.params.gid, [req.body])
+    .put("groups", Number(req.params.gid), [req.body])
     .then(() => {
       res.status(200).json({});
     })

--- a/skipruntime-ts/examples/groups.ts
+++ b/skipruntime-ts/examples/groups.ts
@@ -8,22 +8,22 @@ import {
 
 import { runService } from "@skipruntime/server";
 
-type UserID = string;
-type GroupID = string;
+type UserID = number;
+type GroupID = number;
 type User = { name: string; active?: boolean; friends: UserID[] };
 type Group = { name: string; members: UserID[] };
 
 // Load initial data from a source-of-truth database (mocked for simplicity)
 const initialData: InitialData<ServiceInputs> = {
   users: [
-    ["bob", [{ name: "Bob", active: true, friends: ["alice", "carol"] }]],
-    ["alice", [{ name: "Alice", active: true, friends: ["bob", "carol"] }]],
-    ["carol", [{ name: "Carol", active: false, friends: ["bob", "alice"] }]],
-    ["eve", [{ name: "Eve", active: true, friends: [] }]],
+    [0, [{ name: "Bob", active: true, friends: [1, 2] }]],
+    [1, [{ name: "Alice", active: true, friends: [0, 2] }]],
+    [2, [{ name: "Carol", active: false, friends: [0, 1] }]],
+    [3, [{ name: "Eve", active: true, friends: [] }]],
   ],
   groups: [
-    ["group1", [{ name: "Group 1", members: ["alice", "carol", "eve"] }]],
-    ["group2", [{ name: "Group 2", members: ["bob", "carol"] }]],
+    [1001, [{ name: "Group 1", members: [1, 2, 3] }]],
+    [1002, [{ name: "Group 2", members: [0, 2] }]],
   ],
 };
 
@@ -64,10 +64,10 @@ class FilterFriends extends OneToManyMapper<GroupID, UserID, UserID> {
 class ActiveFriends implements Resource<ResourceInputs> {
   private readonly uid: UserID;
 
-  constructor(params: { [param: string]: Json }) {
-    if (!params["uid"] || typeof params["uid"] != "string")
-      throw new Error("Missing required string parameter 'uid'");
-    this.uid = params["uid"];
+  constructor(params: Json) {
+    if (typeof params != "number")
+      throw new Error("Missing required number parameter 'uid'");
+    this.uid = params;
   }
 
   instantiate(inputs: ResourceInputs): EagerCollection<GroupID, UserID> {

--- a/skipruntime-ts/examples/utils.ts
+++ b/skipruntime-ts/examples/utils.ts
@@ -57,12 +57,12 @@ export class SkipHttpAccessV1 {
     return Promise.allSettled(promises);
   }
 
-  async log(resource: string, params: { [param: string]: Json }) {
+  async log(resource: string, params: Json) {
     const result = await this.service.getAll(resource, params);
     console.log(JSON.stringify(result));
   }
 
-  request(resource: string, params: { [param: string]: Json }) {
+  request(resource: string, params: Json) {
     this.service
       .getStreamUUID(resource, params)
       .then((uuid) => {
@@ -91,7 +91,7 @@ interface RequestQuery {
   type: "request";
   payload: {
     resource: string;
-    params?: { [param: string]: Json };
+    params?: Json;
     port?: number;
   };
 }
@@ -100,7 +100,7 @@ interface LogQuery {
   type: "log";
   payload: {
     resource: string;
-    params?: { [param: string]: Json };
+    params?: Json;
     port?: number;
   };
 }
@@ -300,7 +300,7 @@ export function run(
           (query: string) => {
             const jsquery = JSON.parse(query) as {
               resource: string;
-              params?: { [param: string]: Json };
+              params?: Json;
             };
             access.request(jsquery.resource, jsquery.params ?? {});
           },
@@ -310,7 +310,7 @@ export function run(
           (query: string) => {
             const jsquery = JSON.parse(query) as {
               resource: string;
-              params?: { [param: string]: Json };
+              params?: Json;
             };
             access
               .log(jsquery.resource, jsquery.params ?? {})

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -72,10 +72,10 @@ export class SkipServiceBroker {
     params: Json,
   ): Promise<Entry<K, V>[]> {
     const [data, _headers] = await fetchJSON<Entry<K, V>[]>(
-      `${this.entrypoint}/v1/snapshot`,
+      `${this.entrypoint}/v1/snapshot/${resource}`,
       "POST",
       {},
-      { resource, params },
+      params,
     );
     return data ?? [];
   }
@@ -93,10 +93,10 @@ export class SkipServiceBroker {
     key: string,
   ): Promise<V[]> {
     const [data, _headers] = await fetchJSON<V[]>(
-      `${this.entrypoint}/v1/snapshot`,
+      `${this.entrypoint}/v1/snapshot/${resource}`,
       "POST",
       {},
-      { resource, key, params },
+      { key, params },
     );
     return data ?? [];
   }
@@ -171,10 +171,10 @@ export class SkipServiceBroker {
    * @returns - UUID that can be used to subscribe to updates to resource instance
    */
   async getStreamUUID(resource: string, params: Json = {}): Promise<string> {
-    return fetch(`${this.entrypoint}/v1/streams`, {
+    return fetch(`${this.entrypoint}/v1/streams/${resource}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ resource, params }),
+      body: JSON.stringify(params),
     }).then((res) => res.text());
   }
 

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -69,7 +69,7 @@ export class SkipServiceBroker {
    */
   async getAll<K extends Json, V extends Json>(
     resource: string,
-    params: { [param: string]: Json },
+    params: Json,
   ): Promise<Entry<K, V>[]> {
     const [data, _headers] = await fetchJSON<Entry<K, V>[]>(
       `${this.entrypoint}/v1/snapshot`,
@@ -89,7 +89,7 @@ export class SkipServiceBroker {
    */
   async getArray<V extends Json>(
     resource: string,
-    params: { [param: string]: Json },
+    params: Json,
     key: string,
   ): Promise<V[]> {
     const [data, _headers] = await fetchJSON<V[]>(
@@ -111,7 +111,7 @@ export class SkipServiceBroker {
    */
   async getUnique<V extends Json>(
     resource: string,
-    params: { [param: string]: Json },
+    params: Json,
     key: string,
   ): Promise<V> {
     return this.getArray<V>(resource, params, key).then((values) => {
@@ -170,10 +170,7 @@ export class SkipServiceBroker {
    * @param params - resource instance parameters
    * @returns - UUID that can be used to subscribe to updates to resource instance
    */
-  async getStreamUUID(
-    resource: string,
-    params: { [param: string]: Json } = {},
-  ): Promise<string> {
+  async getStreamUUID(resource: string, params: Json = {}): Promise<string> {
     return fetch(`${this.entrypoint}/v1/streams`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/skipruntime-ts/native/src/BaseTypes.sk
+++ b/skipruntime-ts/native/src/BaseTypes.sk
@@ -45,10 +45,10 @@ base class ExternalService {
   fun subscribe(
     collection: CollectionWriter,
     resource: String,
-    params: Params,
+    params: SKJSON.CJSON,
   ): void;
 
-  fun unsubscribe(resource: String, params: Params): void;
+  fun unsubscribe(resource: String, params: SKJSON.CJSON): void;
 
   fun shutdown(): void;
 }
@@ -58,7 +58,7 @@ base class Resource {
 }
 
 base class ResourceBuilder {
-  fun build(parameters: Params): Resource;
+  fun build(parameters: SKJSON.CJSON): Resource;
 }
 
 base class Service(

--- a/skipruntime-ts/native/src/Extern.sk
+++ b/skipruntime-ts/native/src/Extern.sk
@@ -146,7 +146,7 @@ native fun subscribeOfExternalService(
   externalSupplier: UInt32,
   collection: String,
   resource: String,
-  params: SKJSON.CJObject,
+  params: SKJSON.CJSON,
 ): void;
 
 @cpp_extern("SkipRuntime_ExternalService__unsubscribe")
@@ -154,7 +154,7 @@ native fun subscribeOfExternalService(
 native fun unsubscribeOfExternalService(
   externalSupplier: UInt32,
   resource: String,
-  params: SKJSON.CJObject,
+  params: SKJSON.CJSON,
 ): void;
 
 @cpp_extern("SkipRuntime_ExternalService__shutdown")
@@ -178,18 +178,18 @@ class ExternExternalService(
   fun subscribe(
     collection: CollectionWriter,
     resource: String,
-    params: Params,
+    params: SKJSON.CJSON,
   ): void {
     subscribeOfExternalService(
       this.eptr.value,
       collection.dirName.toString(),
       resource,
-      jsonParams(params),
+      params,
     )
   }
 
-  fun unsubscribe(resource: String, params: Params): void {
-    unsubscribeOfExternalService(this.eptr.value, resource, jsonParams(params))
+  fun unsubscribe(resource: String, params: SKJSON.CJSON): void {
+    unsubscribeOfExternalService(this.eptr.value, resource, params)
   }
 
   fun shutdown(): void {
@@ -273,7 +273,7 @@ class ExternResource(eptr: SKStore.ExternalPointer) extends Resource {
 @debug
 native fun buildOfResourceBuilder(
   builder: UInt32,
-  params: SKJSON.CJObject,
+  params: SKJSON.CJSON,
 ): Resource;
 
 @cpp_extern("SkipRuntime_deleteResourceBuilder")
@@ -290,8 +290,8 @@ fun createResourceBuilder(resourceBuilder: UInt32): ExternResourceBuilder {
 class ExternResourceBuilder(
   eptr: SKStore.ExternalPointer,
 ) extends ResourceBuilder {
-  fun build(params: Params): Resource {
-    buildOfResourceBuilder(this.eptr.value, jsonParams(params))
+  fun build(params: SKJSON.CJSON): Resource {
+    buildOfResourceBuilder(this.eptr.value, params)
   }
 }
 
@@ -608,15 +608,10 @@ class JSONReducer(
 fun createResourceOfRuntime(
   identifier: String,
   resource: String,
-  jsonParams: SKJSON.CJObject,
+  params: SKJSON.CJSON,
 ): Float {
   SKStore.runWithResult(context ~> {
-    createReactiveResource(
-      context,
-      identifier,
-      resource,
-      Params::create(jsonParams),
-    )
+    createReactiveResource(context, identifier, resource, params)
   }) match {
   | Success _ -> 0.0
   | Failure(err) -> getErrorHdl(err)
@@ -626,19 +621,19 @@ fun createResourceOfRuntime(
 @export("SkipRuntime_Runtime__getAll")
 fun getAllOfRuntime(
   resource: String,
-  jsonParams: SKJSON.CJObject,
+  params: SKJSON.CJSON,
   optRequest: ?Request,
 ): SKJSON.CJSON {
   (getContext() match {
   | Some(context) ->
     try {
-      Success(getAll(context, resource, Params::create(jsonParams), optRequest))
+      Success(getAll(context, resource, params, optRequest))
     } catch {
     | ex -> Failure(ex)
     }
   | _ ->
     SKStore.runWithResult(context ~> {
-      getAll(context, resource, Params::create(jsonParams), optRequest)
+      getAll(context, resource, params, optRequest)
     })
   }) match {
   | Success(result) ->
@@ -666,28 +661,20 @@ fun getAllOfRuntime(
 @export("SkipRuntime_Runtime__getForKey")
 fun getForKeyOfRuntime(
   resource: String,
-  jsonParams: SKJSON.CJObject,
+  params: SKJSON.CJSON,
   key: SKJSON.CJSON,
   optRequest: ?Request,
 ): SKJSON.CJSON {
   (getContext() match {
   | Some(context) ->
     try {
-      Success(
-        getForKey(
-          context,
-          resource,
-          Params::create(jsonParams),
-          key,
-          optRequest,
-        ),
-      )
+      Success(getForKey(context, resource, params, key, optRequest))
     } catch {
     | ex -> Failure(ex)
     }
   | _ ->
     SKStore.runWithResult(context ~> {
-      getForKey(context, resource, Params::create(jsonParams), key, optRequest)
+      getForKey(context, resource, params, key, optRequest)
     })
   }) match {
   | Success(result) ->
@@ -778,9 +765,9 @@ fun jsonExtractOfContext(
 fun useExternalResource(
   service: String,
   identifier: String,
-  jsonParams: SKJSON.CJObject,
+  params: SKJSON.CJSON,
 ): String {
-  useExternalCollection(service, identifier, Params::create(jsonParams)).getId()
+  useExternalCollection(service, identifier, params).getId()
 }
 
 /************ initService ****************/

--- a/skipruntime-ts/native/src/Runtime.sk
+++ b/skipruntime-ts/native/src/Runtime.sk
@@ -22,43 +22,12 @@ class ExistingSubscriptionException() extends Exception {
   }
 }
 
-class Params private (
-  sortedKeys: Array<String>,
-  sortedVals: Array<SKJSON.CJSON>,
-) extends SKStore.File uses Orderable {
-  static fun create(jsonObj: SKJSON.CJObject): this {
-    jsonObj match {
-    | SKJSON.CJObject(fields) ->
-      sortedItems = fields.items().collect(Array).sortedBy(x ~> x.i0);
-      Params(sortedItems.map(kv ~> kv.i0), sortedItems.map(kv ~> kv.i1))
-    };
-  }
+class Params(json: SKJSON.CJSON) extends SKStore.File uses Orderable {
   fun compare(other: Params): Order {
-    kcomp = this.sortedKeys.compare(other.sortedKeys);
-    if (kcomp == EQ()) {
-      for (i in Range(0, this.sortedVals.size())) {
-        vcomp = this.sortedVals[i].compare(other.sortedVals[i]);
-        if (vcomp != EQ()) {
-          break vcomp
-        }
-      } else {
-        EQ()
-      }
-    } else {
-      kcomp
-    }
-  }
-  fun items(): mutable Iterator<(String, SKJSON.CJSON)> {
-    for (i in Range(0, this.sortedKeys.size())) {
-      yield (this.sortedKeys[i], this.sortedVals[i])
-    }
+    this.json.compare(other.json)
   }
   fun toString(): String {
-    vec = mutable Vector[];
-    for ((k, v) in this.items()) {
-      vec.push(`${k}:${v.prettyPrint()}`);
-    };
-    `{${vec.join(",")}}`
+    this.json.prettyPrint()
   }
 }
 
@@ -102,11 +71,11 @@ class ResourceCollection(value: Collection) extends SKStore.File
 
 class ResourceDef(
   name: String,
-  params: Params,
+  params: SKJSON.CJSON,
 ) extends SKStore.File, SKStore.Key {
   //
   fun toString(): String {
-    `${this.name}:${this.params.toString()}`
+    `${this.name}:${this.params.prettyPrint()}`
   }
 }
 
@@ -545,7 +514,7 @@ class LinkToResource(
   supplier: ExternalService,
   writer: CollectionWriter,
   name: String,
-  params: Params,
+  params: SKJSON.CJSON,
 ) extends SKStore.Postponable {
   //
   fun perform(context: mutable SKStore.Context): void {
@@ -559,7 +528,7 @@ class LinkToResource(
 class CloseResource(
   supplier: ExternalService,
   name: String,
-  params: Params,
+  params: SKJSON.CJSON,
 ) extends SKStore.Postponable {
   fun perform(context: mutable SKStore.Context): void {
     pushContext(context);
@@ -627,7 +596,7 @@ fun jsonExtract(from: SKJSON.CJObject, pattern: String): Array<SKJSON.CJSON> {
 fun useExternalCollection(
   supplier: String,
   resource: String,
-  params: Params,
+  params: SKJSON.CJSON,
 ): Collection {
   getContext() match {
   | Some(context) ->
@@ -649,7 +618,7 @@ fun useExternalCollection(
       SKStore.IID::keyType,
       Params::type,
       paramsDir,
-      Array[(SKStore.IID(0), params)],
+      Array[(SKStore.IID(0), Params(params))],
     );
     collectionHdl = hdl.map(
       SKStore.IID::keyType,
@@ -657,12 +626,7 @@ fun useExternalCollection(
       context,
       dirName,
       (context, writer, key, it) ~> {
-        resource_params = it.first;
-        name = mutable Vector<String>[];
-        resource_params.items().each((kv) ->
-          name.push(`${kv.i0}:${kv.i1.prettyPrint()}`)
-        );
-        storeDir = dirName.sub(base64(name.join("|")));
+        storeDir = dirName.sub(base64(it.first.toString()));
         store = context.mkdir(
           kKeyToKey,
           kFileToFile,
@@ -674,10 +638,10 @@ fun useExternalCollection(
               externalSupplier,
               CollectionWriter(storeDir),
               resource,
-              resource_params,
+              it.first.json,
             ),
           ),
-          Some(CloseResource(externalSupplier, resource, resource_params)),
+          Some(CloseResource(externalSupplier, resource, it.first.json)),
         );
         writer.set(key, Handle(store));
       },
@@ -1214,7 +1178,7 @@ value class GetResult<T>(
 fun getAll(
   context: mutable SKStore.Context,
   resourceName: String,
-  params: Params,
+  params: SKJSON.CJSON,
   optRequest: ?Request,
 ): GetResult<Values> {
   resourceInstanceId = Ksuid::create().toString();
@@ -1251,7 +1215,7 @@ fun getAll(
 fun getForKey(
   context: mutable SKStore.Context,
   resourceName: String,
-  params: Params,
+  params: SKJSON.CJSON,
   key: SKJSON.CJSON,
   optRequest: ?Request,
 ): GetResult<Array<SKJSON.CJSON>> {
@@ -1466,7 +1430,7 @@ fun createReactiveResource(
   context: mutable SKStore.Context,
   identifier: String,
   resource: String,
-  params: Params,
+  params: SKJSON.CJSON,
 ): ResourceInfo {
   definition = ResourceDef(resource, params);
   resourceHdl = SKStore.EHandle(

--- a/skipruntime-ts/native/src/Utils.sk
+++ b/skipruntime-ts/native/src/Utils.sk
@@ -151,14 +151,14 @@ fun base64<T: Show>(toEncode: T): String {
   | None() -> ""
   }
 }
-fun toResourceId(resource: String, params: Params): String {
-  `${resource}_${base64(params.toString())}`
+fun toResourceId(resource: String, params: SKJSON.CJSON): String {
+  `${resource}_${base64(params.prettyPrint())}`
 }
 
 fun toSuppliedResourceId(
   supplier: String,
   resource: String,
-  params: Params,
+  params: SKJSON.CJSON,
 ): String {
   `${supplier}_${toResourceId(resource, params)}`;
 }
@@ -175,12 +175,6 @@ fun collectionsByName(collections: Map<String, Collection>): SKJSON.CJObject {
   fields = mutable Vector[];
   collections.each((k, c) -> fields.push((k, SKJSON.CJString(c.getId()))));
   SKJSON.CJObject(SKJSON.CJFields::create(fields.toArray(), x -> x));
-}
-
-fun jsonParams(params: Params): SKJSON.CJObject {
-  SKJSON.CJObject(
-    SKJSON.CJFields::create(params.items().collect(Array), x -> x),
-  )
 }
 
 module end;

--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -18,7 +18,7 @@ export function controlService(service: ServiceInstance): express.Express {
       service.instantiateResource(
         uuid,
         req.body.resource as string,
-        req.body.params as { [param: string]: Json },
+        req.body as Json,
       );
       res.status(201).send(uuid);
     } catch (e: unknown) {
@@ -41,7 +41,7 @@ export function controlService(service: ServiceInstance): express.Express {
   app.post("/v1/snapshot", (req, res) => {
     try {
       const resource = req.body.resource as string;
-      const params = req.body.params as { [param: string]: Json };
+      const params = req.body as Json;
       const callbacks = {
         resolve: (data: Json[]) => {
           res.status(200).json(data);

--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -9,17 +9,13 @@ import type {
 
 export function controlService(service: ServiceInstance): express.Express {
   const app = express();
-  app.use(express.json());
+  app.use(express.json({ strict: false }));
 
   // Streaming control API.
-  app.post("/v1/streams", (req, res) => {
+  app.post("/v1/streams/:resource", (req, res) => {
     try {
       const uuid = crypto.randomUUID();
-      service.instantiateResource(
-        uuid,
-        req.body.resource as string,
-        req.body as Json,
-      );
+      service.instantiateResource(uuid, req.params.resource, req.body as Json);
       res.status(201).send(uuid);
     } catch (e: unknown) {
       console.log(e);
@@ -38,10 +34,8 @@ export function controlService(service: ServiceInstance): express.Express {
   });
 
   // READS
-  app.post("/v1/snapshot", (req, res) => {
+  app.post("/v1/snapshot/:resource", (req, res) => {
     try {
-      const resource = req.body.resource as string;
-      const params = req.body as Json;
       const callbacks = {
         resolve: (data: Json[]) => {
           res.status(200).json(data);
@@ -50,11 +44,37 @@ export function controlService(service: ServiceInstance): express.Express {
           res.status(500).json(err instanceof Error ? err.message : err);
         },
       };
-      if (req.body.key) {
-        service.getArray(resource, req.body.key, params, callbacks);
-      } else {
-        service.getAll(resource, params, callbacks);
-      }
+      service.getAll(req.params.resource, req.body as Json, callbacks);
+    } catch (e: unknown) {
+      console.log(e);
+      res.status(500).json(e instanceof Error ? e.message : e);
+    }
+  });
+
+  app.post("/v1/snapshot/:resource/lookup", (req, res) => {
+    try {
+      const callbacks = {
+        resolve: (data: Json[]) => {
+          res.status(200).json(data);
+        },
+        reject: (err: unknown) => {
+          res.status(500).json(err instanceof Error ? err.message : err);
+        },
+      };
+      if (
+        typeof req.body != "object" ||
+        !("key" in req.body) ||
+        !("params" in req.body)
+      )
+        throw new Error(
+          `Invalid request body for synchronous lookup: ${JSON.stringify(req.body)}`,
+        );
+      service.getArray(
+        req.params.resource,
+        req.body.key,
+        req.body.params as Json,
+        callbacks,
+      );
     } catch (e: unknown) {
       console.log(e);
       res.status(500).json(e instanceof Error ? e.message : e);

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -25,12 +25,19 @@ export type SkipServer = {
  *
  * The control API responds to the following HTTP requests:
  *
- * - `POST /v1/snapshot`:
- *   Synchronous read of a resource.
+ * - `POST /v1/snapshot/:resource`:
+ *   Synchronous read of an entire resource.
  *
- *   Requires a JSON-encoded request body of the form `{ resource: string; params: { [param: string]: Json }; key?: Json }`.
- *   Instantiates the named `resource` with the given `params`, and responds with the values associated with the given `key` or with the entire contents of the resource if no `key` is provided.
- *   If `key` is provided, the returned data will be a JSON-encoded value of type `Json[]`: an array of the `key`'s values; otherwise, it will be a JSON-encoded value of type `[Json, Json[]][]`: an array of entries, each of which associates a key to an array of its values.
+ *  The body of the request must be a JSON-encoded value, which is passed as parameters to the resource constructor.
+ *  Responds with the current contents of the named `resource` with the given parameters, instantiating the resource if needed.
+ *  Data is returned as a JSON-encoded array of key/value entries, with each entry a tuple of the form `[key, [value1, value2, ...]]`.
+ *
+ * - `POST /v1/snapshot/:resource/lookup`:
+ *   Synchronous read of a specific key in a resource.
+ *
+ *  The body of the request must be a JSON-encoded object with a `key` field and a `params` field.
+ *  Responds with the values associated to `key` in the named `resource` with the given parameters, instantiating the resource if needed.
+ *  Data is returned as a JSON-encoded array of values.
  *
  * - `PATCH /v1/inputs/:collection`:
  *   Partial write (update only the specified keys) of an input collection.
@@ -39,12 +46,19 @@ export type SkipServer = {
  *   The body of the request must be a JSON-encoded value of type `CollectionUpdate.values`, that is `[Json, Json[]][]`: an array of entries each of which associates a key to an array of its new values.
  *   Updates the named `collection` with the key-values entries in the request body.
  *
- * - `POST /v1/streams`:
+ * - `PUT /v1/inputs/:collection/:key`:
+ *   Update of a single key of an input collection.
+ *
+ *   The `collection` must be the name of one of the service's input collections, that is, one of the keys of the `Inputs` type parameter.
+ *   The body of the request must be a JSON-encoded array of the `key`'s new values.
+ *   Updates the named `collection` to associate the `key` with the values in the request body.
+ *
+ * - `POST /v1/streams/:resource`:
  *   Instantiate a resource and return a UUID to subscribe to updates.
  *
  *   Requires the request to have a `Content-Type: application/json` header.
- *   The body of the request must be a JSON-encoded value of type `{ resource: string, params: { [param: string]: Json } }`.
- *   Instantiates the named `resource` with parameters `params` and responds with a UUID that can be used to subscribe to updates.
+ *   The body of the request must be a JSON-encoded value, which will be passed as parameters to the resource constructor.
+ *   Instantiates the named `resource` with the given parameters and responds with a UUID that can be used to subscribe to updates.
  *
  * - `DELETE /v1/streams/:uuid`:
  *   Destroy a resource instance.

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -31,22 +31,18 @@ type GetResult<T> = {
 interface ServiceInstance {
   getAll<K extends Json, V extends Json>(
     resource: string,
-    params?: { [param: string]: Json },
+    params?: Json,
   ): GetResult<Entry<K, V>[]>;
   getArray<V extends Json>(
     resource: string,
     key: string | number,
-    params?: { [param: string]: Json },
+    params?: Json,
   ): GetResult<V[]>;
   update<K extends Json, V extends Json>(
     collection: string,
     entries: Entry<K, V>[],
   ): void;
-  instantiateResource(
-    identifier: string,
-    resource: string,
-    params: { [param: string]: Json },
-  ): void;
+  instantiateResource(identifier: string, resource: string, params: Json): void;
   closeResourceInstance(resourceInstanceId: string): void;
   close(): void;
 }
@@ -362,7 +358,9 @@ type StructuredParams = { x: number; y: { a: number; bs: number[] } };
 class JsonParamsResource implements Resource<Input_NN> {
   private offset: number;
 
-  constructor(params: { [param: string]: Json }) {
+  constructor(params: Json) {
+    if (typeof params != "object" || !("offsets" in params))
+      throw new Error("Malformed resource params");
     const offsets: StructuredParams = params["offsets"] as StructuredParams;
     this.offset =
       offsets.x + offsets.y.a + offsets.y.bs.reduce((x, y) => x + y, 0);

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -199,18 +199,18 @@ export interface FromWasm {
   SkipRuntime_Runtime__createResource(
     identifier: ptr<Internal.String>,
     resource: ptr<Internal.String>,
-    jsonParams: ptr<Internal.CJObject>,
+    params: ptr<Internal.CJSON>,
   ): Handle<Error>;
 
   SkipRuntime_Runtime__getAll(
     resource: ptr<Internal.String>,
-    jsonParams: ptr<Internal.CJObject>,
+    params: ptr<Internal.CJSON>,
     request: ptr<Internal.Request> | null,
   ): ptr<Internal.CJObject | Internal.CJFloat>;
 
   SkipRuntime_Runtime__getForKey(
     resource: ptr<Internal.String>,
-    jsonParams: ptr<Internal.CJObject>,
+    params: ptr<Internal.CJSON>,
     key: ptr<Internal.CJSON>,
     request: ptr<Internal.Request> | null,
   ): ptr<Internal.CJObject | Internal.CJFloat>;
@@ -259,7 +259,7 @@ export interface FromWasm {
   SkipRuntime_Context__useExternalResource(
     service: ptr<Internal.String>,
     identifier: ptr<Internal.String>,
-    params: ptr<Internal.CJObject>,
+    params: ptr<Internal.CJSON>,
   ): ptr<Internal.String>;
 
   // Checker
@@ -304,13 +304,13 @@ interface ToWasm {
     supplier: Handle<ExternalService>,
     collection: ptr<Internal.String>,
     resource: ptr<Internal.String>,
-    params: ptr<Internal.CJObject>,
+    params: ptr<Internal.CJSON>,
   ): void;
 
   SkipRuntime_ExternalService__unsubscribe(
     supplier: Handle<ExternalService>,
     skresource: ptr<Internal.String>,
-    skparams: ptr<Internal.CJObject>,
+    skparams: ptr<Internal.CJSON>,
   ): void;
 
   SkipRuntime_ExternalService__shutdown(
@@ -332,7 +332,7 @@ interface ToWasm {
 
   SkipRuntime_ResourceBuilder__build(
     builder: Handle<ResourceBuilder>,
-    params: ptr<Internal.CJObject>,
+    params: ptr<Internal.CJSON>,
   ): ptr<Internal.Resource>;
 
   SkipRuntime_deleteResourceBuilder(builder: Handle<ResourceBuilder>): void;
@@ -662,36 +662,36 @@ export class WasmFromBinding implements FromBinding {
   SkipRuntime_Runtime__createResource(
     identifier: string,
     resource: string,
-    jsonParams: Pointer<Internal.CJObject>,
+    params: Pointer<Internal.CJSON>,
   ): Handle<Error> {
     return this.fromWasm.SkipRuntime_Runtime__createResource(
       this.utils.exportString(identifier),
       this.utils.exportString(resource),
-      toPtr(jsonParams),
+      toPtr(params),
     );
   }
 
   SkipRuntime_Runtime__getAll(
     resource: string,
-    jsonParams: Pointer<Internal.CJObject>,
+    params: Pointer<Internal.CJSON>,
     request: Nullable<Pointer<Internal.Request>>,
   ): Pointer<Internal.CJObject | Internal.CJFloat> {
     return this.fromWasm.SkipRuntime_Runtime__getAll(
       this.utils.exportString(resource),
-      toPtr(jsonParams),
+      toPtr(params),
       toNullablePtr(request),
     );
   }
 
   SkipRuntime_Runtime__getForKey(
     resource: string,
-    jsonParams: Pointer<Internal.CJObject>,
+    params: Pointer<Internal.CJSON>,
     key: Pointer<Internal.CJSON>,
     request: Pointer<Internal.Request> | null,
   ): Pointer<Internal.CJObject | Internal.CJFloat> {
     return this.fromWasm.SkipRuntime_Runtime__getForKey(
       this.utils.exportString(resource),
-      toPtr(jsonParams),
+      toPtr(params),
       toPtr(key),
       toNullablePtr(request),
     );
@@ -765,7 +765,7 @@ export class WasmFromBinding implements FromBinding {
   SkipRuntime_Context__useExternalResource(
     service: string,
     identifier: string,
-    params: Pointer<Internal.CJObject>,
+    params: Pointer<Internal.CJSON>,
   ): string {
     return this.utils.importString(
       this.fromWasm.SkipRuntime_Context__useExternalResource(
@@ -887,7 +887,7 @@ class LinksImpl implements Links {
 
   buildOfResourceBuilder(
     skbuilder: Handle<ResourceBuilder>,
-    skparams: ptr<Internal.CJObject>,
+    skparams: ptr<Internal.CJSON>,
   ): ptr<Internal.Resource> {
     return toPtr(
       this.tobinding.SkipRuntime_ResourceBuilder__build(skbuilder, skparams),
@@ -978,7 +978,7 @@ class LinksImpl implements Links {
     sksupplier: Handle<ExternalService>,
     skwriter: ptr<Internal.String>,
     skresource: ptr<Internal.String>,
-    skparams: ptr<Internal.CJObject>,
+    skparams: ptr<Internal.CJSON>,
   ) {
     this.tobinding.SkipRuntime_ExternalService__subscribe(
       sksupplier,
@@ -991,7 +991,7 @@ class LinksImpl implements Links {
   unsubscribeOfExternalService(
     sksupplier: Handle<ExternalService>,
     skresource: ptr<Internal.String>,
-    skparams: ptr<Internal.CJObject>,
+    skparams: ptr<Internal.CJSON>,
   ) {
     this.tobinding.SkipRuntime_ExternalService__unsubscribe(
       sksupplier,

--- a/www/docs/getting_started.md
+++ b/www/docs/getting_started.md
@@ -140,9 +140,10 @@ class FilterFriends extends OneToOneMapper<GroupID, UserID[], UserID[]> {
 class ActiveFriends implements Resource<ResourceInputs> {
   private readonly uid: UserID;
 
-  constructor(params: { [param: string]: Json }) {
-    if (!params["uid"]) throw new Error("Missing required parameter 'uid'");
-    this.uid = params["uid"];
+  constructor(params: Json) {
+    if (typeof params != "number")
+      throw new Error("Missing required number parameter 'uid'");
+    this.uid = params;
   }
 
   instantiate(inputs: ResourceInputs): EagerCollection<GroupID, UserID[]> {

--- a/www/docs/resources.md
+++ b/www/docs/resources.md
@@ -77,22 +77,25 @@ The control API (on port 8081 by default) surfaces resource instantiation/deleti
 Resource instantiation and deletion are controlled by two routes:
 
 ```
-POST /v1/streams
+POST /v1/streams/:resource
 DELETE /v1/streams/:uuid
 ```
 
-The `POST` route instantiates a resource according to the JSON-encoded request body (consisting of the resource identifier and any parameters, structured as `{ resource: string; params: { [param: string]: any } }`) and returns a UUID identifying the resource, which can then be used in a query to the streaming API.
+The `POST` route instantiates the named resource parameterized by the JSON-encoded request body and returns a UUID identifying the resource, which can then be used in a query to the streaming API.
 The `DELETE` route closes and tears down the resource instance identified by its `uuid` parameter, terminating any active streams.
 
-Synchronous reads from reactive resources can either access the resource in its entirety or read the data for a single key, using route:
+Synchronous reads from reactive resources can either access the resource in its entirety or read the data for a single key, using routes:
 
 ```
-POST /v1/snapshot
+POST /v1/snapshot/:resource
+POST /v1/snapshot/:resource/lookup
 ```
 
-This `POST` route requires a JSON-encoded request body of the form `{ resource: string; params: { [param: string]: any }; key?: any }`.
-It instantiates a resource if needed to according to the `resource` and `params` fields of the request body, then either returns the values indicated by the `key` or _all_ keys/values if no `key` is provided.
-For reads of a specific `key`, data is returned as an array of values associated to that key; for reads of an entire resource, data is returned as an array of key/value entries, with each entry a tuple of the form `[key, [value1, value2, ...]]`.
+The first route returns all of the entries in the named `resource`, using the parameters provided in the JSON-encoded request body.
+It instantiates the resource if needed, then returns a JSON-encoded array of key/value entries, with each entry a tuple of the form `[key, [value1, value2, ...]]`.
+
+The second route requires the request body to be a JSON-encoded value with a `key` field and a `params` field.
+It instantiates the resource if needed, then returns a JSON-encoded array of all values associated to `key` in the resource.
 
 Lastly, clients can update the input collections of a reactive service:
 


### PR DESCRIPTION
This PR follows up on #590 based on our conversation at yesterday's meeting.
(It's also stacked on that PR for hopefully easier reviewing)

I implemented more or less exactly the API we discussed, with one change:  I added a single-key-lookup synchronous read method to the API, as it was used in some of the examples and feels much more natural this way than forcing creation of another resource, then calling `getAll` on that resource instance (which, using its params, filters out the desired key), then stripping away the redundant structure in the response (which would always have the form `[[key, [val1, val2,...]]]` instead of just `[val1, val2, ...]`, etc.

So, I propose the API in this PR, with two synchronous read routes as documented in `skipruntime-ts/server/src/server.ts` and `www/docs/resources.md`, copied here:

Synchronous reads from reactive resources can either access the resource in its entirety or read the data for a single key, using routes:

```
POST /v1/snapshot/:resource
POST /v1/snapshot/:resource/lookup
```

The first route returns all of the values in the named `resource`, using the parameters provided in the JSON-encoded request body.
It instantiates the resource if needed, then returns a JSON-encoded array of key/value entries, with each entry a tuple of the form `[key, [value1, value2, ...]]`.

The second route requires the request body to be a JSON-encoded value with a `key` field and a `params` field.
It instantiates the resource if needed, then returns a JSON-encoded array of all values associated to `key` in the resource.
