### PR TITLE
Move Entrypoint and SkipExternalService from core to helpers

### DIFF
--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -51,38 +51,10 @@ import {
 } from "./binding.js";
 
 export { UnknownCollectionError, sk_freeze, isSkManaged };
-export { SkipExternalService } from "./remote.js";
 export { Sum, Min, Max, Count } from "./utils.js";
 
 export type JSONMapper = Mapper<Json, Json, Json, Json>;
 export type JSONLazyCompute = LazyCompute<Json, Json>;
-
-/**
- * An entry point of a Skip reactive service.
- *
- * URLs for the service's control and streaming APIs can be constructed from an `Entrypoint`.
- */
-export type Entrypoint = {
-  /**
-   * Hostname of the service.
-   */
-  host: string;
-
-  /**
-   * Port to use for the service's streaming interface.
-   */
-  streaming_port: number;
-
-  /**
-   * Port to use for the service's control interface.
-   */
-  control_port: number;
-
-  /**
-   * Flag that when set indicates that https should be used instead of http.
-   */
-  secured?: boolean;
-};
 
 class Handles {
   private nextID: number = 1;

--- a/skipruntime-ts/helpers/src/index.ts
+++ b/skipruntime-ts/helpers/src/index.ts
@@ -9,5 +9,6 @@ export {
   GenericExternalService,
   Polled,
 } from "./external.js";
+export { SkipExternalService } from "./remote.js";
 export { SkipServiceBroker, fetchJSON, type Entrypoint } from "./rest.js";
-export { Count, Max, Min, SkipExternalService, Sum } from "@skipruntime/core";
+export { Count, Max, Min, Sum } from "@skipruntime/core";

--- a/skipruntime-ts/helpers/src/remote.ts
+++ b/skipruntime-ts/helpers/src/remote.ts
@@ -4,7 +4,7 @@ import EventSource from "eventsource";
 
 import type { Entry, ExternalService, Json } from "@skipruntime/api";
 
-import type { Entrypoint } from "./index.js";
+import type { Entrypoint } from "./rest.js";
 
 interface Closable {
   close(): void;

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -1,7 +1,32 @@
 import type { Json, Entry } from "@skipruntime/api";
 import { NonUniqueValueException } from "@skipruntime/api";
-import type { Entrypoint } from "@skipruntime/core";
-export type { Entrypoint };
+
+/**
+ * An entry point of a Skip reactive service.
+ *
+ * URLs for the service's control and streaming APIs can be constructed from an `Entrypoint`.
+ */
+export type Entrypoint = {
+  /**
+   * Hostname of the service.
+   */
+  host: string;
+
+  /**
+   * Port to use for the service's streaming interface.
+   */
+  streaming_port: number;
+
+  /**
+   * Port to use for the service's control interface.
+   */
+  control_port: number;
+
+  /**
+   * Flag that when set indicates that https should be used instead of http.
+   */
+  secured?: boolean;
+};
 
 function toHttp(entrypoint: Entrypoint) {
   if (entrypoint.secured)


### PR DESCRIPTION
Their only uses are in the helpers package, so move them there.