### PR TITLE
Switch to exact versions in package.json

### DIFF
--- a/examples/hackernews/reactive_service/package.json
+++ b/examples/hackernews/reactive_service/package.json
@@ -10,7 +10,7 @@
   "description": "",
   "dependencies": {
     "postgres": "^3.4.5",
-    "@skipruntime/server": "^0.0.8"
+    "@skipruntime/server": "0.0.8"
   },
   "devDependencies": {
     "@skiplabs/eslint-config": "^0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,21 +51,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/server": "^0.0.4",
+        "@skipruntime/server": "0.0.8",
         "postgres": "^3.4.5"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
         "@skiplabs/tsconfig": "^0.0.1"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@skipruntime/server": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.4.tgz",
-      "integrity": "sha512-A/InfyaQiUpMlxWtczPscrt5By88zOEaB1nJ+Lk1c/zwKT1oGW4v33ph4F28ItuaAujoI+yawK/kRrexyHcVFA==",
-      "dependencies": {
-        "express": "^4.21.0",
-        "skip-wasm": "^0.0.3"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
@@ -3599,40 +3590,6 @@
       "resolved": "sql/ts/tests",
       "link": true
     },
-    "node_modules/skip-wasm": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/skip-wasm/-/skip-wasm-0.0.3.tgz",
-      "integrity": "sha512-n1vjmCHB77W9/7LPELJbj41sKIABLYgbeOErQiPDi69ryYHgoZYHpWmJexYU87djFUJT6NwOYyayOEjvRhrk0w==",
-      "dependencies": {
-        "@skip-wasm/json": "^1.0.3",
-        "@skip-wasm/std": "^1.0.2",
-        "@skipruntime/api": "^0.0.3",
-        "@skipruntime/helpers": "^0.0.3"
-      }
-    },
-    "node_modules/skip-wasm/node_modules/@skipruntime/api": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@skipruntime/api/-/api-0.0.3.tgz",
-      "integrity": "sha512-8F4pK871wBb6siELJgnRlRkOfrdTAt2LTXN8tDhrbd3434fOEkiKXQqia4KAMVJK0fJAOp6EypzuJq6ue3psWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.6.0 <23.0.0"
-      }
-    },
-    "node_modules/skip-wasm/node_modules/@skipruntime/helpers": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.3.tgz",
-      "integrity": "sha512-oAFgiUeCn2lSSzsPezRuFpx1d7GKQgay+FBMOfcTrTGxUfhoVDmAZw1Gz4NX738oT7MkWd4f0lzlojP2wmqT4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@skipruntime/api": "^0.0.3",
-        "eventsource": "^2.0.2",
-        "express": "^4.21.0"
-      },
-      "engines": {
-        "node": ">=22.6.0 <23.0.0"
-      }
-    },
     "node_modules/skipruntime-examples": {
       "resolved": "skipruntime-ts/examples",
       "link": true
@@ -4288,13 +4245,13 @@
     },
     "skiplang/prelude/ts/binding": {
       "name": "@skiplang/std",
-      "version": "0.0.2"
+      "version": "0.0.3"
     },
     "skiplang/prelude/ts/wasm": {
       "name": "@skip-wasm/std",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
-        "@skiplang/std": "0.0.2",
+        "@skiplang/std": "0.0.3",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -4303,9 +4260,9 @@
     },
     "skiplang/skdate/ts": {
       "name": "@skip-wasm/date",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
-        "@skip-wasm/std": "^1.0.4"
+        "@skip-wasm/std": "1.0.5"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -4314,38 +4271,38 @@
     },
     "skiplang/skjson/ts/binding": {
       "name": "@skiplang/json",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
-        "@skiplang/std": "^0.0.2"
+        "@skiplang/std": "0.0.3"
       }
     },
     "skiplang/skjson/ts/wasm": {
       "name": "@skip-wasm/json",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
-        "@skip-wasm/std": "^1.0.4",
-        "@skiplang/json": "^0.0.2"
+        "@skip-wasm/std": "1.0.5",
+        "@skiplang/json": "0.0.3"
       }
     },
     "skipruntime-ts/addon": {
       "name": "@skipruntime/addon",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "hasInstallScript": true,
       "dependencies": {
-        "@skipruntime/core": "^0.0.3"
+        "@skipruntime/core": "0.0.5"
       },
       "devDependencies": {
-        "@skipruntime/tests": "^0.0.7",
+        "@skipruntime/tests": "0.0.9",
         "@types/mocha": "^10.0.10",
         "mocha": "^11.0.1"
       }
     },
     "skipruntime-ts/api": {
       "name": "@skipruntime/api",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
-        "@skiplang/json": "^0.0.2"
+        "@skiplang/json": "0.0.3"
       },
       "engines": {
         "node": ">=22.6.0 <23.0.0"
@@ -4353,16 +4310,16 @@
     },
     "skipruntime-ts/core": {
       "name": "@skipruntime/core",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
-        "@skipruntime/api": "^0.0.5"
+        "@skipruntime/api": "0.0.6"
       }
     },
     "skipruntime-ts/examples": {
       "name": "skipruntime-examples",
       "dependencies": {
-        "@skipruntime/helpers": "^0.0.6",
-        "@skipruntime/server": "^0.0.6",
+        "@skipruntime/helpers": "0.0.8",
+        "@skipruntime/server": "0.0.8",
         "better-sqlite3": "^11.7.2",
         "eventsource": "^2.0.2"
       },
@@ -4373,11 +4330,11 @@
     },
     "skipruntime-ts/helpers": {
       "name": "@skipruntime/helpers",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/api": "^0.0.5",
-        "@skipruntime/core": "^0.0.3",
+        "@skipruntime/api": "0.0.6",
+        "@skipruntime/core": "0.0.5",
         "eventsource": "^2.0.2",
         "express": "^4.21.1"
       },
