### PR TITLE
More precise/descriptive SkipError exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ test-skjson:
 
 .PHONY: test-skipruntime-ts
 test-skipruntime-ts:
-	$(MAKE) -C skipruntime-ts test test-examples
+	$(MAKE) -C skipruntime-ts test test-examples test-error-types
 
 test-%:
 	cd $* && skargo test --profile $(SKARGO_PROFILE)

--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -50,6 +50,15 @@ EXAMPLE_TARGETS := $(patsubst %,test-example-%,$(EXAMPLES))
 .PHONY: test-examples
 test-examples: build-examples $(EXAMPLE_TARGETS)
 
+.PHONY: test-error-types
+test-error-types: # Best-effort check that we don't throw generic JS errors; prefer some version of SkipError instead.
+	grep -qr "throw new Error" $(CURDIR) \
+	--exclude-dir node_modules \
+	--exclude-dir dist \
+	--exclude-dir native \
+	--exclude-dir examples \
+	--exclude-dir tests
+
 regen-%:
 	cd tests/examples && ./$*.sh ../tests/examples/$*.exp.out ../tests/examples/$*.exp.err
 

--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -188,21 +188,12 @@ export interface Reducer<V extends Json, A extends Json> {
 }
 
 /**
- * Exception indicating a key did not have a unique value.
- *
- * Some collections are used to associate each key to a unique value.
- * When this expectation is not met (a key is associated to either zero or multiple values), operations such as `getUnique` throw `NonUniqueValueException`.
- * @hideconstructor
- */
-export class NonUniqueValueException extends Error {}
-
-/**
  * An iterable collection of dependency-safe values.
  */
 export interface Values<T> extends Iterable<T & DepSafe> {
   /**
    * Return the first value, if there is exactly one.
-   * @throws {@link NonUniqueValueException} if this iterable contains either zero or multiple values.
+   * @throws {@link SkipNonUniqueValueError} if this iterable contains either zero or multiple values.
    */
   getUnique(): T & DepSafe;
 
@@ -237,7 +228,7 @@ export interface LazyCollection<K extends Json, V extends Json>
    *
    * @param key - The key to query.
    * @returns The value associated to `key`.
-   * @throws {@link NonUniqueValueException} if `key` is associated to either zero or multiple values.
+   * @throws {@link SkipNonUniqueValueError} if `key` is associated to either zero or multiple values.
    */
   getUnique(key: K): V & DepSafe;
 }
@@ -267,7 +258,7 @@ export interface EagerCollection<K extends Json, V extends Json>
    *
    * @param key - The key to query.
    * @returns The value associated to `key`.
-   * @throws {@link NonUniqueValueException} if `key` is associated to either zero or multiple values.
+   * @throws {@link SkipNonUniqueValueError} if `key` is associated to either zero or multiple values.
    */
   getUnique(key: K): V & DepSafe;
 

--- a/skipruntime-ts/core/src/errors.ts
+++ b/skipruntime-ts/core/src/errors.ts
@@ -1,1 +1,51 @@
-export class UnknownCollectionError extends Error {}
+/**
+ * Umbrella type for run-time errors thrown by the Skip runtime.
+ * @hideconstructor
+ */
+export class SkipError extends Error {}
+
+/**
+ * Exception indicating an attempted read/write to a collection that does not exist.
+ * @hideconstructor
+ */
+export class SkipUnknownCollectionError extends SkipError {}
+
+/**
+ * Exception indicating an attempted read/write to a collection that does not exist.
+ * @hideconstructor
+ */
+export class SkipUnknownResourceError extends SkipError {}
+
+/**
+ * Exception indicating a malformed REST query to a Skip service.
+ * @hideconstructor
+ */
+export class SkipRESTError extends SkipError {}
+
+/**
+ * Exception indicating that a fetch returned an HTTP status outside of the 200-299 range.
+ * @hideconstructor
+ */
+export class SkipFetchError extends SkipError {}
+
+/**
+ * Exception indicating an issue loading the Skip runtime for a specific (native or wasm) platform.
+ * @hideconstructor
+ */
+export class SkipPlatformError extends SkipError {}
+
+/**
+ * Exception indicating a non-top-level class being used as a mapper/reducer/etc.
+ * The Skip runtime requires that these classes be defined at the top-level, so that their names can be used to generate cache keys and the like.
+ * @hideconstructor
+ */
+export class SkipClassNameError extends SkipError {}
+
+/**
+ * Exception indicating a key did not have a unique value.
+ *
+ * Some collections are used to associate each key to a unique value.
+ * When this expectation is not met (a key is associated to either zero or multiple values), operations such as `getUnique` throw `SkipNonUniqueValueError`.
+ * @hideconstructor
+ */
+export class SkipNonUniqueValueError extends SkipError {}

--- a/skipruntime-ts/helpers/src/external.ts
+++ b/skipruntime-ts/helpers/src/external.ts
@@ -1,4 +1,5 @@
 import type { Entry, ExternalService, Json } from "@skipruntime/core";
