### PR TITLE
Tweak postgres unsubscribe flow to avoid printing spurious error

### DIFF
--- a/skipruntime-ts/adapters/postgres/src/index.ts
+++ b/skipruntime-ts/adapters/postgres/src/index.ts
@@ -230,17 +230,18 @@ FOR EACH ROW EXECUTE FUNCTION %I();`,
   }
 
   unsubscribe(instance: string): void {
-    this.client
-      .query(format("DROP FUNCTION IF EXISTS %I CASCADE;", instance))
-      .then(
-        () => this.open_instances.delete(instance),
-        (e: unknown) => {
-          console.error(
-            "Error unsubscribing from resource instance: " + instance,
-          );
-          throw e;
-        },
-      );
+    if (this.open_instances.has(instance))
+      this.client
+        .query(format("DROP FUNCTION IF EXISTS %I CASCADE;", instance))
+        .then(
+          () => this.open_instances.delete(instance),
+          (e: unknown) => {
+            console.error(
+              "Error unsubscribing from resource instance: " + instance,
+            );
+            throw e;
+          },
+        );
   }
 
   shutdown(): void {


### PR DESCRIPTION
Related to previous issues with sequencing of unsubscribe/shutdown, this stops printing spurious error messages surfaced by #708 .