### PR TITLE
Fix clz undefined behaviour

### DIFF
--- a/skiplang/prelude/runtime/memory.c
+++ b/skiplang/prelude/runtime/memory.c
@@ -25,8 +25,14 @@ typedef struct sk_size_info {
 
 void* sk_ftable[SK_FTABLE_SIZE][SK_FTABLE_SIZE] = {0};
 
-size_t sk_bit_size(size_t size) {
-  return (size_t)(sizeof(size_t) * 8 - __builtin_clzl(size - 1));
+#if !(defined(__has_builtin) && __has_builtin(__builtin_stdc_bit_width))
+static inline size_t __builtin_stdc_bit_width(size_t size) {
+  return size ? (size_t)(sizeof(size_t) * 8UL - __builtin_clzl(size)) : 0;
+}
+#endif
+
+static inline size_t sk_bit_size(size_t size) {
+  return __builtin_stdc_bit_width(size - 1);
 }
 
 size_t sk_pow2_size(size_t size) {

--- a/skiplang/prelude/runtime/palloc.c
+++ b/skiplang/prelude/runtime/palloc.c
@@ -587,23 +587,27 @@ int sk_is_static(void* ptr) {
 /* Free table. */
 /*****************************************************************************/
 
+typedef size_t slot_t;
+
 size_t sk_bit_size(size_t size) {
   return (size_t)(sizeof(size_t) * 8 - __builtin_clzl(size - 1));
 }
 
-size_t sk_pow2_size(size_t size) {
+slot_t sk_slot_of_size(size_t size) {
   size = (size + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1);
-  return (1 << sk_bit_size(size));
+  return sk_bit_size(size);
 }
 
-void sk_add_ftable(void* ptr, size_t size) {
-  int slot = sk_bit_size(size);
+size_t sk_size_of_slot(slot_t slot) {
+  return 1 << slot;
+}
+
+void sk_add_ftable(void* ptr, slot_t slot) {
   *(void**)ptr = ginfo->ftable[slot];
   ginfo->ftable[slot] = ptr;
 }
 
-void* sk_get_ftable(size_t size) {
-  int slot = sk_bit_size(size);
+void* sk_get_ftable(slot_t slot) {
   void** ptr = ginfo->ftable[slot];
   if (ptr == NULL) {
     return ptr;
@@ -692,9 +696,10 @@ void SKIP_print_persistent_size() {
 
 void* sk_palloc(size_t size) {
   sk_check_has_lock();
-  size = sk_pow2_size(size);
+  slot_t slot = sk_slot_of_size(size);
+  size = sk_size_of_slot(slot);
   ginfo->total_palloc_size += size;
-  sk_cell_t* ptr = sk_get_ftable(size);
+  sk_cell_t* ptr = sk_get_ftable(slot);
   if (ptr != NULL) {
     return ptr;
   }
@@ -709,7 +714,8 @@ void* sk_palloc(size_t size) {
 
 void sk_pfree_size(void* chunk, size_t size) {
   sk_check_has_lock();
-  size = sk_pow2_size(size);
+  slot_t slot = sk_slot_of_size(size);
+  size = sk_size_of_slot(slot);
   ginfo->total_palloc_size -= size;
-  sk_add_ftable(chunk, size);
+  sk_add_ftable(chunk, slot);
 }


### PR DESCRIPTION
As reported by @beauby and confirmed by @jberdine, compilation with LLVM > 16 fails because of `clz` being called with 0 which is an undefined behaviour.

Here is a fix + a simplification of the computation of the free table slots + a light specification of free table slot functions.

This fixes compilation of the compiler itself with LLVM 17, I leave the rest to the CI.

...why is free table management done in `palloc.c` in 64-bits (not even behind an `#ifdef`?) and in `memory.c` in 32-bits?