@@ -4390,19 +4347,19 @@
     },
     "skipruntime-ts/runtime": {
       "name": "@skipruntime/runtime",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "dependencies": {
-        "@skipruntime/wasm": "^0.0.4"
+        "@skipruntime/wasm": "0.0.6"
       },
       "optionalDependencies": {
-        "@skipruntime/addon": "^0.0.2"
+        "@skipruntime/addon": "0.0.4"
       }
     },
     "skipruntime-ts/server": {
       "name": "@skipruntime/server",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "dependencies": {
-        "@skipruntime/runtime": "^0.0.2",
+        "@skipruntime/runtime": "0.0.4",
         "express": "^4.21.1"
       },
       "devDependencies": {
@@ -4411,22 +4368,22 @@
     },
     "skipruntime-ts/tests": {
       "name": "@skipruntime/tests",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "dependencies": {
-        "@skipruntime/core": "^0.0.3",
-        "@skipruntime/helpers": "^0.0.6",
+        "@skipruntime/core": "0.0.5",
+        "@skipruntime/helpers": "0.0.8",
         "earl": "^1.3.0"
       }
     },
     "skipruntime-ts/wasm": {
       "name": "@skipruntime/wasm",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "dependencies": {
-        "@skip-wasm/json": "^1.0.5",
-        "@skipruntime/core": "^0.0.3"
+        "@skip-wasm/json": "1.0.6",
+        "@skipruntime/core": "0.0.5"
       },
       "devDependencies": {
-        "@skipruntime/tests": "^0.0.7",
+        "@skipruntime/tests": "0.0.9",
         "@types/mocha": "^10.0.10",
         "mocha": "^11.0.1"
       }
@@ -4435,9 +4392,9 @@
       "name": "skdb",
       "version": "1.0.0",
       "dependencies": {
-        "@skip-wasm/date": "^1.0.3",
-        "@skip-wasm/json": "^1.0.5",
-        "@skip-wasm/std": "^1.0.4"
+        "@skip-wasm/date": "1.0.4",
+        "@skip-wasm/json": "1.0.6",
+        "@skip-wasm/std": "1.0.5"
       },
       "bin": {
         "skdb-cli": "dist/skdb-cli.js"
@@ -4452,8 +4409,8 @@
       "name": "skdb-tests",
       "dependencies": {
         "@playwright/test": "^1.47.2",
-        "@skip-wasm/date": "^1.0.2",
-        "@skip-wasm/json": "^1.0.4",
+        "@skip-wasm/date": "1.0.4",
+        "@skip-wasm/json": "1.0.6",
         "skdb": "^1.0.0",
         "ws": "^8.18.0"
       },

--- a/skiplang/skdate/ts/package.json
+++ b/skiplang/skdate/ts/package.json
@@ -15,6 +15,6 @@
     "@types/ws": "^8.5.13"
   },
   "dependencies": {
-    "@skip-wasm/std": "^1.0.5"
+    "@skip-wasm/std": "1.0.5"
   }
 }

--- a/skiplang/skjson/ts/binding/package.json
+++ b/skiplang/skjson/ts/binding/package.json
@@ -12,6 +12,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skiplang/std": "^0.0.3"
+    "@skiplang/std": "0.0.3"
   }
 }

