### PR TITLE
Exclude examples from skipruntime-ts build jobs

### DIFF
--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 SKARGO_PROFILE?=release
-NPM_WORKSPACES=$(shell jq --raw-output "[.workspaces[] | select(startswith(\"sql\") | not)] | map(\"-w \" + .) | .[]" ../package.json)
+NPM_WORKSPACES=$(shell jq --raw-output "[.workspaces[] | select((startswith(\"sql\") or contains(\"examples\")) | not)] | map(\"-w \" + .) | .[]" ../package.json)
 
 .PHONY: build
 build:


### PR DESCRIPTION
Follow-up to #671; meant to include there but apparently I don't understand github "automerge" as it jumped the gun.