### PR TITLE
Changing the order in which we update sub-directories.

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -159,12 +159,12 @@ fun updateDirtyReaders(
       context.!dirtyReaders = List.Cons(reader, context.dirtyReaders);
     };
     time = if (reader.parentName == reader.childName) {
-      (-child.getTime(), -child.getTime())
+      -child.getTimeStack()
     } else {
-      (child.getTime(), parent.getTime())
+      child.getTimeStack()
     };
     arrow = Arrow(reader.parentName, reader.childName);
-    context.addToUpdate(time, arrow);
+    context.addToUpdate(time, parent.getTime(), arrow);
   };
 }
 
@@ -297,6 +297,38 @@ value class Time(value: Int) uses Orderable, Show {
   }
 }
 
+class TimeStack private (private values: Array<Time>) uses Orderable {
+  static fun createInput(time: Time): this {
+    static(Array[time])
+  }
+
+  static fun create(context: mutable Context, time: Time): this {
+    context.arrowStack.maybeHead() match {
+    | None() -> static::createInput(time)
+    | Some((_arrow, timeStack)) -> timeStack.extend(time)
+    }
+  }
+
+  fun extend(time: Time): this {
+    !this.values = this.values.concat(Array[time]);
+    this
+  }
+
+  fun negate(): this {
+    !this.values = this.values.map(x -> -x);
+    this
+  }
+
+  fun compare(other: TimeStack): Order {
+    for (i in Range(0, this.values.size())) {
+      if (i >= other.values.size()) return GT();
+      cmp = this.values.compare(other.values);
+      if (cmp != EQ()) return cmp;
+    };
+    EQ()
+  }
+}
+
 /*****************************************************************************/
 /* Tells the context if we can reuse directories or not. */
 /*****************************************************************************/
