### PR TITLE
Add error handling around CollectionWriter FFI

### DIFF
--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -352,11 +352,11 @@ class CollectionWriter<K extends Json, V extends Json> {
         isInit,
       );
     };
-    if (this.refs.needGC()) {
-      this.refs.runWithGC(update_);
-    } else {
-      update_();
-    }
+    const errorHdl = this.refs.needGC()
+      ? this.refs.runWithGC(update_)
+      : update_();
+
+    if (errorHdl) throw this.refs.handles.deleteHandle(errorHdl);
   }
 
   loading(): void {
@@ -365,8 +365,10 @@ class CollectionWriter<K extends Json, V extends Json> {
         this.collection,
       );
     };
-    if (this.refs.needGC()) this.refs.runWithGC(loading_);
-    else loading_();
+    const errorHdl = this.refs.needGC()
+      ? this.refs.runWithGC(loading_)
+      : loading_();
+    if (errorHdl) throw this.refs.handles.deleteHandle(errorHdl);
   }
 
   error(error: Json): void {
@@ -376,8 +378,10 @@ class CollectionWriter<K extends Json, V extends Json> {
         this.refs.skjson.exportJSON(error),
       );
     };
-    if (this.refs.needGC()) this.refs.runWithGC(error_);
-    else error_();
+    const errorHdl = this.refs.needGC()
+      ? this.refs.runWithGC(error_)
+      : error_();
+    if (errorHdl) throw this.refs.handles.deleteHandle(errorHdl);
   }
 }
 


### PR DESCRIPTION
~~I'm chasing other FFI calls to convince myself there are no other gaps in the error handling logic, but submitting this change for now.~~
EDIT: After covering the three CollectionWriter methods, I audited all of the other `getErrorHdl` on the native side and confirmed that they're covered by corresponding logic on the JS side.  So we should be watertight now.