### PR TITLE
Async shutdowns & postgres teardown signal handlers

### DIFF
--- a/skipruntime-ts/adapters/postgres/src/index.ts
+++ b/skipruntime-ts/adapters/postgres/src/index.ts
@@ -258,7 +258,7 @@ FOR EACH ROW EXECUTE FUNCTION %I();`,
         );
   }
 
-  shutdown(): void {
+  shutdown(): Promise<void> {
     const query =
       "DROP FUNCTION IF EXISTS " +
       Array.from(this.open_instances)
@@ -266,17 +266,8 @@ FOR EACH ROW EXECUTE FUNCTION %I();`,
         .join(", ") +
       " CASCADE;";
     this.open_instances.clear();
-
-    const shutdown =
-      this.open_instances.size == 0
-        ? this.client.end()
-        : this.client.query(query).then(() => this.client.end());
-
-    shutdown.catch((e: unknown) => {
-      console.error(
-        "Error shutting down Postgres external service; trigger functions may need teardown.",
-      );
-      throw e;
-    });
+    return this.open_instances.size == 0
+      ? this.client.end()
+      : this.client.query(query).then(() => this.client.end());
   }
 }

--- a/skipruntime-ts/adapters/postgres/src/index.ts
+++ b/skipruntime-ts/adapters/postgres/src/index.ts
@@ -137,15 +137,29 @@ export class PostgresExternalService implements ExternalService {
     this.clientID = "skip_pg_client_" + Math.random().toString(36).slice(2);
 
     this.client = new pg.Client(db_config);
-    this.client.connect().then(
-      () => this.client.query(format(`LISTEN %I;`, this.clientID)),
-      (e: unknown) => {
-        console.error(
-          "Error connecting to Postgres at " + JSON.stringify(db_config),
-        );
-        throw e;
-      },
-    );
+    this.client
+      .connect()
+      .then(() => this.client.query(format(`LISTEN %I;`, this.clientID)))
+      .then(
+        () => {
+          const handler = () => {
+            void this.shutdown().then(() => process.exit());
+          };
+          [
+            "SIGINT",
+            "SIGTERM",
+            "SIGUSR1",
+            "SIGUSR2",
+            "uncaughtException",
+          ].forEach((sig) => process.on(sig, handler));
+        },
+        (e: unknown) => {
+          console.error(
+            "Error connecting to Postgres at " + JSON.stringify(db_config),
+          );
+          throw e;
+        },
+      );
   }
 
   /**
@@ -259,6 +273,8 @@ FOR EACH ROW EXECUTE FUNCTION %I();`,
   }
 
   shutdown(): Promise<void> {
+    if (this.open_instances.size == 0) return this.client.end();
+
     const query =
       "DROP FUNCTION IF EXISTS " +
       Array.from(this.open_instances)
@@ -266,8 +282,6 @@ FOR EACH ROW EXECUTE FUNCTION %I();`,
         .join(", ") +
       " CASCADE;";
     this.open_instances.clear();
-    return this.open_instances.size == 0
-      ? this.client.end()
-      : this.client.query(query).then(() => this.client.end());
+    return this.client.query(query).then(() => this.client.end());
   }
 }

--- a/skipruntime-ts/addon/src/fromjs.cc
+++ b/skipruntime-ts/addon/src/fromjs.cc
@@ -130,12 +130,12 @@ void SkipRuntime_ExternalService__unsubscribe(uint32_t externalSupplierId,
                      "SkipRuntime_ExternalService__unsubscribe", 2, argv);
 }
 
-void SkipRuntime_ExternalService__shutdown(uint32_t externalSupplierId) {
+double SkipRuntime_ExternalService__shutdown(uint32_t externalSupplierId) {
   Isolate* isolate = Isolate::GetCurrent();
   Local<Object> externFunctions = kExternFunctions.Get(isolate);
   Local<Value> argv[1] = {Number::New(isolate, externalSupplierId)};
-  CallJSVoidFunction(isolate, externFunctions,
-                     "SkipRuntime_ExternalService__shutdown", 1, argv);
+  return CallJSNumberFunction(isolate, externFunctions,
+                              "SkipRuntime_ExternalService__shutdown", 1, argv);
 }
 
 void SkipRuntime_deleteExternalService(uint32_t externalSupplierId) {

--- a/skipruntime-ts/addon/src/tojs.cc
+++ b/skipruntime-ts/addon/src/tojs.cc
@@ -41,7 +41,7 @@ SKNotifier SkipRuntime_createNotifier(int32_t ref);
 SKReducer SkipRuntime_createReducer(int32_t ref, CJSON json);
 
 double SkipRuntime_initService(SKService service);
-double SkipRuntime_closeService();
+CJSON SkipRuntime_closeService();
 
 CJArray SkipRuntime_Collection__getArray(char* collection, CJSON key);
 CJSON SkipRuntime_Collection__getUnique(char* collection, CJSON key);
@@ -583,8 +583,8 @@ void InitService(const FunctionCallbackInfo<Value>& args) {
 void CloseService(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   NatTryCatch(isolate, [&args](Isolate* isolate) {
-    double skerror = SkipRuntime_closeService();
-    args.GetReturnValue().Set(Number::New(isolate, skerror));
+    CJSON skresult = SkipRuntime_closeService();
+    args.GetReturnValue().Set(External::New(isolate, skresult));
   });
 }
 

--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -439,7 +439,7 @@ export interface ExternalService {
    *
    * @returns {void}
    */
