### PR TITLE
Avoid explicit `initService` in user code by dynamic dispatch in `runService`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4525,6 +4525,10 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.0"
+      },
+      "optionalDependencies": {
+        "@skipruntime/native": "0.0.5",
+        "@skipruntime/wasm": "0.0.7"
       }
     },
     "skipruntime-ts/tests": {

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -6,7 +6,6 @@ import type {
 } from "@skipruntime/core";
 
 import { runService } from "@skipruntime/server";
-import { initService } from "@skipruntime/wasm";
 
 import Database from "better-sqlite3";
 
@@ -79,9 +78,7 @@ const data: Entry<string, User>[] = db
 
 db.close();
 
-const instance = await initService(serviceWithInitialData(data));
-
-const closable = runService(instance, {
+const closable = await runService(serviceWithInitialData(data), {
   streaming_port: 8080,
   control_port: 8081,
 });

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -78,13 +78,13 @@ const data: Entry<string, User>[] = db
 
 db.close();
 
-const closable = await runService(serviceWithInitialData(data), {
+const server = await runService(serviceWithInitialData(data), {
   streaming_port: 8080,
   control_port: 8081,
 });
 
 function shutdown() {
-  closable.close();
+  server.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -1,4 +1,9 @@
-import type { Context, EagerCollection, Resource, SkipService } from "@skipruntime/core";
+import type {
+  Context,
+  EagerCollection,
+  Resource,
+  SkipService,
+} from "@skipruntime/core";
 import { runService } from "@skipruntime/server";
 import { GenericExternalService, Polled } from "@skipruntime/helpers";
 
@@ -47,7 +52,7 @@ class DeparturesResource implements Resource<ResourceInputs> {
   }
 }
 
-const service : SkipService<ResourceInputs, ResourceInputs> = {
+const service: SkipService<ResourceInputs, ResourceInputs> = {
   initialData: { config: [] },
   resources: {
     departures: DeparturesResource,
@@ -64,13 +69,13 @@ const service : SkipService<ResourceInputs, ResourceInputs> = {
   createGraph: (ic) => ic,
 };
 
-const closable = await runService(service, {
+const server = await runService(service, {
   control_port: 3591,
   streaming_port: 3590,
 });
 
 function shutdown() {
-  closable.close();
+  server.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -1,5 +1,4 @@
-import type { EagerCollection, Context, Resource } from "@skipruntime/core";
-import { initService } from "@skipruntime/wasm";
+import type { Context, EagerCollection, Resource, SkipService } from "@skipruntime/core";
 import { runService } from "@skipruntime/server";
 import { GenericExternalService, Polled } from "@skipruntime/helpers";
 
@@ -48,7 +47,7 @@ class DeparturesResource implements Resource<ResourceInputs> {
   }
 }
 
-const instance = await initService({
+const service : SkipService<ResourceInputs, ResourceInputs> = {
   initialData: { config: [] },
   resources: {
     departures: DeparturesResource,
@@ -63,15 +62,15 @@ const instance = await initService({
     }),
   },
   createGraph: (ic) => ic,
-});
+};
 
-const service = runService(instance, {
+const closable = await runService(service, {
   control_port: 3591,
   streaming_port: 3590,
 });
 
 function shutdown() {
-  service.close();
+  closable.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/groups.ts
+++ b/skipruntime-ts/examples/groups.ts
@@ -6,7 +6,6 @@ import {
   OneToManyMapper,
 } from "@skipruntime/core";
 
-import { initService } from "@skipruntime/wasm";
 import { runService } from "@skipruntime/server";
 
 type UserID = number;
@@ -77,22 +76,22 @@ class ActiveFriends implements Resource<ResourceInputs> {
   }
 }
 
-const instance = await initService({
+const service = {
   initialData,
   resources: { active_friends: ActiveFriends },
   createGraph(input: ServiceInputs): ResourceInputs {
     const actives = input.groups.map(ActiveUsers, input.users);
     return { users: input.users, actives };
   },
-});
+};
 
 // Specify and run the reactive service
-const service = runService(instance, {
+const closable = await runService(service, {
   streaming_port: 8080,
   control_port: 8081,
 });
 function shutdown() {
-  service.close();
+  closable.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/groups.ts
+++ b/skipruntime-ts/examples/groups.ts
@@ -86,12 +86,12 @@ const service = {
 };
 
 // Specify and run the reactive service
-const closable = await runService(service, {
+const server = await runService(service, {
   streaming_port: 8080,
   control_port: 8081,
 });
 function shutdown() {
-  closable.close();
+  server.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -7,8 +7,6 @@ import type {
 } from "@skipruntime/core";
 import { ManyToOneMapper } from "@skipruntime/core";
 import { SkipExternalService } from "@skipruntime/helpers";
-
-import { initService } from "@skipruntime/wasm";
 import { runService } from "@skipruntime/server";
 
 class Mult extends ManyToOneMapper<string, number, number> {
@@ -33,7 +31,7 @@ class MultResource implements Resource {
     return sub.merge(add).map(Mult);
   }
 }
-const instance = await initService({
+const service = {
   resources: { data: MultResource },
   externalServices: {
     sumexample: SkipExternalService.direct({
@@ -46,14 +44,14 @@ const instance = await initService({
   createGraph(inputCollections: NamedCollections) {
     return inputCollections;
   },
-});
-const service = runService(instance, {
+};
+const closable = await runService(service, {
   streaming_port: 3589,
   control_port: 3590,
 });
 
 function shutdown() {
-  service.close();
+  closable.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -45,13 +45,13 @@ const service = {
     return inputCollections;
   },
 };
-const closable = await runService(service, {
+const server = await runService(service, {
   streaming_port: 3589,
   control_port: 3590,
 });
 
 function shutdown() {
-  closable.close();
+  server.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -76,7 +76,7 @@ class ComputedCells implements Resource<Outputs> {
     return collections.output;
   }
 }
-const service  = {
+const service = {
   initialData: { cells: [] },
   resources: { computed: ComputedCells },
   createGraph(inputCollections: Inputs, context: Context): Outputs {
@@ -88,13 +88,13 @@ const service  = {
   },
 };
 
-const closable = await runService(service, {
+const server = await runService(service, {
   control_port: 9999,
   streaming_port: 9998,
 });
 
 function shutdown() {
-  closable.close();
+  server.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -9,7 +9,6 @@ import type {
 
 import { OneToOneMapper } from "@skipruntime/core";
 
-import { initService } from "@skipruntime/wasm";
 import { runService } from "@skipruntime/server";
 
 class ComputeExpression implements LazyCompute<string, string> {
@@ -77,7 +76,7 @@ class ComputedCells implements Resource<Outputs> {
     return collections.output;
   }
 }
-const instance = await initService({
+const service  = {
   initialData: { cells: [] },
   resources: { computed: ComputedCells },
   createGraph(inputCollections: Inputs, context: Context): Outputs {
@@ -87,15 +86,15 @@ const instance = await initService({
     // Produce eager collection for output resource
     return { output: cells.map(CallCompute, evaluator) };
   },
-});
+};
 
-const service = runService(instance, {
+const closable = await runService(service, {
   control_port: 9999,
   streaming_port: 9998,
 });
 
 function shutdown() {
-  service.close();
+  closable.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -2,7 +2,6 @@ import type { EagerCollection, Values, Resource } from "@skipruntime/core";
 
 import { ManyToOneMapper } from "@skipruntime/core";
 
-import { initService } from "@skipruntime/wasm";
 import { runService } from "@skipruntime/server";
 
 class Plus extends ManyToOneMapper<string, number, number> {
@@ -37,13 +36,13 @@ class Sub implements Resource<Collections> {
   }
 }
 
-const instance = await initService({
+const service = {
   initialData: { input1: [], input2: [] },
   resources: { add: Add, sub: Sub },
-  createGraph: (inputs) => inputs,
-});
+  createGraph: (inputs : Collections) => inputs,
+};
 
-const closable = runService(instance, {
+const closable = await runService(service, {
   control_port: 3588,
   streaming_port: 3587,
 });

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -39,16 +39,16 @@ class Sub implements Resource<Collections> {
 const service = {
   initialData: { input1: [], input2: [] },
   resources: { add: Add, sub: Sub },
-  createGraph: (inputs : Collections) => inputs,
+  createGraph: (inputs: Collections) => inputs,
 };
 
-const closable = await runService(service, {
+const server = await runService(service, {
   control_port: 3588,
   streaming_port: 3587,
 });
 
 function shutdown() {
-  closable.close();
+  server.close();
 }
 
 process.on("SIGTERM", shutdown);

--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -16,5 +16,9 @@
   "dependencies": {
     "express": "^4.21.1",
     "@skipruntime/core": "0.0.6"
+  },
+  "optionalDependencies": {
+    "@skipruntime/native": "0.0.5",
+    "@skipruntime/wasm": "0.0.7"
   }
 }

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -85,6 +85,7 @@ export type SkipServer = {
  * @param options - Service configuration options.
  * @param options.control_port - Port on which control service will listen.
  * @param options.streaming_port - Port on which streaming service will listen.
+ * @param options.platform - Skip runtime platform to be used to run the service: either `wasm`, `native`, or `auto` (which is the default and will prefer `native` if available).
  * @returns Object to manage the running server.
  */
 export async function runService(
@@ -92,24 +93,55 @@ export async function runService(
   options: {
     streaming_port: number;
     control_port: number;
+    platform?: "wasm" | "native" | "auto";
   } = {
     streaming_port: 8080,
     control_port: 8081,
+    platform: "auto",
   },
 ): Promise<SkipServer> {
   let instance: ServiceInstance;
-  try {
-    const runtime = await import("@skipruntime/native");
-    instance = await runtime.initService(service);
-  } catch {
+
+  const initNative = async () => {
     try {
-      const runtime = await import("@skipruntime/wasm");
-      instance = await runtime.initService(service);
+      const runtime = await import("@skipruntime/native");
+      return await runtime.initService(service);
     } catch {
       throw new Error(
-        "No Skip runtime found; one of `@skipruntime/native` (on a supported platform) or `@skipruntime/wasm` is required.",
+        'Error loading Skip runtime for specified "native" platform.',
       );
     }
+  };
+
+  const initWasm = async () => {
+    try {
+      const runtime = await import("@skipruntime/wasm");
+      return await runtime.initService(service);
+    } catch {
+      throw new Error(
+        'Error loading Skip runtime for specified "wasm" platform.',
+      );
+    }
+  };
+  switch (options.platform) {
+    case "native":
+      instance = await initNative();
+      break;
+    case "wasm":
+      instance = await initWasm();
+      break;
+    default:
+      try {
+        instance = await initNative();
+      } catch {
+        try {
+          instance = await initWasm();
+        } catch {
+          throw new Error(
+            "No Skip runtime found; one of `@skipruntime/native` (on a supported platform) or `@skipruntime/wasm` is required.",
+          );
+        }
+      }
   }
   const controlHttpServer = controlService(instance).listen(
     options.control_port,

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -81,7 +81,7 @@ export type SkipServer = {
  *
  * @typeParam Inputs - Named collections from which the service computes.
  * @typeParam ResourceInputs - Named collections provided to resource computations.
- * @param service - The SkipService definition to run
+ * @param service - The SkipService definition to run.
  * @param options - Service configuration options.
  * @param options.control_port - Port on which control service will listen.
  * @param options.streaming_port - Port on which streaming service will listen.

--- a/www/docs/externals.md
+++ b/www/docs/externals.md
@@ -20,22 +20,20 @@ Skip reactive services are designed to interoperate simply and easily: services 
 To receive data from another Skip service, specify it in the `externalServices` field of your `SkipService`, for example as follows:
 
 ```typescript
-const instance = await initService(
-  {
-    initialData: ...
-    resources: ...
-    createGraph: ...
-    externalServices: {
-      myOtherService: SkipExternalService.direct({
-        host: "my.other.service.net",
-        streaming_port: 8080,
-        control_port: 8081,
-      }),
-    },
-  }
-);
+const service = {
+  initialData: ...
+  resources: ...
+  createGraph: ...
+  externalServices: {
+    myOtherService: SkipExternalService.direct({
+      host: "my.other.service.net",
+      streaming_port: 8080,
+      control_port: 8081,
+    }),
+  },
+};
 
-const service = runService(instance);
+await runService(service);
 ```
 
 This instantiates a new service, with a dependency on a service named `myOtherService` running at the specified ports of `my.other.service.net`.
@@ -68,26 +66,23 @@ The simplest option is *polling*, sending periodic requests to pull data from ex
 To specify a polled external dependency, specify it in your service definition, e.g. as follows
 
 ```typescript
-const instannce = await initService(
-  {
-    initialData: ...
-    resources: ...
-    createGraph: ...
-    externalServices: {
-      myExternalService: new GenericExternalService({
-        my_resource: new Polled(
-          // HTTP endpoint
-          "https://api.example.com/my_resource",
-		  // Polling interval, in milliseconds
-          5000,
-		  // data processing into `Entry<K, V>[]` key/values structure
-          (data: Result) => data.results.map((value, idx) => [idx, [value]]))
-      }),
-    },
-  }
-);
-
-const service = await runService(instannce);
+const service = {
+  initialData: ...
+  resources: ...
+  createGraph: ...
+  externalServices: {
+    myExternalService: new GenericExternalService({
+      my_resource: new Polled(
+        // HTTP endpoint
+        "https://api.example.com/my_resource",
+	    // Polling interval, in milliseconds
+        5000,
+	    // data processing into `Entry<K, V>[]` key/values structure
+        (data: Result) => data.results.map((value, idx) => [idx, [value]]))
+    }),
+  },
+};
+await runService(service);
 ```
 
 Although the underlying data source is non-reactive, this external service can be used identically to reactive external Skip services as in the previous section, e.g.

--- a/www/docs/getting_started.md
+++ b/www/docs/getting_started.md
@@ -112,14 +112,15 @@ const [users, groups] = await Promise.all([
 ]);
 
 // Specify and run the reactive service
-const instance = await initService({
+const service = {
   initialData: { users, groups },
   resources: { active_friends: ActiveFriends },
   createGraph(input: ServiceInputs): ResourceInputs {
     const actives = input.groups.map(ActiveUsers, input.users);
     return { users: input.users, actives };
-  }});
-const service = runService(instance);
+  }
+};
+await runService(service);
 ```
 
 This example service operates over two _input collections_ (one for users and one for groups, as specified by `ServiceInputs`) and passes some `ResourceInputs` to its resources: a reactively-computed collection `actives` of the set of active users in each group, along with the `users` input collection.

--- a/www/docs/resources.md
+++ b/www/docs/resources.md
@@ -18,16 +18,15 @@ In this way, we can think of resources as parameterized outputs; request paramet
 For a concrete example, take the "active friends" resource from the getting-started [example](getting_started.md#the-anatomy-of-a-skip-service) service:
 
 ```typescript
-const instance = await initService({
+const service = {
   initialData: { users, groups },
   resources: { active_friends: ActiveFriends },
   createGraph(input: ServiceInputs): ResourceInputs {
     const actives = input.groups.map(ActiveUsers, input.users);
     return { users: input.users, actives };
   },
-});
-
-const service = await runService(instance);
+};
+await runService(service);
 ```
 
 The service has two input collections `"users"` and `"groups"` (populated here with some initial data), no external dependencies (i.e. the service definition does not define the optional `externalServices` field), and one resource: `ActiveFriends`, defined as follows:


### PR DESCRIPTION
Previously (before #668) we passed a `SkipService` _definition_ to `runService`, which figured out which runtime (wasm or native) was available, initialized the service, and spun up an HTTP server. Since that PR, `runService` expects an initialized service, leaving it up to client code which runtime to use.

This PR returns us to the pre-#668 status quo, dispatching to the proper `initService` from within `runService` depending on what's available at runtime.  The main benefits are to simplify the public interface, allow code to be more portable across platforms, and reduce the surface of APIs to document/expose.

@skiplabsdaniel , do you see any problems with this? It undoes your change as mentioned, but my impression from reading that is that the change was incidental.

cc @jberdine re: comments on #691 
