### PR TITLE
[skiplang/skstore] Fix locking in `runWithGcIntern`.

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -1566,6 +1566,9 @@ fun runWithGcIntern(
     }) match {
     | Some(x) -> x
     | None() ->
+      if (synchronizer is None _) {
+        gGlobalUnlock();
+      };
       destroyObstack(pos);
       return context
     };
@@ -1581,7 +1584,6 @@ fun runWithGcIntern(
           sync,
           underLockF,
         );
-        gGlobalUnlock();
         context.notifyAll(startTick);
         destroyObstack(pos)
       | Some _ ->


### PR DESCRIPTION
When calling `runWithGc()` without a `synchronizer`, the global lock was released after each iteration, and never re-acquired.

The code path did not seem to be actively used, as it would systematically crash.