### PR TITLE
Improve addon build step

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -32,7 +32,7 @@ jobs:
       - setup
       - run:
           name: Typecheck and lint typescript sources
-          command: npm install && npm run build && npm run lint
+          command: SKIPRUNTIME=$(pwd)/build/skipruntime npm install && npm run build && npm run lint
 
   compiler:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ SKARGO_PROFILE?=release
 SKDB_WASM=sql/target/wasm32-unknown-unknown/$(SKARGO_PROFILE)/skdb.wasm
 SKDB_BIN=sql/target/host/$(SKARGO_PROFILE)/skdb
 SDKMAN_DIR?=$(HOME)/.sdkman
+SKIPRUNTIME?=$(CURDIR)/build/skipruntime
+
+export SKIPRUNTIME
 
 ################################################################################
 # skdb wasm + js client

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "typescript": "^5.7.2"
   },
   "scripts": {
-    "install": "SKIPRUNTIME=$(pwd)/build/skipruntime npm run prepare --workspaces --if-present",
+    "install": "npm run prepare --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
     "clean": "npm run clean --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",

--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -2,7 +2,9 @@ SHELL := /bin/bash
 
 SKARGO_PROFILE?=release
 NPM_WORKSPACES=$(shell jq --raw-output "[.workspaces[] | select((startswith(\"sql\") or contains(\"examples\")) | not)] | map(\"-w \" + .) | .[]" ../package.json)
+SKIPRUNTIME?=$(realpath $(CURDIR)/..)/build/skipruntime
 
+export SKIPRUNTIME
 
 .PHONY: install
 install:

--- a/skipruntime-ts/addon/binding.gyp
+++ b/skipruntime-ts/addon/binding.gyp
@@ -11,7 +11,7 @@
       ],
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      "libraries": ["-L<!(echo $SKIPRUNTIME) -lskip-runtime-ts"],
+      "libraries": ["-L<!(realpath $SKIPRUNTIME) -lskip-runtime-ts -Wl,--require-defined=SKIP_new_Obstack"],
     }
   ]
 }

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "prepare": "skargo build -r --lib --manifest-path=../native/Skargo.toml --out-dir=../../build/skipruntime",
-    "build": "skargo build -r --lib --manifest-path=../native/Skargo.toml --out-dir=../../build/skipruntime && tsc && SKIPRUNTIME=$(realpath ../../build/skipruntime) npm i",
-    "clean": "rm -rf dist build",
+    "build": "skargo build -r --lib --manifest-path=../native/Skargo.toml --out-dir=../../build/skipruntime && tsc && SKIPRUNTIME=$(realpath ../../build/skipruntime) node-gyp configure && node-gyp build",
+    "clean": "rm -rf dist && node-gyp clean",
     "lint": "eslint"
   },
   "dependencies": {


### PR DESCRIPTION
Use directly node-gyp in build step instead of using full install
With SKIPRUNTIME empty -lskip-runtime-ts ignored during link so SKIPRUNTIME is forced to be a valid directory SKIP_new_Obstack is forced to be a defined symbol just in case.

close #700