### PR TITLE
Return Iterable from LazyCompute

### DIFF
--- a/skipruntime-ts/api/src/api.ts
+++ b/skipruntime-ts/api/src/api.ts
@@ -263,7 +263,7 @@ export interface EagerCollection<K extends Json, V extends Json>
  * The type of a _lazy_ reactive function which produces a value for some `key`, possibly using a `self` reference to get/produce other lazily-computed results.
  */
 export interface LazyCompute<K extends Json, V extends Json> {
-  compute(self: LazyCollection<K, V>, key: K): Nullable<V>;
+  compute(self: LazyCollection<K, V>, key: K): Iterable<V>;
 }
 
 /**

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -785,11 +785,11 @@ export class ToBinding {
   ): Pointer<Internal.CJArray> {
     const skjson = this.getJsonConverter();
     const lazyCompute = this.handles.get(sklazyCompute);
-    const computed = lazyCompute.compute(
+    const result = lazyCompute.compute(
       new LazyCollectionImpl<Json, Json>(self, this.refs()),
       skjson.importJSON(skkey) as Json,
     );
-    return skjson.exportJSON(computed ? [computed] : []);
+    return skjson.exportJSON(Array.from(result));
   }
 
   SkipRuntime_deleteLazyCompute(lazyCompute: Handle<JSONLazyCompute>): void {

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -14,7 +14,10 @@ import { runService } from "@skipruntime/server";
 class ComputeExpression implements LazyCompute<string, string> {
   constructor(private skall: EagerCollection<string, Json>) {}
 
-  compute(selfHdl: LazyCollection<string, string>, key: string): string | null {
+  compute(
+    selfHdl: LazyCollection<string, string>,
+    key: string,
+  ): Iterable<string> {
     const getComputed = (key: string) => {
       const v = selfHdl.getUnique(key);
       if (typeof v == "number") return v;
@@ -32,19 +35,21 @@ class ComputeExpression implements LazyCompute<string, string> {
           case "A1 + A2": {
             const v1 = getComputed("A1");
             const v2 = getComputed("A2");
-            return (v1 + v2).toString();
+            return [(v1 + v2).toString()];
           }
           case "A3 * A2":
-            return (getComputed("A3") * getComputed("A2")).toString();
+            return [(getComputed("A3") * getComputed("A2")).toString()];
           default:
-            return "# Not managed expression.";
+            return [
+              `# Syntax error; unmanaged expression: "${+v.substring(1)}"`,
+            ];
         }
       } else {
         return v;
       }
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : JSON.stringify(e);
-      return "# " + msg;
+      return ["# " + msg];
     }
   }
 }

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -220,8 +220,11 @@ const slicedMap1Service: SkipService<Input_NN, Input_NN> = {
 class TestLazyAdd implements LazyCompute<number, number> {
   constructor(private readonly other: EagerCollection<number, number>) {}
 
-  compute(_selfHdl: LazyCollection<number, number>, key: number): number {
-    return this.other.getUnique(key) + 2;
+  compute(
+    _selfHdl: LazyCollection<number, number>,
+    key: number,
+  ): Iterable<number> {
+    return [this.other.getUnique(key) + 2];
   }
 }
 


### PR DESCRIPTION
I went to see what it would take to do this re: #607 and turns out... very little!  no Skiplang changes needed, since the nullable was already being converted to a JS array (at skipruntime-ts/core/src/index.ts#792)

closes #607