### PR TITLE
Native implementations of reducers and typing improvements throughout `skipruntime-ts/native`

### DIFF
--- a/.circleci/generate_config.sh
+++ b/.circleci/generate_config.sh
@@ -33,14 +33,14 @@ then
 EOF
 fi
 
-if (( $skc != 0 ))
-then
-    cat <<EOF
-  compiler:
-    jobs:
-      - compiler
-EOF
-fi
+#if (( $skc != 0 ))
+#then
+#    cat <<EOF
+#  compiler:
+#    jobs:
+#      - compiler
+#EOF
+#fi
 
 if (( $skstore != 0 ))
 then

--- a/skiplang/prelude/src/skstore/Handle.sk
+++ b/skiplang/prelude/src/skstore/Handle.sk
@@ -258,6 +258,60 @@ fun sumReducer(): EReducer<IntFile, IntFile> {
   };
 }
 
+fun minReducer(): EReducer<IntFile, IntFile> {
+  EReducer{
+    type => IntFile::type,
+    canReset => true,
+    init => iter ~> {
+      min: ?Int = None();
+      for (x in iter) {
+        if (min.isNone() || x.value < min.fromSome()) !min = Some(x.value);
+      };
+      min match {
+      | Some(x) -> Array[IntFile(x)]
+      | None() -> Array[]
+      }
+    },
+    update => (state, old, new) ~> {
+      min = state[0].value;
+      for (x in new) {
+        if (x.value < min) !min = x.value;
+      };
+      for (x in old) {
+        if (x.value <= min) return None()
+      };
+      Some(Array[IntFile(min)])
+    },
+  }
+}
+
+fun maxReducer(): EReducer<IntFile, IntFile> {
+  EReducer{
+    type => IntFile::type,
+    canReset => true,
+    init => iter ~> {
+      max: ?Int = None();
+      for (x in iter) {
+        if (max.isNone() || x.value > max.fromSome()) !max = Some(x.value);
+      };
+      max match {
+      | Some(x) -> Array[IntFile(x)]
+      | None() -> Array[]
+      }
+    },
+    update => (state, old, new) ~> {
+      max = state[0].value;
+      for (x in new) {
+        if (x.value > max) !max = x.value;
+      };
+      for (x in old) {
+        if (x.value >= max) return None()
+      };
+      Some(Array[IntFile(max)])
+    },
+  }
+}
+
 /*****************************************************************************/
 /* The preferred way of accessing the file-system. */
 /*****************************************************************************/

--- a/skiplang/prelude/ts/binding/src/index.ts
+++ b/skiplang/prelude/ts/binding/src/index.ts
@@ -7,6 +7,12 @@ export interface Pointer<InternalType extends T<any>> {
   [skpointer]: InternalType;
 }
 
+export const sknative: unique symbol = Symbol.for("Skip.native_stub");
+
+export interface NativeStub {
+  [sknative]: string;
+}
+
 export type float = number;
 export type int = number;
 

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -142,10 +142,19 @@ export interface FromBinding {
     mapper: Pointer<Internal.Mapper>,
     reducer: Pointer<Internal.Reducer>,
   ): string;