@@ -347,7 +379,7 @@ mutable class Context{
   mutable time: Time = Time(0),
   mutable tick: Tick = Tick(1),
   mutable lazyCapacity: Int = 10,
-  mutable toUpdate: SortedMap<(Time, Time), Arrow> = SortedMap[],
+  mutable toUpdate: SortedMap<(TimeStack, Time), Arrow> = SortedMap[],
   mutable deps: Deps = Deps[],
   mutable debugMode: Bool = debugMode,
   mutable failOnExn: Bool = true,
@@ -359,7 +391,7 @@ mutable class Context{
   mutable dirty: List<Path> = List[],
   mutable dirtyReaders: List<ArrowKey> = List[],
   mutable canReuse: CanReuse = CRIfMatch(),
-  mutable arrowStack: List<ArrowKey> = List[],
+  mutable arrowStack: List<(ArrowKey, TimeStack)> = List[],
   mutable lazyGets: SortedSet<Path> = SortedSet[],
   mutable lazyGetsQueueIn: List<Array<Path>> = List[],
   mutable lazyGetsQueueOut: List<Array<Path>> = List[],
@@ -403,8 +435,12 @@ mutable class Context{
     this.!postponables = List.Cons(postponable, this.postponables);
   }
 
-  mutable fun addToUpdate(time: (Time, Time), arrow: Arrow): void {
-    this.!toUpdate = this.toUpdate.set(time, arrow);
+  mutable fun addToUpdate(
+    timeStack: TimeStack,
+    parentTime: Time,
+    arrow: Arrow,
+  ): void {
+    this.!toUpdate = this.toUpdate.set((timeStack, parentTime), arrow);
   }
 
   mutable fun subscribe(
@@ -540,21 +576,21 @@ mutable class Context{
     this.reads
   }
 
-  mutable fun enter(arrow: ArrowKey): void {
-    this.!arrowStack = List.Cons(arrow, this.arrowStack);
+  mutable fun enter(arrow: ArrowKey, timeStack: TimeStack): void {
+    this.!arrowStack = List.Cons((arrow, timeStack), this.arrowStack);
   }
 
   mutable fun leave(arrow: ArrowKey): void {
     this.arrowStack match {
     | List.Nil() -> invariant_violation("Cannot leave empty context")
     | List.Cons(arr, rl) ->
-      invariant(arr == arrow);
+      invariant(arr.i0 == arrow);
       this.!arrowStack = rl
     }
   }
 
   readonly fun currentArrow(): ?ArrowKey {
-    this.arrowStack.maybeHead()
+    this.arrowStack.maybeHead().map(x -> x.i0)
   }
 
   readonly fun getDeps(path: Path): SortedSet<ArrowKey> {
@@ -608,6 +644,7 @@ mutable class Context{
           preDir = EagerDir{
             time,
             input => false,
+            timeStack => TimeStack::createInput(time),
             dirName => preDirName,
             totalSize => 0,
             fixedData => FixedDataMap::create(),
@@ -997,6 +1034,7 @@ mutable class Context{
     creator = this.currentArrow();
     dir = EagerDir{
       time,
+      timeStack => TimeStack::create(this, time),
       input => true,
       dirName,
       fixedData,
@@ -1095,7 +1133,7 @@ mutable class Context{
       print_debug("REMOVED: " + dirName);
     };
     this.unsafeMaybeGetEagerDir(dirName) match {
-    | None() -> return void
+    | None() -> void
     | Some(dir) ->
       if (this.hasPre.contains(dirName)) {
         this.!hasPre = this.hasPre.remove(dirName);
@@ -1109,12 +1147,16 @@ mutable class Context{
         }
       };
       dir.removeSubDirs(this);
-      dir.optOnDelete.each(this.postpone)
+      dir.optOnDelete.each(this.postpone);
+
+      this.!deps = this.deps.removeDir(dirName);
+      this.!dirsWithSharedSubDirs = this.dirsWithSharedSubDirs.remove(dirName);
+      this.!sharedSubDirsRefCount = this.sharedSubDirsRefCount.remove(dirName);
+      this.setDir(
+        dirName,
+        DeletedDir{dirName, time => dir.time, timeStack => dir.timeStack},
+      )
     };
-    this.!deps = this.deps.removeDir(dirName);
-    this.!dirsWithSharedSubDirs = this.dirsWithSharedSubDirs.remove(dirName);
-    this.!sharedSubDirsRefCount = this.sharedSubDirsRefCount.remove(dirName);
-    this.setDir(dirName, DeletedDir{dirName, time => this.timeStamp()});
   }
 
   mutable fun transitiveChildDirs(dirName: DirName): SortedSet<DirName> {

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -319,12 +319,18 @@ class TimeStack private (private values: Array<Time>) uses Orderable {
     this
   }
 
+  fun maxMinus(): this {
+    !this.values = this.values.map(x -> Time(Int::max - x.value));
+    this
+  }
+
   fun compare(other: TimeStack): Order {
     for (i in Range(0, this.values.size())) {
       if (i >= other.values.size()) return GT();
-      cmp = this.values.compare(other.values);
+      cmp = this.values[i].compare(other.values[i]);
       if (cmp != EQ()) return cmp;
     };
+    if (other.values.size() > this.values.size()) return LT();
     EQ()
   }
 }

--- a/skiplang/prelude/src/skstore/DeletedDir.sk
+++ b/skiplang/prelude/src/skstore/DeletedDir.sk
@@ -3,7 +3,11 @@
 /*****************************************************************************/
 module SKStore;
 
-class DeletedDir{time: Time, dirName: DirName} extends Dir {
+class DeletedDir{
+  time: Time,
+  timeStack: TimeStack,
+  dirName: DirName,
+} extends Dir {
   fun incrRefCount(_context: mutable Context): void {
     void
   }
@@ -25,6 +29,9 @@ class DeletedDir{time: Time, dirName: DirName} extends Dir {
   }
   fun getTime(): Time {
     this.time
+  }
+  fun getTimeStack(): TimeStack {
+    this.timeStack
   }
   fun getArrayRaw(Key): Array<File> {
     Array[]

--- a/skiplang/prelude/src/skstore/Dir.sk
+++ b/skiplang/prelude/src/skstore/Dir.sk
@@ -42,6 +42,11 @@ base class Dir extends File {
    * Returns the creation time of that directory.
    */
   fun getTime(): Time;
+
+  /**
+   * Returns the creation time of that directory and all of its ancestors
+   */
+  fun getTimeStack(): TimeStack;
 }
 
 /*****************************************************************************/

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -633,6 +633,7 @@ mutable class FixedDataMapIterator<T> private {
 
 class EagerDir{
   time: Time,
+  timeStack: TimeStack,
   dirName: DirName,
   input: Bool,
   fixedData: FixedDataMap,
@@ -887,6 +888,10 @@ class EagerDir{
     this.time
   }
 
+  fun getTimeStack(): TimeStack {
+    this.timeStack
+  }
+
   private fun getAllKeysWithValues(): SortedSet<Key> {
     result = SortedSet[];
     this.unsafeGetFileIter().each(kv -> {
@@ -916,6 +921,7 @@ class EagerDir{
     oldVec: mutable Vector<(Path, MInfo)>,
     parent: EagerDir,
     childName: DirName,
+    timeStack: TimeStack,
     f: MapFun,
     acc: mutable Vector<FixedRow<Array<File>>>,
     current: mutable IntRef,
@@ -934,6 +940,7 @@ class EagerDir{
         oldVec,
         parent.dirName,
         childName,
+        timeStack,
         key,
         fixedFiles,
         f,
@@ -962,6 +969,7 @@ class EagerDir{
       oldVec,
       parent.dirName,
       childName,
+      timeStack,
       key,
       fixedFiles,
       f,
@@ -973,6 +981,7 @@ class EagerDir{
     context: mutable Context,
     parent: EagerDir,
     childName: DirName,
+    timeStack: TimeStack,
     f: MapFun,
     currentStart: Int,
     currentEnd: Int,
@@ -1004,6 +1013,7 @@ class EagerDir{
           oldVec,
           parent,
           childName,
+          timeStack,
           f,
           acc,
           current,
@@ -1026,6 +1036,7 @@ class EagerDir{
         oldVec,
         parent.dirName,
         childName,
+        timeStack,
         key,
         parent.getIterRaw(key),
         f,
@@ -1038,7 +1049,16 @@ class EagerDir{
 
     while (current.value <= currentEnd) {
       fixedKey = parent.fixedData.data[current.value].key;
-      static::fixedMapData(context, oldVec, parent, childName, f, acc, current);
+      static::fixedMapData(
+        context,
+        oldVec,
+        parent,
+        childName,
+        timeStack,
+        f,
+        acc,
+        current,
+      );
       !size = size + 1;
       if (shouldGC(obstack) != 0) {
         return (acc, oldVec, Some(fixedKey), current.value);
@@ -1052,6 +1072,7 @@ class EagerDir{
     oldVec: mutable Vector<(Path, MInfo)>,
     parent: EagerDir,
     childName: DirName,
+    timeStack: TimeStack,
     f: MapFun,
     acc: mutable Vector<FixedRow<Array<File>>>,
     rangeOpt: ?KeyRange,
@@ -1087,6 +1108,7 @@ class EagerDir{
             context,
             parent,
             childName,
+            timeStack,
             f,
             lcurrent,
             currentEnd,
@@ -1112,12 +1134,13 @@ class EagerDir{
     oldVec: mutable Vector<(Path, MInfo)>,
     parentName: DirName,
     childName: DirName,
+    timeStack: TimeStack,
     key: Key,
     valueIter: mutable Iterator<File>,
     f: MapFun,
   ): void {
     arrow = ArrowKey(parentName, childName, key);
-    context.enter(arrow);
+    context.enter(arrow, timeStack);
 
     if (context.debugMode) {
       print_string(`MAP_ROW: ${parentName} ${key}`);
@@ -1210,6 +1233,13 @@ class EagerDir{
     if (context.debugMode) {
       print_string(`REUSING: ${childName}`);
     };
+    childDir = context.unsafeGetEagerDir(childName);
+    time = context.timeStamp();
+    !childDir = childDir with {
+      time,
+      timeStack => TimeStack::create(context, time),
+    };
+    context.setDir(childName, childDir);
     context.!newDirs = context.newDirs.set(childName);
   }
 
@@ -1283,6 +1313,9 @@ class EagerDir{
       acc = mutable Vector[];
       oldVec = mutable Vector[];
 
+      time = context.timeStamp();
+      timeStack = TimeStack::create(context, time);
+
       if (!unsafeSkipInit) {
         for (parentName => parentData in parents) {
           for (p in parentData) {
@@ -1295,6 +1328,7 @@ class EagerDir{
                 oldVec,
                 parent,
                 childName,
+                timeStack,
                 f,
                 acc,
                 None(),
@@ -1306,6 +1340,7 @@ class EagerDir{
                   oldVec,
                   parent,
                   childName,
+                  timeStack,
                   f,
                   acc,
                   Some(range),
@@ -1317,7 +1352,6 @@ class EagerDir{
       };
 
       fixedData = FixedDataMap::create(acc);
-      time = context.timeStamp();
       totalSize = acc.size();
       reducer = reducerOpt.map(ireducer ->
         Reducer::create(fixedData, ireducer)
@@ -1338,6 +1372,7 @@ class EagerDir{
 
       EagerDir{
         time,
+        timeStack,
         dirName => childName,
         input => false,
         parents,
@@ -1524,6 +1559,7 @@ class EagerDir{
   ): void {
     parent = context.unsafeGetEagerDir(parentName);
     childName = childRef.dirName;
+    timeStack = childRef.timeStack;
 
     dirty = SortedSet[];
     if (contextDirtyReaders.containsKey(parent.dirName)) {
@@ -1570,7 +1606,7 @@ class EagerDir{
       childRef,
       (contextOpt, key, child) ~> {
         ctx = contextOpt.fromSome();
-        ctx.enter(ArrowKey(parentName, childName, key));
+        ctx.enter(ArrowKey(parentName, childName, key), timeStack);
         path = Path::create(parentName, key);
         oldInfo = static::getOld(child, path);
         oldKeys = SortedSet<Key>::createFromItems(oldInfo.getKeys());
@@ -1775,7 +1811,8 @@ class EagerDir{
       | Some(childDir) ->
         !childDirs = childDirs.set(childName);
         context.addToUpdate(
-          (childDir.time, parentTime),
+          childDir.timeStack,
+          parentTime,
           Arrow(this.dirName, childName),
         )
       }
@@ -1791,7 +1828,8 @@ class EagerDir{
       | None() -> continue
       | Some(childDir) ->
         context.addToUpdate(
-          (childDir.time, parentTime),
+          childDir.timeStack,
+          parentTime,
           Arrow(this.dirName, childName),
         )
       }

--- a/skiplang/prelude/src/skstore/EagerFilter.sk
+++ b/skiplang/prelude/src/skstore/EagerFilter.sk
@@ -101,6 +101,7 @@ class EagerFilter private {
     dirName = DirName::create(childName.toString() + suffix);
     dir = EagerDir{
       time,
+      timeStack => TimeStack::createInput(time),
       input => false,
       dirName,
       fixedData,

--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -19,6 +19,7 @@ base class LazyResult {
 
 class LazyDir{
   time: Time,
+  timeStack: TimeStack,
   dirName: DirName,
   data: SortedMap<Key, LazyResult> = SortedMap[],
   lazyFun: ((mutable Context, Key) ~> LazyResult),
@@ -30,6 +31,10 @@ class LazyDir{
 
   fun getTime(): Time {
     this.time
+  }
+
+  fun getTimeStack(): TimeStack {
+    this.timeStack
   }
 
   fun reset(context: mutable Context): void {
@@ -108,7 +113,13 @@ class LazyDir{
       };
       ldir
     | _ ->
-      newDir = LazyDir{time, dirName, lazyFun, collect};
+      newDir = LazyDir{
+        time,
+        timeStack => TimeStack::create(context, time),
+        dirName,
+        lazyFun,
+        collect,
+      };
       updateDirtyReaders(context, Path::create(dirName.tag(), DirTag()));
       context.setDir(dirName, newDir);
       newDir
@@ -179,7 +190,7 @@ class LazyDir{
       | Some(a) -> Some(ArrowKey(a.childName, this.dirName, key))
       | _ -> None()
       };
-      arrow.each(context.enter);
+      arrow.each(a -> context.enter(a, this.timeStack));
       res = this.lazyFun(context, key);
       arrow.each(context.leave);
       res

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -2087,6 +2087,7 @@ fun importNext(
           time = targetCtx.timeStamp();
           targetDir = SKStore.EagerDir{
             time,
+            timeStack => SKStore.TimeStack::createInput(time),
             input => true,
             dirName => targetDirName,
             fixedData => SKStore.FixedDataMap::create(),

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -1452,6 +1452,7 @@ class Evaluator{options: Options, user: ?UserFile} {
     );
     sinkDir = context.unsafeGetEagerDir(sinkDirName);
     !sinkDir.time.value = Int::max - sinkDir.time.value;
+    !sinkDir.timeStack = sinkDir.timeStack.maxMinus();
     context.setDir(sinkDir.dirName, sinkDir);
     updateTableMap(context);
     sinkDirName

--- a/sql/src/SqlTables.sk
+++ b/sql/src/SqlTables.sk
@@ -276,8 +276,10 @@ fun dirDescrCopy(
   sinkName = SKStore.DirName::create(
     "/sink/" + tableName + "/" + version.value + "/",
   );
+  time = context.timeStamp();
   dir = SKStore.EagerDir{
-    time => context.timeStamp(),
+    time,
+    timeStack => SKStore.TimeStack::createInput(time),
     dirName => nextName,
     input => true,
     fixedData => oldDir.fixedData,


### PR DESCRIPTION
We use to have a scheme that was pretty simple. Update the directories in their order of creation. The scheme works, but the problem is that this order is sub-optimal when the topology of subdir changes.

Imagine the following scenario:

```
creating dir A/ which is empty
creating dir B/ which reads A

A gets updated, and now creates subdirs.
```

From this point on, the subdirs in A will always be updated **after** B. Which means that, more often than not, B will be computed twice.

To fix this, this diff introduces the notion of a TimeStack. The order in which the directories are computed is no longer based on just creation time, but the stack of all the creation time of all the creators.

So if directory A, creates a subdir S, the timeStack will be
```Array[A.creationTime, S.creationTime]```.

This way, we guarantee that the subdirs are always updated before the
next directories at the same level as the parent.