### PR TITLE
Update NPM package versions

### DIFF
--- a/examples/hackernews/reactive_service/package.json
+++ b/examples/hackernews/reactive_service/package.json
@@ -9,10 +9,10 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@skipruntime/core": "0.0.6",
-    "@skipruntime/wasm": "0.0.7",
-    "@skipruntime/server": "0.0.9",
-    "@skip-adapter/postgres": "0.0.5"
+    "@skipruntime/core": "0.0.10",
+    "@skipruntime/wasm": "0.0.10",
+    "@skipruntime/server": "0.0.10",
+    "@skip-adapter/postgres": "0.0.10"
   },
   "devDependencies": {
     "@skiplabs/eslint-config": "^0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,10 +51,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.5",
-        "@skipruntime/core": "0.0.6",
-        "@skipruntime/server": "0.0.9",
-        "@skipruntime/wasm": "0.0.7"
+        "@skip-adapter/postgres": "0.0.10",
+        "@skipruntime/core": "0.0.10",
+        "@skipruntime/server": "0.0.10",
+        "@skipruntime/wasm": "0.0.10"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
@@ -4421,13 +4421,13 @@
     },
     "skiplang/prelude/ts/binding": {
       "name": "@skiplang/std",
-      "version": "0.0.3"
+      "version": "0.0.4"
     },
     "skiplang/prelude/ts/wasm": {
       "name": "@skip-wasm/std",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
-        "@skiplang/std": "0.0.3",
+        "@skiplang/std": "0.0.4",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -4436,9 +4436,9 @@
     },
     "skiplang/skdate/ts": {
       "name": "@skip-wasm/date",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
-        "@skip-wasm/std": "1.0.5"
+        "@skip-wasm/std": "1.0.6"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -4447,25 +4447,25 @@
     },
     "skiplang/skjson/ts/binding": {
       "name": "@skiplang/json",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
-        "@skiplang/std": "0.0.3"
+        "@skiplang/std": "0.0.4"
       }
     },
     "skiplang/skjson/ts/wasm": {
       "name": "@skip-wasm/json",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
-        "@skip-wasm/std": "1.0.5",
-        "@skiplang/json": "0.0.3"
+        "@skip-wasm/std": "1.0.6",
+        "@skiplang/json": "0.0.4"
       }
     },
     "skipruntime-ts/adapters/postgres": {
       "name": "@skip-adapter/postgres",
-      "version": "0.0.5",
+      "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.6",
+        "@skipruntime/core": "0.0.10",
         "pg": "^8.13.1",
         "pg-format": "^1.0.4"
       },
@@ -4479,24 +4479,24 @@
     },
     "skipruntime-ts/addon": {
       "name": "@skipruntime/native",
-      "version": "0.0.5",
+      "version": "0.0.10",
       "hasInstallScript": true,
       "dependencies": {
-        "@skipruntime/core": "0.0.6"
+        "@skipruntime/core": "0.0.10"
       }
     },
     "skipruntime-ts/core": {
       "name": "@skipruntime/core",
-      "version": "0.0.6",
+      "version": "0.0.10",
       "dependencies": {
-        "@skiplang/json": "0.0.3"
+        "@skiplang/json": "0.0.4"
       }
     },
     "skipruntime-ts/examples": {
       "name": "skipruntime-examples",
       "dependencies": {
-        "@skipruntime/helpers": "0.0.9",
-        "@skipruntime/server": "0.0.9",
+        "@skipruntime/helpers": "0.0.10",
+        "@skipruntime/server": "0.0.10",
         "better-sqlite3": "^11.7.2",
         "eventsource": "^2.0.2"
       },
@@ -4507,10 +4507,10 @@
     },
     "skipruntime-ts/helpers": {
       "name": "@skipruntime/helpers",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.6",
+        "@skipruntime/core": "0.0.10",
         "eventsource": "^2.0.2",
         "express": "^4.21.1"
       },