+import { SkipUnknownResourceError } from "@skipruntime/core";
 import { fetchJSON } from "./rest.js";
 
 /**
@@ -47,7 +48,9 @@ export class GenericExternalService implements ExternalService {
       | ExternalResource
       | undefined;
     if (!resource) {
-      throw new Error(`Unkonwn resource named '${resourceName}'`);
+      throw new SkipUnknownResourceError(
+        `Unknown resource named '${resourceName}'`,
+      );
     }
     this.instances.set(instance, resource);
     resource.open(instance, params, callbacks);

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -1,5 +1,5 @@
 import type { Json, Entry } from "@skipruntime/core";
-import { NonUniqueValueException } from "@skipruntime/core";
+import { SkipNonUniqueValueError, SkipFetchError } from "@skipruntime/core";
 
 /**
  * An entry point of a Skip reactive service.
@@ -70,7 +70,7 @@ export async function fetchJSON<V extends Json>(
     signal: AbortSignal.timeout(options.timeout ?? 1000),
   });
   if (!response.ok) {
-    throw new Error(`${response.status}: ${response.statusText}`);
+    throw new SkipFetchError(`${response.status}: ${response.statusText}`);
   }
   const responseText = await response.text();
   const responseJSON =
@@ -158,7 +158,7 @@ export class SkipServiceBroker {
    * @param params - Resource instance parameters.
    * @param key - Key to read.
    * @returns The value associated to the key.
-   * @throws `NonUniqueValueException` when the key is associated to either zero or multiple values.
+   * @throws `SkipNonUniqueValueError` when the key is associated to either zero or multiple values.
    */
   async getUnique<K extends Json, V extends Json>(
     resource: string,
@@ -167,7 +167,7 @@ export class SkipServiceBroker {
   ): Promise<V> {
     return this.getArray<K, V>(resource, params, key).then((values) => {
       if (values.length !== 1 || values[0] === undefined)
-        throw new NonUniqueValueException();
+        throw new SkipNonUniqueValueError();
       return values[0];
     });
   }

--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -1,5 +1,9 @@
 import express from "express";
-import { ServiceInstance, UnknownCollectionError } from "@skipruntime/core";
+import {
+  ServiceInstance,
+  SkipUnknownCollectionError,
+  SkipRESTError,
+} from "@skipruntime/core";
 import type { CollectionUpdate, Entry, Json } from "@skipruntime/core";
 
 export function controlService(service: ServiceInstance): express.Express {
@@ -61,7 +65,7 @@ export function controlService(service: ServiceInstance): express.Express {
         !("key" in req.body) ||
         !("params" in req.body)
       )
-        throw new Error(
+        throw new SkipRESTError(
           `Invalid request body for synchronous lookup: ${JSON.stringify(req.body)}`,
         );
       service.getArray(
@@ -86,7 +90,7 @@ export function controlService(service: ServiceInstance): express.Express {
       service.update(req.params.collection, req.body as Entry<Json, Json>[]);
       res.sendStatus(200);
     } catch (e: unknown) {
-      if (e instanceof UnknownCollectionError) {
+      if (e instanceof SkipUnknownCollectionError) {
         res.sendStatus(404);
       } else {
         console.log(e);
@@ -136,7 +140,7 @@ export function streamingService(service: ServiceInstance): express.Express {
       });
     } catch (e: unknown) {
       console.log(e);
-      if (e instanceof UnknownCollectionError) {
+      if (e instanceof SkipUnknownCollectionError) {
         res.sendStatus(404);
       } else {
         res.sendStatus(500);

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -4,7 +4,11 @@
  * @packageDocumentation
  */
 
-import { type SkipService, ServiceInstance } from "@skipruntime/core";
+import {
+  type SkipService,
+  ServiceInstance,
+  SkipPlatformError,
+} from "@skipruntime/core";
 import { controlService, streamingService } from "./rest.js";
 
 /**
@@ -107,7 +111,7 @@ export async function runService(
       const runtime = await import("@skipruntime/native");
       return await runtime.initService(service);
     } catch {
-      throw new Error(
+      throw new SkipPlatformError(
         'Error loading Skip runtime for specified "native" platform.',
       );
     }
@@ -118,7 +122,7 @@ export async function runService(
       const runtime = await import("@skipruntime/wasm");
       return await runtime.initService(service);
     } catch {
-      throw new Error(
+      throw new SkipPlatformError(
         'Error loading Skip runtime for specified "wasm" platform.',
       );
     }
@@ -132,7 +136,7 @@ export async function runService(
         try {
           instance = await initWasm();
         } catch {
-          throw new Error(
+          throw new SkipPlatformError(
             "No Skip runtime found; one of `@skipruntime/native` (on a supported platform) or `@skipruntime/wasm` is required.",
           );
         }

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -16,7 +16,7 @@ import type {
   ServiceInstance,
 } from "@skipruntime/core";
 import {
-  NonUniqueValueException,
+  SkipNonUniqueValueError,
   OneToOneMapper,
   Count,
   Sum,
@@ -460,7 +460,7 @@ class MockExternalCheck implements Mapper<number, number, number, number[]> {
       const result = this.external.getUnique(key);
       return [[key, [...values, result]]];
     } catch (e) {
-      if (e instanceof NonUniqueValueException)
+      if (e instanceof SkipNonUniqueValueError)
         return [[key, values.toArray()]];
       throw e;
     }


### PR DESCRIPTION
I've been meaning to do this for a while... move us away from `throw new Error(...)` with the generic JS "Error" type and instead set up a simple hierarchy of `SkipError`s which give a bit more information/context about the exception and allow client code to selectively catch/handle as needed.

To my eyes, there's not much downside here but I may not be considering something -- what do you guys think?

I also put in a very simple best-effort syntactic check that new code doesn't `throw new Error` but that's coarse and will only catch the most egregious cases.