### PR TITLE
Add @skipruntime/skip meta-package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,5 +292,9 @@ publish-server:
 publish-postgres-adapter:
 	bin/release_npm.sh @skip-adapter/postgres skipruntime-ts/adapters/postgres/package.json $(OPT)
 
+.PHONY: publish-metapackage
+publish-metapackage:
+	bin/release_npm.sh @skiplabs/skip skipruntime-ts/metapackage/package.json $(OPT)
+
 .PHONY: publish-all
-publish-all: clean publish-std publish-json publish-date publish-core publish-helpers publish-wasm publish-native publish-server publish-postgres-adapter
+publish-all: clean publish-std publish-json publish-date publish-core publish-helpers publish-wasm publish-native publish-server publish-postgres-adapter publish-metapackage

--- a/bin/release_npm.sh
+++ b/bin/release_npm.sh
@@ -12,7 +12,7 @@ fi
 
 cd $(dirname $2)
 
-npm run build
+npm run build --if-present
 
 npm run test --if-present
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4527,12 +4527,12 @@
       "dependencies": {
         "@skipruntime/core": "0.0.6",
         "@skipruntime/helpers": "0.0.9",
-        "@skipruntime/server": "0.0.9"
+        "@skipruntime/server": "0.0.9",
+        "@skipruntime/wasm": "0.0.7"
       },
       "optionalDependencies": {
         "@skip-adapter/postgres": "0.0.5",
-        "@skipruntime/native": "0.0.5",
-        "@skipruntime/wasm": "0.0.7"
+        "@skipruntime/native": "0.0.5"
       }
     },
     "skipruntime-ts/server": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "skipruntime-ts/tests",
         "skipruntime-ts/server",
         "skipruntime-ts/examples",
+        "skipruntime-ts/metapackage",
         "sql/ts",
         "sql/ts/tests",
         "examples/hackernews/reactive_service"
@@ -374,6 +375,10 @@
     },
     "node_modules/@skiplabs/eslint-config": {
       "resolved": "eslint-config",
+      "link": true
+    },
+    "node_modules/@skiplabs/skip": {
+      "resolved": "skipruntime-ts/metapackage",
       "link": true
     },
     "node_modules/@skiplabs/tsconfig": {
@@ -4514,6 +4519,20 @@
       },
       "engines": {
         "node": ">=22.6.0 <23.0.0"
+      }
+    },
+    "skipruntime-ts/metapackage": {
+      "name": "@skiplabs/skip",
+      "version": "0.0.1",
+      "dependencies": {
+        "@skipruntime/core": "0.0.6",
+        "@skipruntime/helpers": "0.0.9",
+        "@skipruntime/server": "0.0.9"
+      },
+      "optionalDependencies": {
+        "@skip-adapter/postgres": "0.0.5",
+        "@skipruntime/native": "0.0.5",
+        "@skipruntime/wasm": "0.0.7"
       }
     },
     "skipruntime-ts/server": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "skipruntime-ts/tests",
     "skipruntime-ts/server",
     "skipruntime-ts/examples",
+    "skipruntime-ts/metapackage",
     "sql/ts",
     "sql/ts/tests",
     "examples/hackernews/reactive_service"

--- a/skipruntime-ts/metapackage/package.json
+++ b/skipruntime-ts/metapackage/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@skiplabs/skip",
+  "version": "0.0.1",
+  "dependencies": {
+    "@skipruntime/core": "0.0.6",
+    "@skipruntime/server": "0.0.9",
+    "@skipruntime/helpers": "0.0.9"
+  },
+  "optionalDependencies": {
+    "@skipruntime/native": "0.0.5",
+    "@skipruntime/wasm": "0.0.7",
+    "@skip-adapter/postgres": "0.0.5"
+  }
+}

--- a/skipruntime-ts/metapackage/package.json
+++ b/skipruntime-ts/metapackage/package.json
@@ -4,11 +4,11 @@
   "dependencies": {
     "@skipruntime/core": "0.0.6",
     "@skipruntime/server": "0.0.9",
-    "@skipruntime/helpers": "0.0.9"
+    "@skipruntime/helpers": "0.0.9",
+    "@skipruntime/wasm": "0.0.7"
   },
   "optionalDependencies": {
     "@skipruntime/native": "0.0.5",
-    "@skipruntime/wasm": "0.0.7",
     "@skip-adapter/postgres": "0.0.5"
   }
 }


### PR DESCRIPTION
I think this should do the trick and let people `npm i @skipruntime/skip` instead of the current `npm i @skipruntime/core @skipruntime/server @skipruntime/helpers`.

Will also be helpful, I think, to keep versions in lockstep for alpha adopters.