### PR TITLE
Simplify docs workflow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = skiplang/prelude/libbacktrace
 	url = https://github.com/ianlancetaylor/libbacktrace.git
     ignore = dirty
+[submodule "www/docs_site"]
+	path = www/docs_site
+	url = git@github.com:SkipLabs/docs_site.git

--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,2 @@
+/www/build
+/www/docs_site

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY --from=bootstrap /work/compiler/stage0/lib/ /usr/lib/
 FROM skiplang AS skip
 
 RUN --mount=type=bind,source=./bin/apt-install.sh,target=/tmp/apt-install.sh \
-    /tmp/apt-install.sh skipruntime-deps other-CI-tools
+    /tmp/apt-install.sh skipruntime-deps other-CI-tools other-dev-tools

--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -54,6 +54,9 @@ for step in "${steps[@]}"; do
             npm install -g prettier
             update-alternatives --auto clang
             ;;
+        other-dev-tools)
+            apt-get install -q -y rsync
+            ;;
         *)
             echo "Unknown step $step"
             usage

--- a/www/README.md
+++ b/www/README.md
@@ -17,12 +17,20 @@ The workflow for working on API docs is:
 - $ make docs-run                       # to run the docs site locally
 - visit http://localhost:3000/docs/api/core
 - edit the doc comments in the sources
-- $ cd /path/to/repo/root
 - $ make docs                           # to regenerate the api docs
 ```
 A faster but not robust way to regenerate the api docs is:
 ```
 - cd /path/to/repo/root/www && npx docusaurus generate-typedoc
+```
+To publish the docs to the live site:
+```
+- $ make docs-publish
+```
+This will suggest to run:
+```
+Test locally: make docs-serve
+Push to live site: cd www/docs_site/; git add -A; git commit -m 'update to <commit>'; git push; cd -
 ```
 
 The documentation for the tags that TypeDoc recognizes is


### PR DESCRIPTION
This PR adds a git submodule for the docs_site repo and adjusts the docs
workflow to update its contents, removing the need to manually sync the
generated files between repos. The workflow for publishing the docs to the
docs site is now (from www/README.md):
```
- $ make docs-publish
```
which will suggest to run:
```
Test locally: make docs-serve
Push to live site: cd www/docs_site/; git add -A; git commit -m 'update to <commit>'; git push; cd -
```
Once the suggested command ending in `git push` is executed, the live docs
site will update in a few seconds.