### PR TITLE
Manage timeouts in departures example

### DIFF
--- a/skipruntime-ts/examples/departures-client.ts
+++ b/skipruntime-ts/examples/departures-client.ts
@@ -3,11 +3,14 @@ import { SkipServiceBroker } from "@skipruntime/helpers";
 
 const streaming_port = 3590;
 const control_port = 3591;
-const service = new SkipServiceBroker({
-  host: "localhost",
-  control_port,
-  streaming_port,
-});
+const service = new SkipServiceBroker(
+  {
+    host: "localhost",
+    control_port,
+    streaming_port,
+  },
+  2000,
+);
 
 // Time to wait (in milliseconds) for local/remote operations to complete,
 // allowing for reproducible/consistent test output

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -5,7 +5,11 @@ import type {
   SkipService,
 } from "@skipruntime/core";
 import { runService } from "@skipruntime/server";
-import { GenericExternalService, Polled } from "@skipruntime/helpers";
+import {
+  GenericExternalService,
+  Polled,
+  defaultParamEncoder,
+} from "@skipruntime/helpers";
 
 const platform: "wasm" | "native" =
   process.env["SKIP_PLATFORM"] == "native" ? "native" : "wasm";
@@ -66,6 +70,8 @@ const service: SkipService<ResourceInputs, ResourceInputs> = {
         "https://api.unhcr.org/rsq/v1/departures",
         10000,
         (data: Result) => data.results.map((v, idx) => [idx, [v]]),
+        defaultParamEncoder,
+        { timeout: 1500 },
       ),
     }),
   },


### PR DESCRIPTION

departures example systematically fails on my computer due to timeout.
Tune timeouts to fix it.