### PR TITLE
Handle postgres time-stamp types

### DIFF
--- a/skipruntime-ts/adapters/postgres/src/index.ts
+++ b/skipruntime-ts/adapters/postgres/src/index.ts
@@ -14,6 +14,10 @@ import {
 import pg from "pg";
 import format from "pg-format";
 
+// Pass timestamp strings straight through instead of attempting to convert to JS Date object, which would be clobbered in the Skip heap
+pg.types.setTypeParser(pg.types.builtins.TIMESTAMP, (x: string) => x);
+pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, (x: string) => x);
+
 /**
  * Exception indicating an error while establishing the connection between PostgreSQL and Skip.
  * @hideconstructor


### PR DESCRIPTION
The default type parser from the `pg` NPM library converts these to `Date` objects which then isn't handled nicely in the Skip heap.  This instead just keeps the raw string, which clients can handle as they choose.

Also adds test coverage of a non-lowercase column, which came up in some user code.