### PR TITLE
Fix postgres setup/teardown sequencing

### DIFF
--- a/skipruntime-ts/adapters/postgres/package.json
+++ b/skipruntime-ts/adapters/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-adapter/postgres",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "exports": {
     ".": "./dist/index.js"

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -20,6 +20,6 @@
     "@skipruntime/helpers": "0.0.9",
     "@skipruntime/native": "0.0.5",
     "@skipruntime/wasm": "0.0.7",
-    "@skip-adapter/postgres": "0.0.4"
+    "@skip-adapter/postgres": "0.0.5"
   }
 }

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -591,9 +591,6 @@ const pg_config = {
 
 // One-off client to create a test SQL table and set up its contents
 const pgSetupClient = new pg.Client(pg_config);
-pgSetupClient.connect().catch(() => {
-  throw new Error("Error connecting to PostgreSQL test instance");
-});
 let pgIsSetup = false;
 
 async function trySetupDB(
@@ -629,7 +626,9 @@ const postgresService: () => Promise<
   SkipService<Input_NN, Input_NN>
 > = async () => {
   const postgres = new PostgresExternalService(pg_config);
-
+  pgSetupClient.connect().catch(() => {
+    throw new Error("Error connecting to PostgreSQL test instance");
+  });
   if (!(await trySetupDB(postgres))) {
     throw new Error("Failed to set up test Postgres DB");
   }


### PR DESCRIPTION
2 unrelated fixes:
 
 * the changes I made to the postgres test setup to accomodate running wasm/native clients separately against in f9fc0f9661bf8f4098676c2a9ea4fc66eafb148a meant that the "nice" warning message printed on systems without a running postgres instance was instead just an exception.
 * Mehdi noticed some error messages in CI on teardown, with "drop function" pointing at functions that don't exist.  This should fix that -- the issue was a race with the runtime calling both unsubscribe and shutdown on the postgres service.
