### PR TITLE
skiplang and skip docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,9 @@
 Dockerfile
 **/target/
 node_modules/
-/compiler/bootstrap/*.ll
-/compiler/runtime/*.bc
-/compiler/runtime/*.a
-/compiler/runtime/*.o
-/compiler/runtime/magic.c
-/compiler/stage*
+/skiplang/compiler/bootstrap/*.ll
+/skiplang/prelude/runtime/*.bc
+/skiplang/prelude/runtime/*.a
+/skiplang/prelude/runtime/*.o
+/skiplang/prelude/runtime/magic.c
+/skiplang/compiler/stage*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,9 @@ RUN apt-get update && \
     echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list.d/llvm.list && \
     echo "deb https://deb.nodesource.com/node_22.x nodistro main" >> /etc/apt/sources.list.d/nodejs.list && \
     apt-get update && \
-    apt-get install -q -y automake clang-15 clang-format-15 curl file gawk gcc git jq lld-15 llvm-15 make nodejs parallel sqlite3 unzip zip && \
+    apt-get install -q -y automake clang-15 clang-format-15 curl file gawk gcc git jq lld-15 llvm-15 make nodejs parallel unzip zip && \
     npm install -g bun && \
-    npm install -g prettier && \
-    npx playwright install-deps
-
-RUN sh -c 'curl -s "https://get.sdkman.io?rcupdate=false" | bash'
-RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
-    sdk install gradle && \
-    sdk install java 20.0.2-tem"
+    npm install -g prettier
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-FROM ubuntu:22.04 AS stage0
+FROM ubuntu:22.04 AS skiplang-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -q -y wget gnupg && \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    wget -O - https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list.d/llvm.list && \
     echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list.d/llvm.list && \
-    echo "deb https://deb.nodesource.com/node_22.x nodistro main" >> /etc/apt/sources.list.d/nodejs.list && \
     apt-get update && \
-    apt-get install -q -y automake clang-15 clang-format-15 curl file gawk gcc git jq lld-15 llvm-15 make nodejs parallel unzip zip && \
-    npm install -g bun && \
-    npm install -g prettier
+    apt-get install -q -y automake clang-15 clang-format-15 curl file gawk gcc git jq lld-15 llvm-15 make parallel unzip zip
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100 && \
@@ -25,14 +21,23 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100 && 
 ENV CC=clang
 ENV CXX=clang++
 
-FROM stage0 AS bootstrap
+FROM skiplang-base AS bootstrap
 
 COPY ./skiplang /work
 
 WORKDIR /work/compiler
 RUN make clean && make STAGE=0
 
-FROM stage0 AS base
+FROM skiplang-base AS skiplang
 
 COPY --from=bootstrap /work/compiler/stage0/bin/ /usr/bin/
 COPY --from=bootstrap /work/compiler/stage0/lib/ /usr/lib/
+
+FROM skiplang AS skip
+
+RUN wget -O - https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | apt-key add - && \
+    echo "deb https://deb.nodesource.com/node_22.x nodistro main" >> /etc/apt/sources.list.d/nodejs.list && \
+    apt-get update && \
+    apt-get install -q -y nodejs && \
+    npm install -g bun && \
+    npm install -g prettier

--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -6,19 +6,34 @@ REPO="$SCRIPT_DIR/.."
 set -e
 set -x
 
+if [ "$1" = "--prod" ]; then
+  DOCKERBUILD_EXTRA=("--platform=linux/amd64")
+  PROD=true
+else
+  DOCKERBUILD_EXTRA=()
+  PROD=false
+fi
+
 cd "$REPO"
 
 git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
 echo ".git" >> .dockerignore
 
 dockerbuild () {
-    docker build . --no-cache --progress=plain --tag "$1" --file "$2/Dockerfile"
+    local tag="$1"
+    local file="$2/Dockerfile"
+    shift 2
+    docker build . --no-cache --progress=plain --tag "$tag" --file "$file" "$@"
 }
 
-dockerbuild skiplabs/skdb-base .
-dockerbuild skiplabs/skdb sql
-dockerbuild skiplabs/skdb-dev-server sql/server/dev
-[[ -f $USER/Dockerfile ]] && dockerbuild "$USER-skdb" "$USER"
+dockerbuild skiplabs/skdb-base . "${DOCKERBUILD_EXTRA[@]}"
+dockerbuild skiplabs/skdb sql "${DOCKERBUILD_EXTRA[@]}"
+if $PROD; then
+  dockerbuild skiplabs/server-core sql/server/core
+else
+  dockerbuild skiplabs/skdb-dev-server sql/server/dev
+  [[ -f $USER/Dockerfile ]] && dockerbuild "$USER-skdb" "$USER"
+fi
 
 git restore .dockerignore
 

--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -6,19 +6,19 @@ REPO="$SCRIPT_DIR/.."
 set -e
 set -x
 
-cd $REPO
+cd "$REPO"
 
 git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
 echo ".git" >> .dockerignore
 
 dockerbuild () {
-    docker build . --no-cache --progress=plain --tag $1 --file $2/Dockerfile
+    docker build . --no-cache --progress=plain --tag "$1" --file "$2/Dockerfile"
 }
 
 dockerbuild skiplabs/skdb-base .
 dockerbuild skiplabs/skdb sql
 dockerbuild skiplabs/skdb-dev-server sql/server/dev
-[[ -f $USER/Dockerfile ]] && dockerbuild $USER-skdb $USER
+[[ -f $USER/Dockerfile ]] && dockerbuild "$USER-skdb" "$USER"
 
 git restore .dockerignore
 

--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -26,7 +26,8 @@ dockerbuild () {
     docker build . --no-cache --progress=plain --tag "$tag" --file "$file" "$@"
 }
 
-dockerbuild skiplabs/skdb-base . "${DOCKERBUILD_EXTRA[@]}"
+dockerbuild skiplabs/skip-base . "${DOCKERBUILD_EXTRA[@]}"
+dockerbuild skiplabs/skdb-base sql --target base "${DOCKERBUILD_EXTRA[@]}"
 dockerbuild skiplabs/skdb sql "${DOCKERBUILD_EXTRA[@]}"
 if $PROD; then
   dockerbuild skiplabs/server-core sql/server/core

--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -26,7 +26,8 @@ dockerbuild () {
     docker build . --no-cache --progress=plain --tag "$tag" --file "$file" "$@"
 }
 
-dockerbuild skiplabs/skip-base . "${DOCKERBUILD_EXTRA[@]}"
+dockerbuild skiplabs/skiplang . --target skiplang "${DOCKERBUILD_EXTRA[@]}"
+dockerbuild skiplabs/skip . "${DOCKERBUILD_EXTRA[@]}"
 dockerbuild skiplabs/skdb-base sql --target base "${DOCKERBUILD_EXTRA[@]}"
 dockerbuild skiplabs/skdb sql "${DOCKERBUILD_EXTRA[@]}"
 if $PROD; then

--- a/bin/build_prod_skdb_images.sh
+++ b/bin/build_prod_skdb_images.sh
@@ -1,28 +1,6 @@
 #! /bin/bash
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO="$SCRIPT_DIR/.."
-
 set -e
 set -x
 
-cd "$REPO"
-
-git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
-echo ".git" >> .dockerignore
-
-dockerbuild () {
-    docker build . --no-cache --progress=plain --tag "$1" --file "$2/Dockerfile" "$3"
-}
-
-dockerbuild skiplabs/skdb-base . --platform=linux/amd64
-dockerbuild skiplabs/skdb sql --platform=linux/amd64
-dockerbuild skiplabs/server-core sql/server/core
-
-git restore .dockerignore
-
-echo disk usage:
-docker system df
-
-echo images:
-docker images
+"$(dirname -- "${BASH_SOURCE[0]}")"/build_docker_images.sh --prod

--- a/bin/build_prod_skdb_images.sh
+++ b/bin/build_prod_skdb_images.sh
@@ -6,13 +6,13 @@ REPO="$SCRIPT_DIR/.."
 set -e
 set -x
 
-cd $REPO
+cd "$REPO"
 
 git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
 echo ".git" >> .dockerignore
 
 dockerbuild () {
-    docker build . --no-cache --progress=plain --tag "$1" --file "$2/Dockerfile" $3
+    docker build . --no-cache --progress=plain --tag "$1" --file "$2/Dockerfile" "$3"
 }
 
 dockerbuild skiplabs/skdb-base . --platform=linux/amd64

--- a/bin/release_docker.sh
+++ b/bin/release_docker.sh
@@ -1,0 +1,79 @@
+#! /bin/bash
+
+# if hitting space issues, try some of these
+# docker system df
+# docker system prune
+# docker system prune -a
+# docker volume rm $(docker volume ls -qf dangling=true)
+# docker image rm $(docker image ls -qf dangling=true)
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR/../" || exit 1
+
+usage() {
+    echo "Usage: $0 NAME:TAG+"
+    echo "  where NAME:TAG is one of"
+    echo "    skdb:latest"
+    echo "    skdb-base:latest"
+    echo "    skdb-dev-server:latest, skdb-dev-server:quickstart"
+    echo "  the tag latest can be omitted"
+}
+
+if [ $# -eq 0 ]; then
+    usage
+    exit 1
+fi
+
+for name_tag in "$@"; do
+  case "${name_tag%:latest}" in
+    skdb)
+      BUILD_SKDB=true
+      ;;
+    skdb-base)
+      BUILD_SKDB_BASE=true
+      ;;
+    skdb-dev-server)
+      BUILD_SKDB_DEV_SERVER_ARGS+=(--tag skiplabs/skdb-dev-server:latest)
+      ;;
+    skdb-dev-server:quickstart)
+      BUILD_SKDB_DEV_SERVER_ARGS+=(--tag skiplabs/skdb-dev-server:quickstart)
+      ;;
+    *)
+      echo "Unknown NAME:TAG '$name_tag'"
+      echo
+      usage
+      exit 1
+  esac
+done
+
+git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
+echo ".git" >> .dockerignore
+
+builder=$(docker buildx create --use)
+
+dockerbuild () {
+  docker buildx build \
+       . \
+       --no-cache \
+       --progress=plain \
+       --platform linux/amd64,linux/arm64 \
+       --push \
+       "$@"
+}
+
+if ${BUILD_SKDB_BASE:-false}; then
+  dockerbuild --file Dockerfile --tag skiplabs/skdb-base:latest
+fi
+
+if ${BUILD_SKDB:-false}; then
+  dockerbuild --file sql/Dockerfile --tag skiplabs/skdb:latest
+fi
+
+if [ ${#BUILD_SKDB_DEV_SERVER_ARGS[@]} -gt 0 ]; then
+  dockerbuild --file sql/server/dev/Dockerfile "${BUILD_SKDB_DEV_SERVER_ARGS[@]}"
+fi
+
+docker buildx stop "$builder"
+docker buildx rm "$builder"
+
+git restore .dockerignore

--- a/bin/release_docker.sh
+++ b/bin/release_docker.sh
@@ -13,7 +13,8 @@ cd "$SCRIPT_DIR/../" || exit 1
 usage() {
     echo "Usage: $0 NAME:TAG+"
     echo "  where NAME:TAG is one of"
-    echo "    skip-base:latest"
+    echo "    skiplang:latest"
+    echo "    skip:latest"
     echo "    skdb:latest"
     echo "    skdb-base:latest"
     echo "    skdb-dev-server:latest, skdb-dev-server:quickstart"
@@ -27,8 +28,11 @@ fi
 
 for name_tag in "$@"; do
   case "${name_tag%:latest}" in
-    skip-base)
-      BUILD_SKIP_BASE=true
+    skiplang)
+      BUILD_SKIPLANG=true
+      ;;
+    skip)
+      BUILD_SKIP=true
       ;;
     skdb)
       BUILD_SKDB=true
@@ -65,8 +69,12 @@ dockerbuild () {
        "$@"
 }
 
-if ${BUILD_SKIP_BASE:-false}; then
-  dockerbuild --file Dockerfile --tag skiplabs/skip-base:latest
+if ${BUILD_SKIPLANG:-false}; then
+  dockerbuild --file Dockerfile --target skiplang --tag skiplabs/skiplang:latest
+fi
+
+if ${BUILD_SKIP:-false}; then
+  dockerbuild --file Dockerfile --tag skiplabs/skip:latest
 fi
 
 if ${BUILD_SKDB_BASE:-false}; then

--- a/bin/release_docker.sh
+++ b/bin/release_docker.sh
@@ -13,6 +13,7 @@ cd "$SCRIPT_DIR/../" || exit 1
 usage() {
     echo "Usage: $0 NAME:TAG+"
     echo "  where NAME:TAG is one of"
+    echo "    skip-base:latest"
     echo "    skdb:latest"
     echo "    skdb-base:latest"
     echo "    skdb-dev-server:latest, skdb-dev-server:quickstart"
@@ -26,6 +27,9 @@ fi
 
 for name_tag in "$@"; do
   case "${name_tag%:latest}" in
+    skip-base)
+      BUILD_SKIP_BASE=true
+      ;;
     skdb)
       BUILD_SKDB=true
       ;;
@@ -61,8 +65,12 @@ dockerbuild () {
        "$@"
 }
 
+if ${BUILD_SKIP_BASE:-false}; then
+  dockerbuild --file Dockerfile --tag skiplabs/skip-base:latest
+fi
+
 if ${BUILD_SKDB_BASE:-false}; then
-  dockerbuild --file Dockerfile --tag skiplabs/skdb-base:latest
+  dockerbuild --file sql/Dockerfile --target base --tag skiplabs/skdb-base:latest
 fi
 
 if ${BUILD_SKDB:-false}; then

--- a/bin/release_docker_skdb.sh
+++ b/bin/release_docker_skdb.sh
@@ -1,31 +1,6 @@
 #! /bin/bash
 
-# if hitting space issues, try some of these
-# docker system df
-# docker system prune
-# docker system prune -a
-# docker volume rm $(docker volume ls -qf dangling=true)
-# docker image rm $(docker image ls -qf dangling=true)
+set -e
+set -x
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-cd "$SCRIPT_DIR/../" || exit 1
-
-git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
-echo ".git" >> .dockerignore
-
-builder=$(docker buildx create --use)
-
-docker buildx build \
-       --no-cache \
-       --progress=plain \
-       --platform linux/amd64,linux/arm64 \
-       -t skiplabs/skdb:latest \
-       -f sql/Dockerfile \
-       --push \
-       .
-
-docker buildx stop "$builder"
-docker buildx rm "$builder"
-
-git restore .dockerignore
+"$(dirname -- "${BASH_SOURCE[0]}")"/release_docker.sh skdb

--- a/bin/release_docker_skdb_base.sh
+++ b/bin/release_docker_skdb_base.sh
@@ -1,30 +1,6 @@
 #! /bin/bash
 
-# if hitting space issues, try some of these
-# docker system df
-# docker system prune
-# docker system prune -a
-# docker volume rm $(docker volume ls -qf dangling=true)
-# docker image rm $(docker image ls -qf dangling=true)
+set -e
+set -x
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-cd "$SCRIPT_DIR/../" || exit 1
-
-git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
-echo ".git" >> .dockerignore
-
-builder=$(docker buildx create --use)
-
-docker buildx build \
-       --no-cache \
-       --progress=plain \
-       --platform linux/amd64,linux/arm64 \
-       -t skiplabs/skdb-base:latest \
-       --push \
-       .
-
-docker buildx stop "$builder"
-docker buildx rm "$builder"
-
-git restore .dockerignore
+"$(dirname -- "${BASH_SOURCE[0]}")"/release_docker.sh skdb-base

--- a/bin/release_docker_skdb_dev_server.sh
+++ b/bin/release_docker_skdb_dev_server.sh
@@ -13,15 +13,15 @@ cd "$SCRIPT_DIR/../" || exit 1
 
 read -r -p "Release 'latest' version? [y/N] " latest
 if [[ "$latest" =~ ^([yY]|[yY][eE][sS])$ ]]; then
-    push_latest="-t skiplabs/skdb-dev-server:latest"
+    push_latest=(-t skiplabs/skdb-dev-server:latest)
 fi
 
 read -r -p "Release 'quickstart' version? [y/N] " quickstart
 if [[ "$quickstart" =~ ^([yY]|[yY][eE][sS])$ ]]; then
-    push_quickstart="-t skiplabs/skdb-dev-server:quickstart"
+    push_quickstart=(-t skiplabs/skdb-dev-server:quickstart)
 fi
 
-if [[ -z "$push_latest" && -z "$push_quickstart" ]]; then
+if [[ -z "${push_latest[*]}" && -z "${push_quickstart[*]}" ]]; then
     echo Nothing to do, exiting.
     exit 0
 fi
@@ -35,8 +35,8 @@ docker buildx build \
        --no-cache \
        --progress=plain \
        --platform linux/amd64,linux/arm64 \
-       $push_latest \
-       $push_quickstart \
+       "${push_latest[@]}" \
+       "${push_quickstart[@]}" \
        -f sql/server/dev/Dockerfile \
        --push \
        .

--- a/bin/release_docker_skdb_dev_server.sh
+++ b/bin/release_docker_skdb_dev_server.sh
@@ -1,49 +1,23 @@
 #! /bin/bash
 
-# if hitting space issues, try some of these
-# docker system df
-# docker system prune
-# docker system prune -a
-# docker volume rm $(docker volume ls -qf dangling=true)
-# docker image rm $(docker image ls -qf dangling=true)
+set -e
+set -x
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-cd "$SCRIPT_DIR/../" || exit 1
+tags=()
 
 read -r -p "Release 'latest' version? [y/N] " latest
 if [[ "$latest" =~ ^([yY]|[yY][eE][sS])$ ]]; then
-    push_latest=(-t skiplabs/skdb-dev-server:latest)
+    tags+=(skdb-dev-server:latest)
 fi
 
 read -r -p "Release 'quickstart' version? [y/N] " quickstart
 if [[ "$quickstart" =~ ^([yY]|[yY][eE][sS])$ ]]; then
-    push_quickstart=(-t skiplabs/skdb-dev-server:quickstart)
+    tags+=(skdb-dev-server:quickstart)
 fi
 
-if [[ -z "${push_latest[*]}" && -z "${push_quickstart[*]}" ]]; then
+if [[ -z "${tags[*]}" ]]; then
     echo Nothing to do, exiting.
     exit 0
 fi
 
-git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
-echo ".git" >> .dockerignore
-
-builder=$(docker buildx create --platform linux/amd64,linux/arm64 --use)
-
-docker buildx build \
-       --no-cache \
-       --progress=plain \
-       --platform linux/amd64,linux/arm64 \
-       "${push_latest[@]}" \
-       "${push_quickstart[@]}" \
-       -f sql/server/dev/Dockerfile \
-       --push \
-       .
-
-# TODO: keep versions and alias latest
-
-docker buildx stop "$builder"
-docker buildx rm "$builder"
-
-git restore .dockerignore
+"$(dirname -- "${BASH_SOURCE[0]}")"/release_docker.sh "${tags[@]}"

--- a/sql/Dockerfile
+++ b/sql/Dockerfile
@@ -1,4 +1,4 @@
-FROM skiplabs/skip-base AS base
+FROM skiplabs/skip AS base
 
 RUN apt-get install -q -y sqlite3
 RUN npx playwright install-deps

--- a/sql/Dockerfile
+++ b/sql/Dockerfile
@@ -1,8 +1,17 @@
-FROM skiplabs/skdb-base AS skdb
+FROM skiplabs/skip-base AS base
+
+RUN apt-get install -q -y sqlite3
+RUN npx playwright install-deps
+
+RUN sh -c 'curl -s "https://get.sdkman.io?rcupdate=false" | bash'
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+    sdk install gradle && \
+    sdk install java 20.0.2-tem"
+
+FROM base AS skdb
 
 COPY . /skdb
 
 WORKDIR /skdb
 
 RUN make clean && make -C skiplang/compiler clean && make build/skdb && make build/init.sql
-


### PR DESCRIPTION
Removed things that were useful for skdb but not skipruntime. I.e.
`skdb-base` = `skip` + `sqlite3`, `playwright`, `sdk`, `gradle`, `java` (3.35GB)
`skip` = `skiplang` + nodejs (2.04GB)
`skiplang` (1.27GB)

Once `skiplang` and `skip` are pushed, we can use it in the CI in place of skdb-base for most things.

Also merged the shell scripts to reduce copy-pastes.