### PR TITLE
Update 2 dependencies

### DIFF
--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@skipruntime/tests": "^0.0.7",
     "@types/mocha": "^10.0.10",
-    "mocha": "^10.8.2"
+    "mocha": "^11.0.1"
   },
   "dependencies": {
     "@skipruntime/core": "^0.0.3"

--- a/skipruntime-ts/examples/package.json
+++ b/skipruntime-ts/examples/package.json
@@ -9,12 +9,12 @@
   },
   "devDependencies": {
     "@types/eventsource": "^1.1.15",
-    "@types/sqlite3": "^3.1.11"
+    "@types/better-sqlite3": "^7.6.12"
   },
   "dependencies": {
     "@skipruntime/helpers": "^0.0.6",
     "@skipruntime/server": "^0.0.6",
     "eventsource": "^2.0.2",
-    "sqlite3": "^5.1.7"
+    "better-sqlite3": "^11.7.2"
   }
 }

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@skipruntime/tests": "^0.0.7",
-    "mocha": "^10.8.2"
+    "mocha": "^11.0.1"
   },
   "dependencies": {
     "@skipruntime/core": "^0.0.3",


### PR DESCRIPTION
Annoyed by a few irksome deprecation messages when I `npm install`, I decided to update `mocha` and switch the examples from `sqlite3` to `better-sqlite3`.

Example still works (without addon), see #634 and related fix in #635