### PR TITLE
Minor build cleanups

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -119,6 +119,6 @@ jobs:
           no_output_timeout: 10m
           command: |
             mkdir -p ~/test-results
-            cd skipruntime-ts && make test test-examples
+            make test-skipruntime-ts
       - store_test_results:
           path: ~/test-results/skipruntime.xml

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ test-skjson:
 
 .PHONY: test-skipruntime-ts
 test-skipruntime-ts:
-	$(MAKE) -C skipruntime-ts test
+	$(MAKE) -C skipruntime-ts test test-examples
 
 test-%:
 	cd $* && skargo test --profile $(SKARGO_PROFILE)

--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -36,17 +36,23 @@ test: build
 	../bin/cd_sh tests "npm run test"
 
 build-examples:
-	cd examples && npm install && npm run build
+	../bin/cd_sh examples "npm install && npm run build"
 
 test-example-%:
-	cd tests/examples && ./$*.sh /tmp/$*.out /tmp/$*.err
+	../bin/cd_sh tests/examples "./$*.sh /tmp/$*.out /tmp/$*.err"
 	diff /tmp/$*.out tests/examples/$*.exp.out >/dev/null
 	diff /tmp/$*.err tests/examples/$*.exp.err >/dev/null
 
+
+EXAMPLES := $(patsubst tests/examples/%.sh,%,$(wildcard tests/examples/*.sh))
+
+EXAMPLE_TARGETS := $(patsubst %,test-example-%,$(EXAMPLES))
 .PHONY: test-examples
-test-examples: build-examples test-example-groups test-example-database test-example-departures test-example-remote test-example-sheet test-example-sum
+test-examples: build-examples $(EXAMPLE_TARGETS)
 
 regen-%:
 	cd tests/examples && ./$*.sh ../tests/examples/$*.exp.out ../tests/examples/$*.exp.err
 
-regenerate-expectations: build build-examples regen-groups regen-database regen-departures regen-remote regen-sheet regen-sum
+REGEN_TARGETS := $(patsubst %,regen-%,$(EXAMPLES))
+.PHONY: regenerate-expectations
+regenerate-expectations: build build-examples $(REGEN_TARGETS)


### PR DESCRIPTION
- Avoid naked `cd` in Makefiles since they lead to error messages with the
  wrong file names and no contextual output to resolve them.

- Automatically construct the list of skipruntime-ts example tests.