### PR TITLE
Exclude SKDB from skipruntime-ts `build` make target

### DIFF
--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -1,10 +1,27 @@
 SHELL := /bin/bash
 
 SKARGO_PROFILE?=release
+NPM_WORKSPACES=\
+    -w eslint-config\
+    -w tsconfig\
+    -w skiplang/prelude/ts/binding\
+    -w skiplang/prelude/ts/wasm\
+    -w skiplang/skdate/ts\
+    -w skiplang/skjson/ts/binding\
+    -w skiplang/skjson/ts/wasm\
+    -w skipruntime-ts/api\
+    -w skipruntime-ts/core\
+    -w skipruntime-ts/helpers\
+    -w skipruntime-ts/tests\
+    -w skipruntime-ts/wasm\
+    -w skipruntime-ts/addon\
+    -w skipruntime-ts/runtime\
+    -w skipruntime-ts/server\
+    -w skipruntime-ts/examples
 
 .PHONY: build
 build:
-	../bin/cd_sh .. "npm install && npm run build"
+	../bin/cd_sh .. "npm install $(NPM_WORKSPACES) && npm run build $(NPM_WORKSPACES) --if-present"
 
 bunrun-%: build
 	bun run examples/$*.ts

--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -1,23 +1,7 @@
 SHELL := /bin/bash
 
 SKARGO_PROFILE?=release
-NPM_WORKSPACES=\
-    -w eslint-config\
-    -w tsconfig\
-    -w skiplang/prelude/ts/binding\
-    -w skiplang/prelude/ts/wasm\
-    -w skiplang/skdate/ts\
-    -w skiplang/skjson/ts/binding\
-    -w skiplang/skjson/ts/wasm\
-    -w skipruntime-ts/api\
-    -w skipruntime-ts/core\
-    -w skipruntime-ts/helpers\
-    -w skipruntime-ts/tests\
-    -w skipruntime-ts/wasm\
-    -w skipruntime-ts/addon\
-    -w skipruntime-ts/runtime\
-    -w skipruntime-ts/server\
-    -w skipruntime-ts/examples
+NPM_WORKSPACES=$(shell jq --raw-output "[.workspaces[] | select(startswith(\"sql\") | not)] | map(\"-w \" + .) | .[]" ../package.json)
 
 .PHONY: build
 build:


### PR DESCRIPTION
This target previously did an overly-broad build of all of our TS sources, slowing down local development workflow and incurring multiple unnecesasary builds in CI.

NPM's `--workspace/-w` CLI flags only offer a whitelist, not a blacklist, so this specifies all of the workspaces _except_ for those under `sql/ts/**`: the configs at the repo root, and all packages under `skiplang/**` and `skipruntime-ts/**`.