### PR TITLE
Update HN example with new packages

### DIFF
--- a/examples/hackernews/reactive_service/package.json
+++ b/examples/hackernews/reactive_service/package.json
@@ -9,9 +9,10 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "postgres": "^3.4.5",
-    "@skipruntime/api": "0.0.6",
-    "@skipruntime/server": "0.0.8"
+    "@skipruntime/core": "0.0.6",
+    "@skipruntime/wasm": "0.0.7",
+    "@skipruntime/server": "0.0.9",
+    "@skip-adapter/postgres": "0.0.5"
   },
   "devDependencies": {
     "@skiplabs/eslint-config": "^0.0.1",

--- a/examples/hackernews/reactive_service/server.js
+++ b/examples/hackernews/reactive_service/server.js
@@ -1,15 +1,5 @@
-import postgres from "postgres";
 import { runService } from "@skipruntime/server";
-import { serviceWithInitialData } from "./dist/hackernews.service.js";
+import { initService } from "@skipruntime/wasm";
+import { service } from "./dist/hackernews.service.js";
 
-const sql = postgres("postgres://postgres:change_me@db:5432");
-async function selectAll(table) {
-  return (await sql`SELECT * FROM ${sql(table)}`).map((r) => [r.id, [r]]);
-}
-
-// Initial values.
-const posts = await selectAll("posts");
-const users = await selectAll("users");
-const upvotes = await selectAll("upvotes");
-
-runService(serviceWithInitialData(posts, users, upvotes));
+runService(await initService(service));

--- a/examples/hackernews/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/reactive_service/src/hackernews.service.ts
@@ -1,11 +1,13 @@
 import type {
+  Context,
   EagerCollection,
-  Entry,
   Json,
   Values,
   Resource,
   SkipService,
-} from "@skipruntime/api";
+} from "@skipruntime/core";
+
+import { PostgresExternalService } from "@skip-adapter/postgres";
 
 type Post = {
   author_id: number;

--- a/examples/hackernews/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/reactive_service/src/hackernews.service.ts
@@ -56,7 +56,12 @@ class PostsMapper {
   mapEntry(key: number, values: Values<Post>): Iterable<[number, Upvoted]> {
     const post: Post = values.getUnique();
     const upvotes = this.upvotes.getArray(key).length;
-    const author = this.users.getUnique(post.author_id);
+    let author;
+    try {
+      author = this.users.getUnique(post.author_id);
+    } catch {
+      author = { name: "unknown author", email: "unknown email" };
+    }
     // Projecting all posts on key 0 so that they can later be sorted.
     return [[0, { ...post, upvotes, author }]];
   }

--- a/examples/hackernews/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/reactive_service/src/hackernews.service.ts
@@ -28,34 +28,17 @@ type Upvote = {
 
 type Upvoted = Post & { upvotes: number; author: User };
 
-type Inputs = {
-  posts: EagerCollection<number, Post>;
-  users: EagerCollection<number, User>;
-  upvotes: EagerCollection<number, Upvote>;
-};
 type ResourceInputs = {
   postsWithUpvotes: EagerCollection<number, Upvoted>;
 };
 
-export function serviceWithInitialData(
-  posts: Entry<number, Post>[],
-  users: Entry<number, User>[],
-  upvotes: Entry<number, Upvote>[],
-): SkipService<Inputs, ResourceInputs> {
-  return {
-    initialData: { posts, users, upvotes },
-    resources: { posts: PostsResource },
-    createGraph: (inputCollections: Inputs): ResourceInputs => {
-      return {
-        postsWithUpvotes: inputCollections.posts.map(
-          PostsMapper,
-          inputCollections.users,
-          inputCollections.upvotes.map(UpvotesMapper),
-        ),
-      };
-    },
-  };
-}
+const postgres = new PostgresExternalService({
+  host: "db",
+  port: 5432,
+  database: "postgres",
+  user: "postgres",
+  password: "change_me",
+});
 
 class UpvotesMapper {
   mapEntry(key: number, values: Values<Upvote>): Iterable<[number, number]> {
@@ -100,3 +83,34 @@ class PostsResource implements Resource<ResourceInputs> {
     return collections.postsWithUpvotes.take(this.limit).map(SortingMapper);
   }
 }
+
+export const service: SkipService<{}, ResourceInputs> = {
+  initialData: {},
+  resources: { posts: PostsResource },
+  externalServices: { postgres },
+  createGraph(_: {}, context: Context): ResourceInputs {
+    const serialIDKey = { key: { col: "id", type: "SERIAL" } };
+    const posts = context.useExternalResource<number, Post>({
+      service: "postgres",
+      identifier: "posts",
+      params: serialIDKey,
+    });
+    const users = context.useExternalResource<number, User>({
+      service: "postgres",
+      identifier: "users",
+      params: serialIDKey,
+    });
+    const upvotes = context.useExternalResource<number, Upvote>({
+      service: "postgres",
+      identifier: "upvotes",
+      params: serialIDKey,
+    });
+    return {
+      postsWithUpvotes: posts.map(
+        PostsMapper,
+        users,
+        upvotes.map(UpvotesMapper),
+      ),
+    };
+  },
+};

--- a/examples/hackernews/web_service/app.py
+++ b/examples/hackernews/web_service/app.py
@@ -85,13 +85,7 @@ def create_post():
             post_id = cur.fetchone()[0]
             db.commit()
 
-    # Write into the reactive input collection.
-    resp = requests.patch(
-        f"{REACTIVE_SERVICE_URL}/inputs/posts",
-        json=[[post_id, [{**params, "id": post_id, "author_id": author_id}]]],
-    )
-
-    return resp.reason, resp.status_code
+    return "ok", 200
 
 
 @app.delete("/posts/<int:post_id>")
@@ -107,31 +101,7 @@ def delete_post(post_id):
             # Delete the post.
             cur.execute(f"DELETE FROM posts WHERE id={post_id}")
             db.commit()
-
-    # Write into the reactive input collections.
-    upvotes_resp = requests.patch(
-        f"{REACTIVE_SERVICE_URL}/inputs/upvotes",
-        json=[[upvote_id, []] for upvote_id in upvote_ids],
-    )
-    posts_resp = requests.patch(
-        f"{REACTIVE_SERVICE_URL}/inputs/posts",
-        json=[[post_id, []]],
-    )
-
-    if upvotes_resp.status_code != 200 and posts_resp.status_code != 200:
-        reason = f"Failed to update upvotes: {upvotes_resp.reason} and posts: {posts_resp.reason}"
-        status_code = 500
-    elif upvotes_resp.status_code != 200:
-        reason = f"Failed to update upvotes: {upvotes_resp.reason}"
-        status_code = upvotes_resp.status_code
-    elif posts_resp.status_code != 200:
-        reason = f"Failed to update posts: {posts_resp.reason}"
-        status_code = posts_resp.status_code
-    else:
-        reason = "ok"
-        status_code = 200
-
-    return reason, status_code
+    return "ok", 200
 
 
 @app.put("/posts/<int:post_id>")
@@ -148,13 +118,7 @@ def update_post(post_id):
             )
             db.commit()
 
-    # Write into the reactive input collection.
-    resp = requests.patch(
-        f"{REACTIVE_SERVICE_URL}/inputs/posts",
-        json=[[post_id, [{**params, "id": post_id}]]],
-    )
-
-    return resp.reason, resp.status_code
+    return "ok", 200
 
 
 @app.post("/posts/<int:post_id>/upvotes")
@@ -171,13 +135,7 @@ def upvote_post(post_id):
             upvote_id = cur.fetchone()[0]
             db.commit()
 
-    # Write into the reactive input collection.
-    resp = requests.patch(
-        f"{REACTIVE_SERVICE_URL}/inputs/upvotes",
-        json=[[upvote_id, [{"post_id": post_id, "user_id": user_id}]]],
-    )
-
-    return resp.reason, resp.status_code
+    return "ok", 200
 
 
 @app.get("/healthcheck")

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,9 +50,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/api": "0.0.6",
-        "@skipruntime/server": "0.0.8",
-        "postgres": "^3.4.5"
+        "@skip-adapter/postgres": "0.0.5",
+        "@skipruntime/core": "0.0.6",
+        "@skipruntime/server": "0.0.9",
+        "@skipruntime/wasm": "0.0.7"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
@@ -386,18 +387,6 @@
     "node_modules/@skiplang/std": {
       "resolved": "skiplang/prelude/ts/binding",
       "link": true
-    },
-    "node_modules/@skipruntime/api": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@skipruntime/api/-/api-0.0.6.tgz",
-      "integrity": "sha512-1roWZbNcZKTyN+RcnlNsQCWoItyXO2fCsDpiyM1rfjcXFmglvPgns3hb3GpK6/9SRINkLfuux8/2Bp7nGexn+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@skiplang/json": "^0.0.3"
-      },
-      "engines": {
-        "node": ">=22.6.0 <23.0.0"
-      }
     },
     "node_modules/@skipruntime/core": {
       "resolved": "skipruntime-ts/core",
@@ -3198,19 +3187,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/postgres": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.5.tgz",
-      "integrity": "sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/porsager"
-      }
-    },
     "node_modules/postgres-array": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
@@ -4481,7 +4457,7 @@
     },
     "skipruntime-ts/adapters/postgres": {
       "name": "@skip-adapter/postgres",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@skipruntime/core": "0.0.6",
@@ -4555,7 +4531,7 @@
       "name": "@skipruntime/tests",
       "version": "0.0.10",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.3",
+        "@skip-adapter/postgres": "0.0.5",
         "@skipruntime/core": "0.0.6",
         "@skipruntime/helpers": "0.0.9",
         "@skipruntime/native": "0.0.5",


### PR DESCRIPTION
Use the new postgres adapter code in the hackernews example, dropping the stopgap setup of writing to the reactive service's input collections from the web service and instead just writing to the DB and letting data bubble up to the reactive layer.

Also close #677 by updating all of our package versions and service initializaiton code.