--- a/skiplang/skjson/ts/wasm/package.json
+++ b/skiplang/skjson/ts/wasm/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skiplang/json": "^0.0.3",
-    "@skip-wasm/std": "^1.0.5"
+    "@skiplang/json": "0.0.3",
+    "@skip-wasm/std": "1.0.5"
   }
 }

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -14,11 +14,11 @@
     "test": "mocha"
   },
   "devDependencies": {
-    "@skipruntime/tests": "^0.0.9",
+    "@skipruntime/tests": "0.0.9",
     "@types/mocha": "^10.0.10",
     "mocha": "^11.0.1"
   },
   "dependencies": {
-    "@skipruntime/core": "^0.0.5"
+    "@skipruntime/core": "0.0.5"
   }
 }

--- a/skipruntime-ts/api/package.json
+++ b/skipruntime-ts/api/package.json
@@ -18,6 +18,6 @@
     "node": ">=22.6.0 <23.0.0"
   },
   "dependencies": {
-    "@skiplang/json": "^0.0.3"
+    "@skiplang/json": "0.0.3"
   }
 }

--- a/skipruntime-ts/core/package.json
+++ b/skipruntime-ts/core/package.json
@@ -13,6 +13,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/api": "^0.0.6"
+    "@skipruntime/api": "0.0.6"
   }
 }

--- a/skipruntime-ts/examples/package.json
+++ b/skipruntime-ts/examples/package.json
@@ -12,8 +12,8 @@
     "@types/better-sqlite3": "^7.6.12"
   },
   "dependencies": {
-    "@skipruntime/helpers": "^0.0.8",
-    "@skipruntime/server": "^0.0.8",
+    "@skipruntime/helpers": "0.0.8",
+    "@skipruntime/server": "0.0.8",
     "eventsource": "^2.0.2",
     "better-sqlite3": "^11.7.2"
   }

--- a/skipruntime-ts/helpers/package.json
+++ b/skipruntime-ts/helpers/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "eventsource": "^2.0.2",
     "express": "^4.21.1",
-    "@skipruntime/core": "^0.0.5",
-    "@skipruntime/api": "^0.0.6"
+    "@skipruntime/core": "0.0.5",
+    "@skipruntime/api": "0.0.6"
   },
   "devDependencies": {
     "@types/eventsource": "^1.1.15"

--- a/skipruntime-ts/runtime/package.json
+++ b/skipruntime-ts/runtime/package.json
@@ -11,9 +11,9 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/wasm": "^0.0.6"
+    "@skipruntime/wasm": "0.0.6"
   },
   "optionalDependencies": {
-    "@skipruntime/addon": "^0.0.4"
+    "@skipruntime/addon": "0.0.4"
   }
 }

--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -15,6 +15,6 @@
   },
   "dependencies": {
     "express": "^4.21.1",
-    "@skipruntime/runtime": "^0.0.4"
+    "@skipruntime/runtime": "0.0.4"
   }
 }

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "earl": "^1.3.0",
-    "@skipruntime/core": "^0.0.5",
-    "@skipruntime/helpers": "^0.0.8"
+    "@skipruntime/core": "0.0.5",
+    "@skipruntime/helpers": "0.0.8"
   }
 }

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -13,11 +13,11 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
-    "@skipruntime/tests": "^0.0.9",
+    "@skipruntime/tests": "0.0.9",
     "mocha": "^11.0.1"
   },
   "dependencies": {
-    "@skipruntime/core": "^0.0.5",
-    "@skip-wasm/json": "^1.0.6"
+    "@skipruntime/core": "0.0.5",
+    "@skip-wasm/json": "1.0.6"
   }
 }

--- a/sql/ts/package.json
+++ b/sql/ts/package.json
@@ -21,8 +21,8 @@
     "@types/ws": "^8.5.13"
   },
   "dependencies": {
-    "@skip-wasm/std": "^1.0.5",
-    "@skip-wasm/date": "^1.0.4",
-    "@skip-wasm/json": "^1.0.6"
+    "@skip-wasm/std": "1.0.5",
+    "@skip-wasm/date": "1.0.4",
+    "@skip-wasm/json": "1.0.6"
   }
 }

--- a/sql/ts/tests/package.json
+++ b/sql/ts/tests/package.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "@playwright/test": "^1.47.2",
     "ws": "^8.18.0",
-    "@skip-wasm/date": "^1.0.2",
-    "@skip-wasm/json": "^1.0.4",
+    "@skip-wasm/date": "1.0.4",
+    "@skip-wasm/json": "1.0.6",
     "skdb": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix specific dependency versions prior to hitting 1.0, as 0. versions are
unstable, see https://semver.org/#spec-item-4. The plan is to switch back to
`^` versions after 1.0 is released.