@@ -4523,42 +4523,41 @@
     },
     "skipruntime-ts/metapackage": {
       "name": "@skiplabs/skip",
-      "version": "0.0.1",
+      "version": "0.0.10",
       "dependencies": {
-        "@skipruntime/core": "0.0.6",
-        "@skipruntime/helpers": "0.0.9",
-        "@skipruntime/server": "0.0.9",
-        "@skipruntime/wasm": "0.0.7"
+        "@skipruntime/core": "0.0.10",
+        "@skipruntime/helpers": "0.0.10",
+        "@skipruntime/server": "0.0.10",
+        "@skipruntime/wasm": "0.0.10"
       },
       "optionalDependencies": {
-        "@skip-adapter/postgres": "0.0.5",
-        "@skipruntime/native": "0.0.5"
+        "@skip-adapter/postgres": "0.0.10",
+        "@skipruntime/native": "0.0.10"
       }
     },
     "skipruntime-ts/server": {
       "name": "@skipruntime/server",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
-        "@skipruntime/core": "0.0.6",
+        "@skipruntime/core": "0.0.10",
         "express": "^4.21.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.0"
       },
       "optionalDependencies": {
-        "@skipruntime/native": "0.0.5",
-        "@skipruntime/wasm": "0.0.7"
+        "@skipruntime/native": "0.0.10",
+        "@skipruntime/wasm": "0.0.10"
       }
     },
     "skipruntime-ts/tests": {
       "name": "@skipruntime/tests",
-      "version": "0.0.10",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.5",
-        "@skipruntime/core": "0.0.6",
-        "@skipruntime/helpers": "0.0.9",
-        "@skipruntime/native": "0.0.5",
-        "@skipruntime/wasm": "0.0.7",
+        "@skip-adapter/postgres": "0.0.10",
+        "@skipruntime/core": "0.0.10",
+        "@skipruntime/helpers": "0.0.10",
+        "@skipruntime/native": "0.0.10",
+        "@skipruntime/wasm": "0.0.10",
         "earl": "^1.3.0",
         "mocha": "^11.0.1",
         "pg": "^8.13.1"
@@ -4570,19 +4569,19 @@
     },
     "skipruntime-ts/wasm": {
       "name": "@skipruntime/wasm",
-      "version": "0.0.7",
+      "version": "0.0.10",
       "dependencies": {
-        "@skip-wasm/json": "1.0.6",
-        "@skipruntime/core": "0.0.6"
+        "@skip-wasm/json": "1.0.7",
+        "@skipruntime/core": "0.0.10"
       }
     },
     "sql/ts": {
       "name": "skdb",
       "version": "1.0.0",
       "dependencies": {
-        "@skip-wasm/date": "1.0.4",
-        "@skip-wasm/json": "1.0.6",
-        "@skip-wasm/std": "1.0.5"
+        "@skip-wasm/date": "1.0.5",
+        "@skip-wasm/json": "1.0.7",
+        "@skip-wasm/std": "1.0.6"
       },
       "bin": {
         "skdb-cli": "dist/skdb-cli.js"
@@ -4597,8 +4596,8 @@
       "name": "skdb-tests",
       "dependencies": {
         "@playwright/test": "^1.47.2",
-        "@skip-wasm/date": "1.0.4",
-        "@skip-wasm/json": "1.0.6",
+        "@skip-wasm/date": "1.0.5",
+        "@skip-wasm/json": "1.0.7",
         "skdb": "^1.0.0",
         "ws": "^8.18.0"
       },

--- a/skiplang/prelude/ts/binding/package.json
+++ b/skiplang/prelude/ts/binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplang/std",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",

--- a/skiplang/prelude/ts/wasm/package.json
+++ b/skiplang/prelude/ts/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/std",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
@@ -17,7 +17,7 @@
     "@types/ws": "^8.5.13"
   },
   "dependencies": {
-    "@skiplang/std": "0.0.3",
+    "@skiplang/std": "0.0.4",
     "ws": "^8.18.0"
   }
 }