-  shutdown(): void;
+  shutdown(): Promise<void>;
 }
 
 /**

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -236,7 +236,7 @@ export interface FromBinding {
   SkipRuntime_initService(service: Pointer<Internal.Service>): Handle<Error>;
 
   // closeClose
-  SkipRuntime_closeService(): Handle<Error>;
+  SkipRuntime_closeService(): Pointer<Internal.CJSON>;
 
   // Context
 

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -91,4 +91,5 @@ async function shutdown() {
   await server.close();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 ["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -87,9 +87,8 @@ const server = await runService(serviceWithInitialData(data), {
   platform,
 });
 
-function shutdown() {
-  server.close();
+async function shutdown() {
+  await server.close();
 }
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -84,9 +84,8 @@ const server = await runService(service, {
   platform,
 });
 
-function shutdown() {
-  server.close();
+async function shutdown() {
+  await server.close();
 }
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -88,4 +88,5 @@ async function shutdown() {
   await server.close();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 ["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/groups.ts
+++ b/skipruntime-ts/examples/groups.ts
@@ -127,4 +127,5 @@ async function shutdown() {
   await server.close();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 ["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/groups.ts
+++ b/skipruntime-ts/examples/groups.ts
@@ -122,9 +122,9 @@ const server = await runService(service, {
   control_port: 8081,
   platform,
 });
-function shutdown() {
-  server.close();
+
+async function shutdown() {
+  await server.close();
 }
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -73,9 +73,8 @@ const server = await runService(service, {
   platform,
 });
 
-function shutdown() {
-  server.close();
+async function shutdown() {
+  await server.close();
 }
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/remote.ts
+++ b/skipruntime-ts/examples/remote.ts
@@ -77,4 +77,5 @@ async function shutdown() {
   await server.close();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 ["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -101,9 +101,8 @@ const server = await runService(service, {
   platform,
 });
 
-function shutdown() {
-  server.close();
+async function shutdown() {
+  await server.close();
 }
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/sheet.ts
+++ b/skipruntime-ts/examples/sheet.ts
@@ -105,4 +105,5 @@ async function shutdown() {
   await server.close();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 ["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -75,4 +75,5 @@ async function shutdown() {
   await server.close();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 ["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/examples/sum.ts
+++ b/skipruntime-ts/examples/sum.ts
@@ -71,9 +71,8 @@ const server = await runService(service, {
   platform,
 });
 
-function shutdown() {
-  server.close();
+async function shutdown() {
+  await server.close();
 }
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+["SIGTERM", "SIGINT"].map((sig) => process.on(sig, shutdown));

--- a/skipruntime-ts/helpers/src/external.ts
+++ b/skipruntime-ts/helpers/src/external.ts
@@ -64,8 +64,8 @@ export class GenericExternalService implements ExternalService {
     }
   }
 
-  shutdown(): void {
-    return;
+  shutdown(): Promise<void> {
+    return Promise.resolve();
   }
 }
 

--- a/skipruntime-ts/helpers/src/remote.ts
+++ b/skipruntime-ts/helpers/src/remote.ts
@@ -93,9 +93,10 @@ export class SkipExternalService implements ExternalService {
     }
   }
 
-  shutdown(): void {
+  shutdown(): Promise<void> {
     for (const res of this.resources.values()) {
       res.close();
     }
+    return Promise.resolve();
   }
 }

--- a/skipruntime-ts/native/src/BaseTypes.sk
+++ b/skipruntime-ts/native/src/BaseTypes.sk
@@ -35,7 +35,7 @@ base class ExternalService {
 
   fun unsubscribe(instance: String): void;
 
-  fun shutdown(): void;
+  fun shutdown(): Float;
 }
 
 base class Resource {

--- a/skipruntime-ts/native/src/Extern.sk
+++ b/skipruntime-ts/native/src/Extern.sk
@@ -144,7 +144,7 @@ native fun unsubscribeOfExternalService(
 
 @cpp_extern("SkipRuntime_ExternalService__shutdown")
 @debug
-native fun shutdownOfExternalService(externalSupplier: UInt32): void;
+native fun shutdownOfExternalService(externalSupplier: UInt32): Float;
 
 @cpp_extern("SkipRuntime_deleteExternalService")
 @debug
@@ -179,7 +179,7 @@ class ExternExternalService(
     unsubscribeOfExternalService(this.eptr.value, instance)
   }
 
-  fun shutdown(): void {
+  fun shutdown(): Float {
     shutdownOfExternalService(this.eptr.value)
   }
 }
@@ -779,10 +779,10 @@ fun initSkipRuntimeService(service: Service): Float {
 /************ closeService ****************/
 
 @export("SkipRuntime_closeService")
