### PR TITLE
Fix build failures due to zombie symlinks

### DIFF
--- a/prebuild.mjs
+++ b/prebuild.mjs
@@ -14,11 +14,13 @@ const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
 
 export function link(packages) {
-  for (const [simlink, target] of Object.entries(symlinks)) {
-    if (!packages.has(simlink)) continue;
-    if (!fs.existsSync(simlink)) {
-      fs.symlinkSync(path.resolve(dirname, target), simlink, "dir");
-    }
+  for (const [symlink, target] of Object.entries(symlinks)) {
+    if (!packages.has(symlink)) continue;
+    const rand = new Uint32Array(1);
+    crypto.getRandomValues(rand);
+    const tmp = "tmp" + rand.toString("hex");
+    fs.symlinkSync(path.resolve(dirname, target), tmp, "dir");
+    fs.renameSync(tmp, symlink);
   }
 }
 


### PR DESCRIPTION
Before this PR the following reliably fails for me:
```
$ npm install && npm run build
$ git clean -Xdf
$ npm install && npm run build
```
In the final step, the build sees the symlinks created in the first step
that were deleted in the second step as some sort of zombie, where
`fs.exists` thinks they do not exist but `fs.symlink` fails because they
do. Checking in a shell shows that `ls` is similarly confused.

This PR changes the build from checking if the link exists and only if not
calling symlink to creating a symlink with a temporary name and then
renaming it to the desired name. The temporary names are randomly generated,
and POSIX requires the rename to be atomic.