--- a/skiplang/skdate/ts/package.json
+++ b/skiplang/skdate/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/date",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "exports": {
     ".": "./dist/sk_date.js"
@@ -15,6 +15,6 @@
     "@types/ws": "^8.5.13"
   },
   "dependencies": {
-    "@skip-wasm/std": "1.0.5"
+    "@skip-wasm/std": "1.0.6"
   }
 }

--- a/skiplang/skjson/ts/binding/package.json
+++ b/skiplang/skjson/ts/binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplang/json",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
@@ -12,6 +12,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skiplang/std": "0.0.3"
+    "@skiplang/std": "0.0.4"
   }
 }

--- a/skiplang/skjson/ts/wasm/package.json
+++ b/skiplang/skjson/ts/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/json",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "exports": {
     ".": "./dist/skjson.js",
@@ -12,7 +12,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skiplang/json": "0.0.3",
-    "@skip-wasm/std": "1.0.5"
+    "@skiplang/json": "0.0.4",
+    "@skip-wasm/std": "1.0.6"
   }
 }

--- a/skipruntime-ts/adapters/postgres/package.json
+++ b/skipruntime-ts/adapters/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-adapter/postgres",
-  "version": "0.0.5",
+  "version": "0.0.10",
   "type": "module",
   "exports": {
     ".": "./dist/index.js"
@@ -19,7 +19,7 @@
   "dependencies": {
     "pg": "^8.13.1",
     "pg-format": "^1.0.4",
-    "@skipruntime/core": "0.0.6"
+    "@skipruntime/core": "0.0.10"
   },
   "devDependencies": {
     "@types/pg": "^8.11.10",

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/native",
-  "version": "0.0.5",
+  "version": "0.0.10",
   "gypfile": true,
   "type": "module",
   "exports": {
@@ -13,6 +13,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.6"
+    "@skipruntime/core": "0.0.10"
   }
 }

--- a/skipruntime-ts/core/package.json
+++ b/skipruntime-ts/core/package.json
@@ -13,6 +13,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skiplang/json": "0.0.3"
+    "@skiplang/json": "0.0.4"
   }
 }

--- a/skipruntime-ts/core/package.json
+++ b/skipruntime-ts/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/core",
-  "version": "0.0.6",
+  "version": "0.0.10",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",

--- a/skipruntime-ts/examples/package.json
+++ b/skipruntime-ts/examples/package.json
@@ -12,8 +12,8 @@
     "@types/better-sqlite3": "^7.6.12"
   },
   "dependencies": {
-    "@skipruntime/helpers": "0.0.9",
-    "@skipruntime/server": "0.0.9",
+    "@skipruntime/helpers": "0.0.10",
+    "@skipruntime/server": "0.0.10",
     "eventsource": "^2.0.2",
     "better-sqlite3": "^11.7.2"
   }

--- a/skipruntime-ts/helpers/package.json
+++ b/skipruntime-ts/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/helpers",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
@@ -21,7 +21,7 @@
   "dependencies": {
     "eventsource": "^2.0.2",
     "express": "^4.21.1",
-    "@skipruntime/core": "0.0.6"
+    "@skipruntime/core": "0.0.10"
   },
   "devDependencies": {
     "@types/eventsource": "^1.1.15"

--- a/skipruntime-ts/metapackage/package.json
+++ b/skipruntime-ts/metapackage/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@skiplabs/skip",
-  "version": "0.0.1",
+  "version": "0.0.10",
   "dependencies": {
-    "@skipruntime/core": "0.0.6",
-    "@skipruntime/server": "0.0.9",
-    "@skipruntime/helpers": "0.0.9",
-    "@skipruntime/wasm": "0.0.7"
+    "@skipruntime/core": "0.0.10",
+    "@skipruntime/server": "0.0.10",
+    "@skipruntime/helpers": "0.0.10",
+    "@skipruntime/wasm": "0.0.10"
   },
   "optionalDependencies": {
-    "@skipruntime/native": "0.0.5",
-    "@skip-adapter/postgres": "0.0.5"
+    "@skipruntime/native": "0.0.10",
+    "@skip-adapter/postgres": "0.0.10"
   }
 }