-fun closeSkipRuntimeService(): Float {
+fun closeSkipRuntimeService(): SKJSON.CJSON {
   closeService() match {
-  | Success _ -> 0.0
-  | Failure(err) -> getErrorHdl(err)
+  | Success(handles) -> SKJSON.CJArray(handles.map(h -> SKJSON.CJFloat(h)))
+  | Failure(err) -> SKJSON.CJFloat(getErrorHdl(err))
   };
 }
 

--- a/skipruntime-ts/native/src/Runtime.sk
+++ b/skipruntime-ts/native/src/Runtime.sk
@@ -422,7 +422,8 @@ fun initService(service: Service): Result<void, .Exception> {
         );
       buildResourcesGraph(context, sessionHdl, statusHdl, servicesHdl)
     } else {
-      closeService_(context);
+      // Can be done because it's only used on test, we can add a environment variable or some way to protect that usage
+      _ = closeService_(context);
       sessionHdl = SKStore.EHandle(
         SKStore.IID::keyType,
         ServiceDefinition::type,
@@ -440,7 +441,7 @@ fun initService(service: Service): Result<void, .Exception> {
   })
 }
 
-fun closeService_(context: mutable SKStore.Context): void {
+fun closeService_(context: mutable SKStore.Context): Array<Float> {
   resourceHdl = SKStore.EHandle(
     SKStore.SID::keyType,
     ResourceDef::type,
@@ -456,13 +457,19 @@ fun closeService_(context: mutable SKStore.Context): void {
     ServiceDefinition::type,
     kSessionDir,
   );
-  sessionHdl.maybeGet(context, SKStore.IID(0)).each(def -> {
-    def.service.remoteCollections.each((_k, es) -> es.shutdown());
-  });
+  handles = sessionHdl.maybeGet(context, SKStore.IID(0)) match {
+  | Some(def) ->
+    def.service.remoteCollections
+      .values()
+      .map(es -> es.shutdown())
+      .collect(Array)
+  | _ -> Array[]
+  };
   context.update();
+  handles;
 }
 
-fun closeService(): Result<void, .Exception> {
+fun closeService(): Result<Array<Float>, .Exception> {
   SKStore.runWithResult(closeService_)
 }
 

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -144,9 +144,10 @@ export async function runService(
   );
 
   return {
-    close: () => {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    close: async () => {
       controlHttpServer.close();
-      instance.close();
+      await instance.close();
       streamingHttpServer.close();
     },
   };

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -14,7 +14,7 @@ export type SkipServer = {
   /**
    * Stop accepting new connections, close existing connections, and halt a running service.
    */
-  close: () => void;
+  close: () => Promise<void>;
 };
 
 /**
@@ -144,7 +144,6 @@ export async function runService(
   );
 
   return {
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     close: async () => {
       controlHttpServer.close();
       await instance.close();

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -430,7 +430,7 @@ class MockExternal implements ExternalService {
   }
 
   shutdown() {
-    return;
+    return Promise.resolve();
   }
 
   private async mock(

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -1125,7 +1125,7 @@ export function initTests(
       ]);
     } finally {
       service.closeResourceInstance(constantResourceId);
-      service.close();
+      await service.close();
     }
   });
 
@@ -1143,7 +1143,7 @@ export function initTests(
       expect(current == start).toEqual(false);
     } finally {
       service.closeResourceInstance(constantResourceId);
-      service.close();
+      await service.close();
     }
   });
 
@@ -1211,7 +1211,7 @@ export function initTests(
         }
       }
     } finally {
-      service.close();
+      await service.close();
     }
   });
 

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -252,7 +252,7 @@ export interface FromWasm {
   SkipRuntime_initService(service: ptr<Internal.Service>): Handle<Error>;
 
   // closeClose
-  SkipRuntime_closeService(): Handle<Error>;
+  SkipRuntime_closeService(): ptr<Internal.CJSON>;
 
   // Context
 
@@ -324,7 +324,7 @@ interface ToWasm {
 
   SkipRuntime_ExternalService__shutdown(
     supplier: Handle<ExternalService>,
-  ): void;
+  ): Handle<Promise<void>>;
 
   SkipRuntime_deleteExternalService(supplier: Handle<ExternalService>): void;
 
@@ -775,7 +775,7 @@ export class WasmFromBinding implements FromBinding {
     return this.fromWasm.SkipRuntime_initService(toPtr(service));
   }
 
-  SkipRuntime_closeService(): Handle<Error> {
+  SkipRuntime_closeService(): Pointer<Internal.CJSON> {
     return this.fromWasm.SkipRuntime_closeService();
   }
 
@@ -1036,7 +1036,7 @@ class LinksImpl implements Links {
   }
 
   shutdownOfExternalService(sksupplier: Handle<ExternalService>) {
-    this.tobinding.SkipRuntime_ExternalService__shutdown(sksupplier);
+    return this.tobinding.SkipRuntime_ExternalService__shutdown(sksupplier);
   }
 
   deleteExternalService(supplier: Handle<ExternalService>) {


### PR DESCRIPTION
In local testing this keeps the listened-to postgres clean of extra trigger functions.  I suspect that the nastiest of crashes will still fail to cleanup, but that's unavoidable and this works for normal cases.

The changes of my first commit here work for local testing on their own, but I've simulated higher network latency by adding sleeps in the shutdown handler and found that, without async shutdowns (i.e. Daniel's commit in this PR) this often fails. 

