### PR TITLE
Include error types in public api

### DIFF
--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -6,6 +6,7 @@
 
 import type { int, Nullable, Opaque } from "@skiplang/std";
 import type { Managed, Json, JsonObject, DepSafe } from "@skiplang/json";
+export * from "./errors.js";
 export type { Managed, Json, JsonObject, Opaque, DepSafe };
 export { deepFreeze } from "@skiplang/json";
 export type { Nullable };


### PR DESCRIPTION
Users might need to know about them, and they are referenced from the docs.