### PR TITLE
[skiplang/skc] Re-enable clang inlining.

### DIFF
--- a/skiplang/compiler/Makefile
+++ b/skiplang/compiler/Makefile
@@ -1,5 +1,5 @@
 OLEVEL   ?= -O3
-CXXFLAGS ?= $(OLEVEL) -mllvm -inline-threshold=0 # -enable-new-pm=false
+CXXFLAGS ?= $(OLEVEL)
 SKARGO_PROFILE ?= release
 SKC_ARGS ?= --canonize-paths
 SKARGO_ARGS ?= --profile $(SKARGO_PROFILE) $(foreach opt,$(SKC_ARGS),--skcopt $(opt))

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -134,8 +134,6 @@ fun link(
       Array[
         "clang++",
         `-O${config.optLevel}`,
-        "-mllvm",
-        "-inline-threshold=0",
         "-o",
         config.output,
         llFile,


### PR DESCRIPTION
Inlining in clang was disabled because the inlining heuristics had changed in clang 15, leading to compile time blowups. The situation seems to have been fixed in clang 19 (possibly in an earlier version, we need to check with clang 16 once #736 is merged).

Compile times for stage 2 skc:
- Before this commit: 
    clang 15, without inlining: 160.805s
- After this commit:
    clang 15, with inlining: 600.047s
    clang 19, with inlining: 173.062s