### PR TITLE
Add `GET /healthcheck` endpoint to skip control service

### DIFF
--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -99,6 +99,10 @@ export function controlService(service: ServiceInstance): express.Express {
     }
   });
 
+  app.get("/v1/healthcheck", (_, res) => {
+    res.sendStatus(200);
+  });
+
   return app;
 }
 

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -64,6 +64,10 @@ export type SkipServer = {
  *   Destroys the resource instance identified by `uuid`.
  *   Under normal circumstances, resource instances are deleted automatically after some period of inactivity; this interface enables immediately deleting live streams under exceptional circumstances.
  *
+ * - `GET /v1/healthcheck
+ *   Check that the Skip service is running normally.
+ *   Returns HTTP 200 if the service is healthy, for use in monitoring, deployments, and the like.
+ *
  * The streaming API responds to the following HTTP requests:
  *
  * - `GET /v1/streams/:uuid`:


### PR DESCRIPTION
Got a question about healthchecks for a skip service, so thought I'd add one on the control service.

I figured it makes more sense there than the streaming service and you probably don't need both, but I may be missing some case where it would be helpful there too -- any thoughts?



I've got it wired into the hackernews example locally with the patch below, but that'll fail in CI until we cut a new `@skipruntime/server` package release so holding off for now.

```diff
diff --git a/examples/hackernews/compose.yml b/examples/hackernews/compose.yml
index 67611050..51352cb0 100644
--- a/examples/hackernews/compose.yml
+++ b/examples/hackernews/compose.yml
@@ -9,6 +9,8 @@ services:
     depends_on:
       www:
         condition: service_healthy
+      reactive_cache:
+        condition: service_healthy
 
   # Web application
   web:
diff --git a/examples/hackernews/reactive_service/Dockerfile b/examples/hackernews/reactive_service/Dockerfile
index f8de40be..b30017ce 100644
--- a/examples/hackernews/reactive_service/Dockerfile
+++ b/examples/hackernews/reactive_service/Dockerfile
@@ -5,4 +5,5 @@ RUN npm install
 COPY . .
 RUN npm run build
 EXPOSE 8080 8081
+HEALTHCHECK --interval=1s --timeout=5s --retries=5 CMD curl -fs http://127.0.0.1:8081/v1/healthcheck
 CMD ["npm", "start"]

```