--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/server",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "exports": {
     ".": "./dist/server.js"
@@ -15,10 +15,10 @@
   },
   "dependencies": {
     "express": "^4.21.1",
-    "@skipruntime/core": "0.0.6"
+    "@skipruntime/core": "0.0.10"
   },
   "optionalDependencies": {
-    "@skipruntime/native": "0.0.5",
-    "@skipruntime/wasm": "0.0.7"
+    "@skipruntime/native": "0.0.10",
+    "@skipruntime/wasm": "0.0.10"
   }
 }

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/tests",
-  "version": "0.0.10",
+  "private": true,
   "type": "module",
   "scripts": {
     "build": "tsc",
@@ -16,10 +16,10 @@
     "earl": "^1.3.0",
     "mocha": "^11.0.1",
     "pg": "^8.13.1",
-    "@skipruntime/core": "0.0.6",
-    "@skipruntime/helpers": "0.0.9",
-    "@skipruntime/native": "0.0.5",
-    "@skipruntime/wasm": "0.0.7",
-    "@skip-adapter/postgres": "0.0.5"
+    "@skipruntime/core": "0.0.10",
+    "@skipruntime/helpers": "0.0.10",
+    "@skipruntime/native": "0.0.10",
+    "@skipruntime/wasm": "0.0.10",
+    "@skip-adapter/postgres": "0.0.10"
   }
 }

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@skipruntime/core": "0.0.6",
-    "@skip-wasm/json": "1.0.6"
+    "@skip-wasm/json": "1.0.7"
   }
 }

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/wasm",
-  "version": "0.0.7",
+  "version": "0.0.10",
   "type": "module",
   "exports": {
     ".": "./dist/skip-runtime.js"
@@ -11,7 +11,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.6",
+    "@skipruntime/core": "0.0.10",
     "@skip-wasm/json": "1.0.7"
   }
 }

--- a/sql/Makefile
+++ b/sql/Makefile
@@ -51,7 +51,7 @@ test-client: install-test
 test-server: install-test
 	cd ts/tests && make ROOT_DIR=${SCRIPT_DIR} -f service_common.mk
 	cd ts/tests && make ROOT_DIR=${SCRIPT_DIR} -f service_server.mk
-	cd ts/tests && npx playwright test --reporter=line node.play.server.ts
+	cd ts/tests && npx playwright test --reporter=line --timeout=60000 node.play.server.ts
 
 .PHONY: test-mux-node
 test-mux-node: install-test

--- a/sql/ts/package.json
+++ b/sql/ts/package.json
@@ -21,8 +21,8 @@
     "@types/ws": "^8.5.13"
   },
   "dependencies": {
-    "@skip-wasm/std": "1.0.5",
-    "@skip-wasm/date": "1.0.4",
-    "@skip-wasm/json": "1.0.6"
+    "@skip-wasm/std": "1.0.6",
+    "@skip-wasm/date": "1.0.5",
+    "@skip-wasm/json": "1.0.7"
   }
 }

--- a/sql/ts/tests/package.json
+++ b/sql/ts/tests/package.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "@playwright/test": "^1.47.2",
     "ws": "^8.18.0",
-    "@skip-wasm/date": "1.0.4",
-    "@skip-wasm/json": "1.0.6",
+    "@skip-wasm/date": "1.0.5",
+    "@skip-wasm/json": "1.0.7",
     "skdb": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This takes all of our Skip runtime packages to 0.0.10, increments all of our core `@skip-wasm/*` and `@skiplang/*` packages (some of which are already at 1.0.x, and none of which users will install, so I left out of the everything-to-0.0.10 edict), and stops versioning the test package.json.