+  SkipRuntime_Collection__nativeMapReduce(
+    collection: string,
+    mapper: Pointer<Internal.Mapper>,
+    reducer: string,
+  ): string;
 
   SkipRuntime_Collection__reduce(
     collection: string,
     reducer: Pointer<Internal.Reducer>,
+  ): string;
+  SkipRuntime_Collection__nativeReduce(
+    collection: string,
+    reducer: string,
   ): string;
 
   SkipRuntime_Collection__slice(

--- a/skipruntime-ts/core/src/utils.ts
+++ b/skipruntime-ts/core/src/utils.ts
@@ -1,22 +1,20 @@
 import type { Nullable } from "@skip-wasm/std";
-import { ManyToOneMapper } from "@skipruntime/api";
-import type { Reducer, Values, Json } from "@skipruntime/api";
+import { type NativeStub, sknative } from "@skiplang/std";
+import type { Reducer, Json } from "@skipruntime/api";
 
 /**
  * `Reducer` to maintain the sum of input values.
  *
  * A `Reducer` that maintains the sum of values as they are added and removed from a collection.
  */
-export class Sum implements Reducer<number, number> {
-  initial = 0;
+export class Sum implements NativeStub, Reducer<number, number> {
+  [sknative] = "sum";
 
-  add(accum: number, value: number): number {
-    return accum + value;
-  }
-
-  remove(accum: number, value: number): Nullable<number> {
-    return accum - value;
-  }
+  // Lie to TypeScript that this implements Reducer, but leave out any implementations
+  // since we provide a native implementation.
+  initial!: number;
+  add!: (accum: number) => number;
+  remove!: (accum: number) => Nullable<number>;
 }
 
 /**
@@ -24,16 +22,14 @@ export class Sum implements Reducer<number, number> {
  *
  * A `Reducer` that maintains the minimum of values as they are added and removed from a collection.
  */
-export class Min implements Reducer<number, number> {
-  initial = null;
+export class Min implements NativeStub, Reducer<number, number> {
+  [sknative] = "min";
 
-  add(accum: Nullable<number>, value: number): number {
-    return accum === null ? value : Math.min(accum, value);
-  }
-
-  remove(accum: number, value: number): Nullable<number> {
-    return value > accum ? accum : null;
-  }
+  // Lie to TypeScript that this implements Reducer, but leave out any implementations
+  // since we provide a native implementation.
+  initial!: number;
+  add!: (accum: number) => number;
+  remove!: (accum: number) => Nullable<number>;
 }
 
 /**
@@ -41,16 +37,14 @@ export class Min implements Reducer<number, number> {
  *
  * A `Reducer` that maintains the maximum of values as they are added and removed from a collection.
  */
-export class Max implements Reducer<number, number> {
-  initial = null;
+export class Max implements NativeStub, Reducer<number, number> {
+  [sknative] = "max";
 
-  add(accum: Nullable<number>, value: number): number {
-    return accum === null ? value : Math.max(accum, value);
-  }
-
-  remove(accum: number, value: number): Nullable<number> {
-    return value < accum ? accum : null;
-  }
+  // Lie to TypeScript that this implements Reducer, but leave out any implementations
+  // since we provide a native implementation.
+  initial!: number;
+  add!: (accum: number) => number;
+  remove!: (accum: number) => Nullable<number>;
 }
 
 /**
@@ -58,31 +52,12 @@ export class Max implements Reducer<number, number> {
  *
  * A `Reducer` that maintains the number of values as they are added and removed from a collection.
  */
-export class Count<T extends Json> implements Reducer<T, number> {
-  initial = 0;
+export class Count<T extends Json> implements Reducer<T, number>, NativeStub {
+  [sknative] = "count";
 
-  add(accum: number): number {
-    return accum + 1;
-  }
-
-  remove(accum: number): Nullable<number> {
-    return accum - 1;
-  }
-}
-
-/**
- * `Mapper` to count input values.
- *
- * A `Mapper` that associates each key in the output with the number of values it is associated with in the input.
- *
- * @remarks
- * If there are many values associated to keys in a collection, and they are updated frequently, using the `Count` `Reducer` instead could be more efficient.
- */
-export class CountMapper<
-  K extends Json,
-  V extends Json,
-> extends ManyToOneMapper<K, V, number> {
-  mapValues(values: Values<V>): number {
-    return values.toArray().length;
-  }
+  // Lie to TypeScript that this implements Reducer, but leave out any implementations
+  // since we provide a native implementation.
+  initial!: number;
+  add!: (accum: number) => number;
+  remove!: (accum: number) => Nullable<number>;
 }

--- a/skipruntime-ts/helpers/src/index.ts
+++ b/skipruntime-ts/helpers/src/index.ts
@@ -10,11 +10,4 @@ export {
   Polled,
 } from "./external.js";
 export { SkipServiceBroker, fetchJSON, type Entrypoint } from "./rest.js";
-export {
-  Count,
-  CountMapper,
-  Max,
-  Min,
-  SkipExternalService,
-  Sum,
-} from "@skipruntime/core";
+export { Count, Max, Min, SkipExternalService, Sum } from "@skipruntime/core";

--- a/skipruntime-ts/native/src/BaseTypes.sk
+++ b/skipruntime-ts/native/src/BaseTypes.sk
@@ -1,15 +1,5 @@
 module SkipRuntime;
 
-base class FileConverter {
-  fun toJSON(value: SKStore.File): SKJSON.CJSON;
-  fun fromJSON(json: SKJSON.CJSON): SKStore.File;
-}
-
-base class KeyConverter {
-  fun toJSON(value: SKStore.Key): SKJSON.CJSON;
-  fun fromJSON(json: SKJSON.CJSON): SKStore.Key;
-}
-
 base class Reducer<V1: frozen, V2: frozen>(initial: V2) {
   fun getType(): SKStore.File ~> V2;
   fun add(acc: V2, value: V1): V2;
@@ -25,9 +15,6 @@ base class Reducer<V1: frozen, V2: frozen>(initial: V2) {
  * @returns an iterable of key/value pairs to output for the given input(s)
  */
 base class Mapper {
-  fun getKeyConverter(): KeyConverter;
-  fun getFileConverter(): FileConverter;
-
   fun mapEntry(
     key: SKJSON.CJSON,
     values: mutable SKStore.NonEmptyIterator<SKJSON.CJSON>,
@@ -35,9 +22,6 @@ base class Mapper {
 }
 
 base class LazyCompute {
-  fun getKeyConverter(): KeyConverter;
-  fun getFileConverter(): FileConverter;
-
   fun compute(self: LazyCollection, key: SKJSON.CJSON): Array<SKJSON.CJSON>;
 }
 

--- a/skipruntime-ts/native/src/Extern.sk
+++ b/skipruntime-ts/native/src/Extern.sk
@@ -427,10 +427,25 @@ fun mapReduceOfCollection(
   collectionForName(collection).mapReduce(Some(mapper), reducer).getId()
 }
 
+@export("SkipRuntime_Collection__nativeMapReduce")
+fun nativeMapReduce(
+  collection: String,
+  mapper: Mapper,
+  reducer: String,
+): String {
+  collectionForName(collection).nativeMapReduce(Some(mapper), reducer).getId()
+}
+
 @export("SkipRuntime_Collection__reduce")
 fun reduceOfCollection(collection: String, reducer: JSONReducer): String {
   collectionForName(collection).mapReduce(None(), reducer).getId()
 }
+
+@export("SkipRuntime_Collection__nativeReduce")
+fun nativeReduceOfCollection(collection: String, reducer: String): String {
+  collectionForName(collection).nativeMapReduce(None(), reducer).getId()
+}
+
 @export("SkipRuntime_Collection__slice")
 fun sliceOfCollection(collection: String, ranges: SKJSON.CJArray): String {
   collectionForName(collection)

--- a/skipruntime-ts/native/src/Extern.sk
+++ b/skipruntime-ts/native/src/Extern.sk
@@ -69,14 +69,6 @@ fun createMapper(mapper: UInt32): ExternMapper {
 }
 
 class ExternMapper(eptr: SKStore.ExternalPointer) extends Mapper {
-  fun getKeyConverter(): KeyConverter {
-    JSONKeyConverter()
-  }
-
-  fun getFileConverter(): FileConverter {
-    JSONFileConverter()
-  }
-
   fun mapEntry(
     key: SKJSON.CJSON,
     values: mutable SKStore.NonEmptyIterator<SKJSON.CJSON>,
@@ -123,13 +115,6 @@ fun createLazyCompute(lazyCompute: UInt32): ExternLazyCompute {
 }
 
 class ExternLazyCompute(eptr: SKStore.ExternalPointer) extends LazyCompute {
-  fun getKeyConverter(): KeyConverter {
-    JSONKeyConverter()
-  }
-  fun getFileConverter(): FileConverter {
-    JSONFileConverter()
-  }
-
   fun compute(self: LazyCollection, key: SKJSON.CJSON): Array<SKJSON.CJSON> {
     computeOfLazyCompute(this.eptr.value, self.getId(), key) match {
     | SKJSON.CJArray(value) -> value
@@ -330,8 +315,6 @@ fun createService(
   resources: mutable Map<String, ResourceBuilder>,
   remotes: mutable Map<String, ExternalService>,
 ): ExternService {
-  keyConverter = JSONKeyConverter();
-  fileConverter = JSONFileConverter();
   inputs = mutable Vector[];
   jsInputs match {
   | SKJSON.CJObject(fields) ->
@@ -343,8 +326,6 @@ fun createService(
             e = SKJSON.expectArray(v);
             (e[0], SKJSON.expectArray(e[1]))
           }),
-          keyConverter,
-          fileConverter,
         ),
       )
     }
@@ -443,20 +424,12 @@ fun mapReduceOfCollection(
   mapper: Mapper,
   reducer: JSONReducer,
 ): String {
-  collectionForName(collection)
-    .mapReduce(mapper, reducer, JSONFileConverter())
-    .getId()
+  collectionForName(collection).mapReduce(Some(mapper), reducer).getId()
 }
 
 @export("SkipRuntime_Collection__reduce")
 fun reduceOfCollection(collection: String, reducer: JSONReducer): String {
-  collectionForName(collection)
-    .mapReduce(
-      IdentityMapper(JSONKeyConverter(), JSONFileConverter()),
-      reducer,
-      JSONFileConverter(),
-    )
-    .getId()
+  collectionForName(collection).mapReduce(None(), reducer).getId()
 }
 @export("SkipRuntime_Collection__slice")
 fun sliceOfCollection(collection: String, ranges: SKJSON.CJArray): String {
@@ -590,7 +563,7 @@ class JSONReducer(
   eptr: SKStore.ExternalPointer,
 ) extends Reducer<SKJSON.CJSON, SKJSON.CJSON> {
   fun getType(): SKStore.File ~> SKJSON.CJSON {
-    f ~> JSONFile::type(f).value
+    f ~> JSONFile::type(f).json
   }
 
   fun add(acc: SKJSON.CJSON, value: SKJSON.CJSON): SKJSON.CJSON {

--- a/skipruntime-ts/native/src/Runtime.sk
+++ b/skipruntime-ts/native/src/Runtime.sk
@@ -37,33 +37,21 @@ class ResourceCollections(
 
 class ServiceDefinition(runId: String, service: Service) extends SKStore.File
 
-class Handle(
-  value: SKStore.EHandle<SKStore.Key, SKStore.File>,
-) extends SKStore.File
+class Handle(value: SKStore.EHandle<JSONID, JSONFile>) extends SKStore.File
 
 class ConvReducer(
-  private fileConverter: FileConverter,
-  private accConverter: FileConverter,
   private reducer: Reducer<SKJSON.CJSON, SKJSON.CJSON>,
-) extends Reducer<SKStore.File, SKStore.File> {
-  fun getType(): SKStore.File ~> SKStore.File {
-    f ~> f
+) extends Reducer<JSONFile, JSONFile> {
+  fun getType(): SKStore.File ~> JSONFile {
+    JSONFile::type
   }
 
-  fun add(acc: SKStore.File, value: SKStore.File): SKStore.File {
-    this.accConverter.fromJSON(
-      this.reducer.add(
-        this.accConverter.toJSON(acc),
-        this.fileConverter.toJSON(value),
-      ),
-    );
+  fun add(acc: JSONFile, value: JSONFile): JSONFile {
+    JSONFile(this.reducer.add(acc.json, value.json));
   }
 
-  fun remove(acc: SKStore.File, value: SKStore.File): ?SKStore.File {
-    this.reducer.remove(
-      this.accConverter.toJSON(acc),
-      this.fileConverter.toJSON(value),
-    ).map(this.accConverter.fromJSON)
+  fun remove(acc: JSONFile, value: JSONFile): ?JSONFile {
+    this.reducer.remove(acc.json, value.json).map(x -> JSONFile(x))
   }
 }
 
@@ -225,12 +213,7 @@ fun initCtx(): SKStore.Context {
   SKStore.Context{}
 }
 
-class Input(
-  name: String,
-  values: Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)>,
-  keyConverter: KeyConverter,
-  fileConverter: FileConverter,
-)
+class Input(name: String, values: Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)>)
 
 fun buildResourcesGraph(
   context: mutable SKStore.Context,
@@ -342,8 +325,8 @@ fun buildResourcesGraph(
         collection = resource.instantiate(collections);
         // Ensure the name of the resource result
         resourceData = collection.hdl.map(
-          kKeyToKey,
-          kFileToFile,
+          JSONID::keyType,
+          JSONFile::type,
           context,
           dDirname.sub(resourceId),
           (_ctx, writer, key, it) ~> {
@@ -395,22 +378,14 @@ fun initService(service: Service): Result<void, .Exception> {
             iDirName = SKStore.DirName::create(`/${input.name}/`);
             ctx.mkdirMulti(
               iDirName,
-              input.values.map(v ->
-                (
-                  input.keyConverter.fromJSON(v.i0),
-                  v.i1.map(input.fileConverter.fromJSON),
-                )
-              ),
+              input.values.map(v -> (JSONID(v.i0), v.i1.map(x -> JSONFile(x)))),
             );
-            iHdl = SKStore.EHandle<SKStore.Key, SKStore.File>(
-              kKeyToKey,
-              kFileToFile,
+            iHdl = SKStore.EHandle<JSONID, JSONFile>(
+              JSONID::keyType,
+              JSONFile::type,
               iDirName,
             );
-            mInputs.add(
-              input.name,
-              Collection(iHdl, input.keyConverter, input.fileConverter),
-            )
+            mInputs.add(input.name, Collection(iHdl))
           });
           inputCollections = mInputs.chill();
           try {
@@ -548,20 +523,17 @@ fun createLazyCollection(compute: LazyCompute): LazyCollection {
   | Some(context) ->
     collectionId = `collection_${SKStore.genSym(0)}`;
     dirName = subDirName(context, collectionId);
-    keyConverter = compute.getKeyConverter();
-    fileConverter = compute.getFileConverter();
     lhdl = SKStore.LHandle::create(
-      kKeyToKey,
-      kFileToFile,
+      JSONID::keyType,
+      JSONFile::type,
       context,
       dirName,
       (ctx, self, key) ~> {
         pushContext(ctx);
         try {
-          lazyCollection = LazyCollection(self, keyConverter, fileConverter);
-          res = compute
-            .compute(lazyCollection, keyConverter.toJSON(key))
-            .map(fileConverter.fromJSON);
+          res = compute.compute(LazyCollection(self), key.json).map(json ->
+            JSONFile(json)
+          );
           popContext();
           res
         } catch {
@@ -571,7 +543,7 @@ fun createLazyCollection(compute: LazyCompute): LazyCollection {
         }
       },
     );
-    LazyCollection(lhdl, keyConverter, fileConverter)
+    LazyCollection(lhdl)
 
   | _ -> invariant_violation("Store context must be specified.")
   }
@@ -628,8 +600,8 @@ fun useExternalCollection(
       (context, writer, key, it) ~> {
         storeDir = dirName.sub(base64(it.first.toString()));
         store = context.mkdir(
-          kKeyToKey,
-          kFileToFile,
+          JSONID::keyType,
+          JSONFile::type,
           storeDir,
           Array[],
           true,
@@ -648,8 +620,8 @@ fun useExternalCollection(
     );
     Collection(
       hdl.map(
-        kKeyToKey,
-        kFileToFile,
+        JSONID::keyType,
+        JSONFile::type,
         context,
         dataDir,
         (context, writer, key, _it) ~> {
@@ -659,30 +631,20 @@ fun useExternalCollection(
           });
         },
       ),
-      JSONKeyConverter(),
-      JSONFileConverter(),
     )
   | _ -> invariant_violation("Store context must be specified.")
   }
 }
 
-class Collection(
-  hdl: SKStore.EHandle<SKStore.Key, SKStore.File>,
-  keyConverter: KeyConverter,
-  fileConverter: FileConverter,
-) {
+class Collection(hdl: SKStore.EHandle<JSONID, JSONFile>) {
   //
-  static fun forName(
-    name: String,
-    keyConverter: KeyConverter,
-    fileConverter: FileConverter,
-  ): Collection {
-    hdl = SKStore.EHandle(
-      kKeyToKey,
-      kFileToFile,
+  static fun forName(name: String): Collection {
+    hdl = SKStore.EHandle<JSONID, JSONFile>(
+      JSONID::keyType,
+      JSONFile::type,
       SKStore.DirName::create(name),
     );
-    Collection(hdl, keyConverter, fileConverter)
+    Collection(hdl)
   }
 
   fun getId(): String {
@@ -700,9 +662,7 @@ class Collection(
       if (dir.creator == context.currentArrow()) {
         throw ReadInCreatorException()
       };
-      dir
-        .getArray(context, this.keyConverter.fromJSON(key))
-        .map(this.fileConverter.toJSON)
+      dir.getArray(context, JSONID(key)).map(x ~> JSONFile::type(x).json)
     | _ -> invariant_violation("Store context must be specified.")
     }
   }
@@ -723,7 +683,7 @@ class Collection(
    * @returns The resulting (eager) output collection
    */
   fun map(mapper: Mapper): Collection {
-    this.map_(mapper, None())
+    this.map_(Some(mapper), None())
   }
 
   /**
@@ -734,32 +694,21 @@ class Collection(
    * @returns An eager collection containing the output of the reducer
    */
   fun mapReduce(
-    mapper: Mapper,
+    mapperOpt: ?Mapper,
     reducer: Reducer<SKJSON.CJSON, SKJSON.CJSON>,
-    accConverter: FileConverter,
   ): Collection {
     getContext() match {
     | Some(context) ->
-      keyConverter = this.keyConverter;
-      fileConverter = this.fileConverter;
       collectionId = `collection_${SKStore.genSym(0)}`;
       dirName = this.hdl.dirName.sub(collectionId);
-      hdl = this.hdl.mapReduce(
-        kKeyToKey,
-        kFileToFile,
-        context,
-        dirName,
+      mapper = mapperOpt match {
+      | None() -> identityMap
+      | Some(mapper) ->
         (ctx, writer, key, values) ~> {
           pushContext(ctx);
           try {
-            for (entry in mapper.mapEntry(
-              keyConverter.toJSON(key),
-              values.map(fileConverter.toJSON),
-            )) {
-              writer.append(
-                keyConverter.fromJSON(entry.i0),
-                fileConverter.fromJSON(entry.i1),
-              )
+            for (entry in mapper.mapEntry(key.json, values.map(x -> x.json))) {
+              writer.append(JSONID(entry.i0), JSONFile(entry.i1))
             };
             popContext();
           } catch {
@@ -767,17 +716,17 @@ class Collection(
             popContext();
             throw ex
           }
-        },
-        accReducer(
-          ConvReducer(
-            fileConverter,
-            accConverter,
-            reducer,
-            accConverter.fromJSON(reducer.initial),
-          ),
-        ),
+        }
+      };
+      hdl = this.hdl.mapReduce(
+        JSONID::keyType,
+        JSONFile::type,
+        context,
+        dirName,
+        mapper,
+        accReducer(ConvReducer(reducer, JSONFile(reducer.initial))),
       );
-      Collection(hdl, mapper.getKeyConverter(), mapper.getFileConverter())
+      Collection(hdl)
     | _ -> invariant_violation("Store context must be specified.")
     }
   }
@@ -787,10 +736,7 @@ class Collection(
    * the given ranges.
    */
   fun sliced(ranges: Array<(SKJSON.CJSON, SKJSON.CJSON)>): Collection {
-    this.map_(
-      IdentityMapper(this.keyConverter, this.fileConverter),
-      Some(ranges),
-    )
+    this.map_(None(), Some(ranges))
   }
 
   /**
@@ -810,7 +756,7 @@ class Collection(
         removeElementAsOne,
         None(),
       );
-      Collection(resHdl, this.keyConverter, this.fileConverter)
+      Collection(resHdl)
     | _ -> invariant_violation("Store context must be specified.")
     }
   }
@@ -827,8 +773,8 @@ class Collection(
       collectionId = `collection_${SKStore.genSym(0)}`;
       dirName = this.hdl.dirName.sub(collectionId);
       hdl = SKStore.EHandle::multiMap(
-        kKeyToKey,
-        kFileToFile,
+        JSONID::keyType,
+        JSONFile::type,
         context,
         Array[this].concat(others).map(c ->
           c match {
@@ -837,7 +783,7 @@ class Collection(
         ),
         dirName,
       );
-      Collection(hdl, this.keyConverter, this.fileConverter)
+      Collection(hdl)
     | _ -> invariant_violation("Store context must be specified.")
     }
   }
@@ -867,8 +813,8 @@ class Collection(
       (key, files) = kv;
       values.push(
         (
-          this.keyConverter.toJSON(key),
-          files.collect(Array).map(this.fileConverter.toJSON),
+          JSONID::keyType(key).json,
+          files.collect(Array).map(x -> JSONFile::type(x).json),
         ),
       );
     };
@@ -877,7 +823,7 @@ class Collection(
 
   fun items(
     context: mutable SKStore.Context,
-  ): mutable Iterator<(SKStore.Key, mutable Iterator<SKStore.File>)> {
+  ): mutable Iterator<(JSONID, mutable Iterator<JSONFile>)> {
     this.hdl.items(context)
   }
 
@@ -893,8 +839,6 @@ class Collection(
     ) ~> void,
     close: () ~> void,
   ): void {
-    keyConverter = this.keyConverter;
-    fileConverter = this.fileConverter;
     context.subscribe(
       session,
       SKStore.NWatch(
@@ -903,7 +847,10 @@ class Collection(
         (_dirName, values, tick, update) ~> {
           notify(
             values.map(v ->
-              (keyConverter.toJSON(v.i0), v.i1.map(fileConverter.toJSON))
+              (
+                JSONID::keyType(v.i0).json,
+                v.i1.map(x -> JSONFile::type(x).json),
+              )
             ),
             tick,
             update,
@@ -926,31 +873,21 @@ class Collection(
   }
 
   private fun map_(
-    mapper: Mapper,
+    mapperOpt: ?Mapper,
     rangeOpt: ?Array<(SKJSON.CJSON, SKJSON.CJSON)> = None(),
   ): Collection {
     getContext() match {
     | Some(context) ->
-      keyConverter = this.keyConverter;
-      fileConverter = this.fileConverter;
       collectionId = `collection_${SKStore.genSym(0)}`;
       dirName = this.hdl.dirName.sub(collectionId);
-      hdl = this.hdl.map(
-        kKeyToKey,
-        kFileToFile,
-        context,
-        dirName,
+      mapper = mapperOpt match {
+      | None() -> identityMap
+      | Some(mapper) ->
         (ctx, writer, key, values) ~> {
           pushContext(ctx);
           try {
-            for (entry in mapper.mapEntry(
-              keyConverter.toJSON(key),
-              values.map(fileConverter.toJSON),
-            )) {
-              writer.append(
-                keyConverter.fromJSON(entry.i0),
-                fileConverter.fromJSON(entry.i1),
-              )
+            for (entry in mapper.mapEntry(key.json, values.map(x -> x.json))) {
+              writer.append(JSONID(entry.i0), JSONFile(entry.i1))
             };
             popContext();
           } catch {
@@ -958,35 +895,33 @@ class Collection(
             popContext();
             throw ex
           }
-        },
+        }
+      };
+      hdl = this.hdl.map(
+        JSONID::keyType,
+        JSONFile::type,
+        context,
+        dirName,
+        mapper,
         rangeOpt.map(v ->
-          v.map(r ->
-            SKStore.KeyRange(
-              keyConverter.fromJSON(r.i0),
-              keyConverter.fromJSON(r.i1),
-            )
-          )
+          v.map(r -> SKStore.KeyRange(JSONID(r.i0), JSONID(r.i1)))
         ),
       );
-      Collection(hdl, mapper.getKeyConverter(), mapper.getFileConverter())
+      Collection(hdl)
     | _ -> invariant_violation("Store context must be specified.")
     }
   }
 }
 
-class LazyCollection(
-  private hdl: SKStore.LHandle<SKStore.Key, SKStore.File>,
-  private keyConverter: KeyConverter,
-  private fileConverter: FileConverter,
-) {
+class LazyCollection(private hdl: SKStore.LHandle<JSONID, JSONFile>) {
   //
-  static fun forName(
-    name: String,
-    keyConverter: KeyConverter,
-    fileConverter: FileConverter,
-  ): LazyCollection {
-    hdl = SKStore.LHandle(k ~> k, f ~> f, SKStore.DirName::create(name));
-    LazyCollection(hdl, keyConverter, fileConverter)
+  static fun forName(name: String): LazyCollection {
+    hdl = SKStore.LHandle(
+      JSONID::keyType,
+      JSONFile::type,
+      SKStore.DirName::create(name),
+    );
+    LazyCollection(hdl)
   }
 
   fun getId(): String {
@@ -1000,9 +935,7 @@ class LazyCollection(
   fun getArray(key: SKJSON.CJSON): Array<SKJSON.CJSON> {
     getContext() match {
     | Some(context) ->
-      this.hdl.getArray(context, this.keyConverter.fromJSON(key)).map(
-        this.fileConverter.toJSON,
-      )
+      this.hdl.getArray(context, JSONID(key)).map(file -> file.json)
     | _ -> invariant_violation("Store context must be specified.")
     }
   }
@@ -1013,10 +946,7 @@ class LazyCollection(
    */
   fun getUnique(key: SKJSON.CJSON): SKJSON.CJSON {
     getContext() match {
-    | Some(context) ->
-      this.fileConverter.toJSON(
-        this.hdl.get(context, this.keyConverter.fromJSON(key)),
-      )
+    | Some(context) -> this.hdl.get(context, JSONID(key)).json
     | _ -> invariant_violation("Store context must be specified.")
     }
   }

--- a/skipruntime-ts/native/src/Runtime.sk
+++ b/skipruntime-ts/native/src/Runtime.sk
@@ -731,6 +731,102 @@ class Collection(hdl: SKStore.EHandle<JSONID, JSONFile>) {
     }
   }
 
+  fun nativeMapReduceImpl<V_elt: SKStore.File, V_acc: SKStore.File>(
+    mapperOpt: ?Mapper,
+    reducer: SKStore.EReducer<V_elt, V_acc>,
+    eltType: SKStore.File ~> V_elt,
+    inputConv: SKJSON.CJSON ~> V_elt,
+    outputConv: V_acc ~> SKJSON.CJSON,
+  ): Collection {
+    mapper = (ctx, writer, key, values) ~> {
+      mapperOpt match {
+      | None() ->
+        writer.setArray(key, values.map(x -> inputConv(x.json)).collect(Array))
+      | Some(mapper) ->
+        pushContext(ctx);
+        try {
+          for (entry in mapper.mapEntry(key.json, values.map(x -> x.json))) {
+            writer.append(JSONID(entry.i0), inputConv(entry.i1))
+          };
+          popContext();
+        } catch {
+        | ex ->
+          popContext();
+          throw ex
+        }
+      }
+    };
+    getContext() match {
+    | Some(context) ->
+      hdl = this.hdl.mapReduce(
+        JSONID::keyType,
+        eltType,
+        context,
+        this.hdl.dirName.sub(`collection_${SKStore.genSym(0)}`),
+        mapper,
+        reducer,
+      );
+      Collection(
+        hdl.map(
+          JSONID::keyType,
+          JSONFile::type,
+          context,
+          this.hdl.dirName.sub(`collection_${SKStore.genSym(1)}`),
+          (_ctx, writer, key, values) ~> {
+            writer.setArray(
+              key,
+              values.map(x -> JSONFile(outputConv(x))).collect(Array),
+            )
+          },
+        ),
+      )
+    | _ -> invariant_violation("Store context must be specified.")
+    }
+  }
+
+  fun nativeMapReduce(mapperOpt: ?Mapper, reducer: String): Collection {
+    jsonToIntFile = json ~>
+      json match {
+      | SKJSON.CJInt(x) -> SKStore.IntFile(x)
+      | _ -> throw SKStore.Error("Non-number JSON input to native reducer")
+      };
+    reducer match {
+    | "sum" ->
+      this.nativeMapReduceImpl(
+        mapperOpt,
+        SKStore.sumReducer(),
+        SKStore.IntFile::type,
+        jsonToIntFile,
+        file ~> SKJSON.CJInt(file.value),
+      )
+    | "min" ->
+      this.nativeMapReduceImpl(
+        mapperOpt,
+        SKStore.minReducer(),
+        SKStore.IntFile::type,
+        jsonToIntFile,
+        file ~> SKJSON.CJInt(file.value),
+      )
+    | "max" ->
+      this.nativeMapReduceImpl(
+        mapperOpt,
+        SKStore.maxReducer(),
+        SKStore.IntFile::type,
+        jsonToIntFile,
+        file ~> SKJSON.CJInt(file.value),
+      )
+    | "count" ->
+      this.nativeMapReduceImpl(
+        mapperOpt,
+        SKStore.countReducer(),
+        JSONFile::type,
+        json ~> JSONFile(json),
+        file ~> SKJSON.CJInt(file.value),
+      )
+    | _ -> throw SKStore.Error("Unrecognized native reducer: " + reducer)
+    }
+  }
+
   /**
    * Create a new eager collection by keeping only the elements whose keys are in
    * the given ranges.

--- a/skipruntime-ts/native/src/Utils.sk
+++ b/skipruntime-ts/native/src/Utils.sk
@@ -22,34 +22,14 @@ const kResourceInstance2SubIdDir: SKStore.DirName = SKStore.DirName::create(
   "/sk_prv/resources/instance2subid/",
 );
 
-class JSONKeyConverter() extends KeyConverter {
-  fun toJSON(value: SKStore.Key): SKJSON.CJSON {
-    JSONID::keyType(value).value
-  }
-
-  fun fromJSON(json: SKJSON.CJSON): SKStore.Key {
-    JSONID(json)
-  }
-}
-
-class JSONFileConverter() extends FileConverter {
-  fun toJSON(value: SKStore.File): SKJSON.CJSON {
-    JSONFile::type(value).value
-  }
-
-  fun fromJSON(json: SKJSON.CJSON): SKStore.File {
-    JSONFile(json)
-  }
-}
-
-class JSONID(value: SKJSON.CJSON) extends SKStore.Key {
+class JSONID(json: SKJSON.CJSON) extends SKStore.Key {
   //
   fun toString(): String {
-    this.value.prettyPrint()
+    this.json.prettyPrint()
   }
 }
 
-class JSONFile(value: SKJSON.CJSON) extends SKStore.File
+class JSONFile(json: SKJSON.CJSON) extends SKStore.File
 
 fun accReducer<V1: SKStore.File, V2: SKStore.File>(
   reducer: Reducer<V1, V2>,
@@ -87,27 +67,6 @@ fun identityMap<K: SKStore.Key, V: SKStore.File>(
   it: mutable SKStore.NonEmptyIterator<V>,
 ): void {
   writer.setArray(key, it.collect(Array));
-}
-
-class IdentityMapper(
-  private keyConverter: KeyConverter,
-  private fileConverter: FileConverter,
-) extends Mapper {
-  //
-  fun getKeyConverter(): KeyConverter {
-    this.keyConverter
-  }
-
-  fun getFileConverter(): FileConverter {
-    this.fileConverter
-  }
-
-  fun mapEntry(
-    key: SKJSON.CJSON,
-    values: mutable SKStore.NonEmptyIterator<SKJSON.CJSON>,
-  ): mutable Iterator<(SKJSON.CJSON, SKJSON.CJSON)> {
-    values.collect(Array).map(v -> (key, v)).iterator()
-  }
 }
 
 fun noFilter<K: SKStore.Key, V: SKStore.File>(
@@ -164,11 +123,11 @@ fun toSuppliedResourceId(
 }
 
 fun collectionForName(name: String): Collection {
-  Collection::forName(name, JSONKeyConverter(), JSONFileConverter())
+  Collection::forName(name)
 }
 
 fun lazyForName(name: String): LazyCollection {
-  LazyCollection::forName(name, JSONKeyConverter(), JSONFileConverter())
+  LazyCollection::forName(name)
 }
 
 fun collectionsByName(collections: Map<String, Collection>): SKJSON.CJObject {

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -153,10 +153,19 @@ export interface FromWasm {
     mapper: ptr<Internal.Mapper>,
     reducer: ptr<Internal.Reducer>,
   ): ptr<Internal.String>;
+  SkipRuntime_Collection__nativeMapReduce(
+    collection: ptr<Internal.String>,
+    mapper: ptr<Internal.Mapper>,
+    reducer: ptr<Internal.String>,
+  ): ptr<Internal.String>;
 
   SkipRuntime_Collection__reduce(
     collection: ptr<Internal.String>,
     reducer: ptr<Internal.Reducer>,
+  ): ptr<Internal.String>;
+  SkipRuntime_Collection__nativeReduce(
+    collection: ptr<Internal.String>,
+    reducer: ptr<Internal.String>,
   ): ptr<Internal.String>;
 
   SkipRuntime_Collection__slice(
@@ -582,6 +591,20 @@ export class WasmFromBinding implements FromBinding {
     );
   }
 
+  SkipRuntime_Collection__nativeMapReduce(
+    collection: string,
+    mapper: Pointer<Internal.Mapper>,
+    reducer: string,
+  ): string {
+    return this.utils.importString(
+      this.fromWasm.SkipRuntime_Collection__nativeMapReduce(
+        this.utils.exportString(collection),
+        toPtr(mapper),
+        this.utils.exportString(reducer),
+      ),
+    );
+  }
+
   SkipRuntime_Collection__reduce(
     collection: string,
     reducer: Pointer<Internal.Reducer>,
@@ -590,6 +613,18 @@ export class WasmFromBinding implements FromBinding {
       this.fromWasm.SkipRuntime_Collection__reduce(
         this.utils.exportString(collection),
         toPtr(reducer),
+      ),
+    );
+  }
+
+  SkipRuntime_Collection__nativeReduce(
+    collection: string,
+    reducer: string,
+  ): string {
+    return this.utils.importString(
+      this.fromWasm.SkipRuntime_Collection__nativeReduce(
+        this.utils.exportString(collection),
+        this.utils.exportString(reducer),
       ),
     );
   }

--- a/www/docs/functions.md
+++ b/www/docs/functions.md
@@ -57,21 +57,7 @@ const activeGroupMembers : EagerCollection<GroupID, UserID> = users.map(ActiveUs
 
 This general form of `Mapper` allows arbitrary manipulation of collections' key/value structure, but is often unnecessary and clunky for simple maps, especially those that preserve the key structure of their input and just manipulate the values.
 
-For example, to maintain a _count_ of active users per group, we can define a `ManyToOneMapper`:
-
-```typescript
-class CountUsers extends ManyToOneMapper<GroupID, UserID, number> {
-  mapValues(values: NonEmptyIterator<UserID>): number {
-    return values.toArray().length;
-  }
-}
-```
-
-Then, map over the eager collection of group members to produce an eager collection `activeGroupMembers.map(CountUsers)` of type `EagerCollection<GroupID, number>` which maintains up-to-date counts of active users per group, as users' activity status and group memberships change.
-Note that this mapper -- counting the number of values per key -- is available as a generic utility `CountMapper` in Skip; this example is provided just to demonstrate a use of `ManyToOneMapper`.
-
-
-The simplest form of mapper maintains input collections' key/value structure one-to-one.
+Simpler mappers that maintain input collections' key/value structure one-to-one can be defined more succinctly.
 For example, to compute the number of groups each user belongs to, we can define a `OneToOneMapper`:
 
 ```typescript
@@ -81,3 +67,17 @@ class GroupsPerUser extends OneToOneMapper<UserID, User, number> {
   }
 }
 ```
+
+It is also common to collapse multiple values for a single key down to some aggregate with a `ManyToOneMapper`; for example, to maintain a _count_ of active users per group:
+
+```typescript
+class CountUsers extends ManyToOneMapper<GroupID, UserID, number> {
+  mapValues(values: NonEmptyIterator<UserID>): number {
+    return values.toArray().length;
+  }
+}
+```
+
+By mapping `CountUsers` over the eager collection of group members, we can produce an eager collection `activeGroupMembers.map(CountUsers)` of type `EagerCollection<GroupID, number>` with counts of active users per group, maintained up-to-date as users' activity status and group memberships change.
+
+Note that this particular mapper -- counting the number of values per key -- is available as a generic utility `Count` in Skip with a fast native implementation; this example is provided just to demonstrate a use of `ManyToOneMapper`.


### PR DESCRIPTION
This moves all of our utility reducers (sum, min, max, count) from TS to Skiplang and closes #488, but also makes some wider cleanups around skipruntime-ts/native.

Previously, that code made various assumptions that all of the collections it deals with are JSONID/JSONFile but typed all of its collections internally as SKStore.Key/SKStore.File (i.e. top).  Now, the proper key/value types are reflected in the type parameters throughout, and I've pulled out a lot of unused abstraction, where structures carried around a lot of "converters" which were always instantiated for JSONID/JSONFile.

This lets us use utility reducers defined in `skiplang/prelude` which should be much more efficient than TS implementations and incur much lower FFI overhead.

I've still got to dig into the native node addon to get this plumbed through there, but pushing this and calling it a day for now, will figure that out later.