### PR TITLE
Specify order on Json values

### DIFF
--- a/skiplang/skjson/src/JSON.sk
+++ b/skiplang/skjson/src/JSON.sk
@@ -89,6 +89,17 @@ value class CJFields(cols: Array<String>, values: Array<CJSON>) uses Orderable {
       yield (fieldName, value);
     }
   }
+  fun mapAcc<R>(f: (R, String, CJSON) -> (R, CJSON), acc: R): (R, this) {
+    ((_i, !acc), !this.values) = this.values.mapAcc(
+      (i_acc, v) -> {
+        (i, a) = i_acc;
+        (!a, !v) = f(a, this.cols[i], v);
+        ((i + 1, a), v)
+      },
+      (0, acc),
+    );
+    (acc, this)
+  }
 }
 
 mutable class CJSONBuilder{

--- a/skiplang/skjson/src/JSON.sk
+++ b/skiplang/skjson/src/JSON.sk
@@ -61,7 +61,10 @@ base class CJSON uses Orderable {
     SKJSON.TObject(SKJSON.Fields::create(result.chill()))
 }
 
-value class CJFields(cols: Array<String>, values: Array<CJSON>) uses Orderable {
+value class CJFields private (
+  cols: Array<String>,
+  values: Array<CJSON>,
+) uses Orderable {
   /* Invariant:
     - cols and values have the same length
       - requires that internFieldNames preserves cols length

--- a/skiplang/skjson/src/JSON.sk
+++ b/skiplang/skjson/src/JSON.sk
@@ -15,6 +15,33 @@ base class CJSON uses Orderable {
   | CJArray(Array<CJSON>)
   | CJObject(CJFields)
 
+  /* The order is such that null < bool < number < string < array < object */
+  fun compare(other: CJSON): Order {
+    (this, other) match {
+    | (CJNull(), CJNull()) -> EQ()
+    | (CJNull(), _) -> LT()
+    | (_, CJNull()) -> GT()
+    | (CJBool(a), CJBool(b)) -> a.compare(b)
+    | (CJBool(_), _) -> LT()
+    | (_, CJBool(_)) -> GT()
+    | (CJInt(a), CJInt(b)) -> a.compare(b)
+    | (CJFloat(a), CJFloat(b)) -> a.compare(b)
+    | (CJInt(a), CJFloat(b)) -> a.toFloat().compare(b)
+    | (CJFloat(a), CJInt(b)) -> a.compare(b.toFloat())
+    | (CJInt(_), _) -> LT()
+    | (CJFloat(_), _) -> LT()
+    | (_, CJInt(_)) -> GT()
+    | (_, CJFloat(_)) -> GT()
+    | (CJString(a), CJString(b)) -> a.compare(b)
+    | (CJString(_), _) -> LT()
+    | (_, CJString(_)) -> GT()
+    | (CJArray(a), CJArray(b)) -> a.compare(b)
+    | (CJArray(_), _) -> LT()
+    | (_, CJArray(_)) -> GT()
+    | (CJObject(a), CJObject(b)) -> a.compare(b)
+    }
+  }
+
   fun toJSON(): JSON.Value
   | CJNull() -> JSON.Null()
   | CJBool(x) -> JSON.Bool(x)
@@ -81,6 +108,25 @@ value class CJFields private (
       if (i != 0) invariant(fields[i - 1].i0 < elt.i0);
     };
     static(internFieldNames(fields.map(x -> x.i0)), fields.map(x -> x.i1))
+  }
+
+  fun compare(other: CJFields): Order {
+    i = 0;
+    while (i < this.cols.size()) {
+      if (i >= other.cols.size()) {
+        return GT();
+      };
+      this.cols[i].compare(other.cols[i]) match {
+      | EQ() -> void
+      | cmp -> return cmp
+      };
+      this.values[i].compare(other.values[i]) match {
+      | EQ() -> void
+      | cmp -> return cmp
+      };
+      !i = i + 1;
+    };
+    if (i < other.cols.size()) LT() else EQ()
   }
 
   fun isEmpty(): Bool {

--- a/skiplang/skjson/src/JSON.sk
+++ b/skiplang/skjson/src/JSON.sk
@@ -62,6 +62,10 @@ base class CJSON uses Orderable {
 }
 
 value class CJFields(cols: Array<String>, values: Array<CJSON>) uses Orderable {
+  /* Invariant:
+    - cols and values have the same length
+      - requires that internFieldNames preserves cols length
+    - cols was sorted lexicographically and had no duplicates, before being passed to internFieldNames */
   static fun empty(): this {
     static(Array[], Array[])
   }

--- a/skiplang/skjson/src/JSON.sk
+++ b/skiplang/skjson/src/JSON.sk
@@ -62,9 +62,6 @@ base class CJSON uses Orderable {
 }
 
 value class CJFields(cols: Array<String>, values: Array<CJSON>) uses Orderable {
-  fun isEmpty(): Bool {
-    this.values.isEmpty()
-  }
   static fun empty(): this {
     static(Array[], Array[])
   }
@@ -79,6 +76,9 @@ value class CJFields(cols: Array<String>, values: Array<CJSON>) uses Orderable {
     static(internFieldNames(fields.map(x -> x.i0)), fields.map(x -> x.i1))
   }
 
+  fun isEmpty(): Bool {
+    this.values.isEmpty()
+  }
   fun items(): mutable Iterator<(String, CJSON)> {
     for (i => value in this.values) {
       fieldName = this.cols[i];

--- a/skiplang/skjson/src/Type.sk
+++ b/skiplang/skjson/src/Type.sk
@@ -431,14 +431,14 @@ class Type private (types: Array<(Int, SType)>) uses Orderable {
         j = 0;
         newValues = mutable Vector[];
         loop {
-          if (i >= tyFields.size() || j >= fieldNames.size()) {
+          if (j >= fieldNames.size()) {
             return CJObject(CJFields(fieldNames, newValues.toArray()))
           };
-          if (tyFields[i].name < fieldNames[j]) {
+          if (i < tyFields.size() && tyFields[i].name < fieldNames[j]) {
             !i = i + 1;
             continue
           };
-          if (tyFields[i].name > fieldNames[j]) {
+          if (i >= tyFields.size() || tyFields[i].name > fieldNames[j]) {
             newValues.push(fieldValues[j]);
             !j = j + 1;
             continue

--- a/skiplang/skjson/src/Type.sk
+++ b/skiplang/skjson/src/Type.sk
@@ -426,28 +426,28 @@ class Type private (types: Array<(Int, SType)>) uses Orderable {
       | (TObject(objectFields), CJObject(fields)) ->
         tyFields = objectFields.fields;
         fieldNames = fields.cols;
-        fieldValues = fields.values;
-        i = 0;
-        j = 0;
-        newValues = mutable Vector[];
-        loop {
-          if (j >= fieldNames.size()) {
-            return CJObject(CJFields(fieldNames, newValues.toArray()))
-          };
-          if (i < tyFields.size() && tyFields[i].name < fieldNames[j]) {
-            !i = i + 1;
-            continue
-          };
-          if (i >= tyFields.size() || tyFields[i].name > fieldNames[j]) {
-            newValues.push(fieldValues[j]);
-            !j = j + 1;
-            continue
-          };
-          invariant(tyFields[i].name == fieldNames[j]);
-          newValues.push(tyFields[i].type.convertNum(fieldValues[j]));
-          !i = i + 1;
-          !j = j + 1;
-        }
+        (_, fieldValues) = fields.values.mapAcc(
+          (acc, v) -> {
+            (iFieldName, iTyField) = acc;
+            fieldName = fieldNames[iFieldName];
+            while (
+              iTyField < tyFields.size() &&
+              tyFields[iTyField].name < fieldName
+            ) {
+              !iTyField = iTyField + 1;
+            };
+            if (
+              iTyField < tyFields.size() &&
+              tyFields[iTyField].name == fieldName
+            ) {
+              !v = tyFields[iTyField].type.convertNum(v);
+              !iTyField = iTyField + 1;
+            };
+            ((iFieldName + 1, iTyField), v)
+          },
+          (0, 0),
+        );
+        return CJObject(CJFields(fieldNames, fieldValues))
       | (TObject(_), _) -> void
       }
     };

--- a/skiplang/skjson/src/Type.sk
+++ b/skiplang/skjson/src/Type.sk
@@ -425,11 +425,8 @@ class Type private (types: Array<(Int, SType)>) uses Orderable {
       | (TArray(_), _) -> void
       | (TObject(objectFields), CJObject(fields)) ->
         tyFields = objectFields.fields;
-        fieldNames = fields.cols;
-        (_, fieldValues) = fields.values.mapAcc(
-          (acc, v) -> {
-            (iFieldName, iTyField) = acc;
-            fieldName = fieldNames[iFieldName];
+        (_, !fields) = fields.mapAcc(
+          (iTyField, fieldName, v) -> {
             while (
               iTyField < tyFields.size() &&
               tyFields[iTyField].name < fieldName
@@ -443,11 +440,11 @@ class Type private (types: Array<(Int, SType)>) uses Orderable {
               !v = tyFields[iTyField].type.convertNum(v);
               !iTyField = iTyField + 1;
             };
-            ((iFieldName + 1, iTyField), v)
+            (iTyField, v)
           },
-          (0, 0),
+          0,
         );
-        return CJObject(CJFields(fieldNames, fieldValues))
+        return CJObject(fields)
       | (TObject(_), _) -> void
       }
     };

--- a/skiplang/skjson/tests/test.sk
+++ b/skiplang/skjson/tests/test.sk
@@ -545,24 +545,30 @@ fun testPatterns(): void {
           (
             "obj",
             SKJSON.CJObject(
-              SKJSON.CJFields(
-                Array["c"],
+              SKJSON.CJFields::create(
                 Array[
-                  SKJSON.CJObject(
-                    SKJSON.CJFields(
-                      Array["d"],
-                      Array[
-                        SKJSON.CJArray(
-                          Array[
-                            SKJSON.CJFloat(0.0),
-                            SKJSON.CJFloat(1.0),
-                            SKJSON.CJFloat(2.3),
-                          ],
-                        ),
-                      ],
+                  (
+                    "c",
+                    SKJSON.CJObject(
+                      SKJSON.CJFields::create(
+                        Array[
+                          (
+                            "d",
+                            SKJSON.CJArray(
+                              Array[
+                                SKJSON.CJFloat(0.0),
+                                SKJSON.CJFloat(1.0),
+                                SKJSON.CJFloat(2.3),
+                              ],
+                            ),
+                          ),
+                        ],
+                        x -> x,
+                      ),
                     ),
                   ),
                 ],
+                x -> x,
               ),
             ),
           ),

--- a/skiplang/skjson/tests/test.sk
+++ b/skiplang/skjson/tests/test.sk
@@ -589,4 +589,84 @@ fun testPatterns(): void {
   };
 }
 
+@test
+fun testOrder(): void {
+  before1 = 0.999999999999999889; // next_after(1.0, 0.0)
+  after1 = 1.00000000000000022; // next_after(1.0, 2.0)
+  expectedOrder = Array[
+    SKJSON.CJNull(),
+    SKJSON.CJBool(false),
+    SKJSON.CJBool(true),
+    SKJSON.CJInt(-9223372036854775808), // INT64_MIN
+    SKJSON.CJFloat(-1.1),
+    SKJSON.CJInt(-1),
+    SKJSON.CJFloat(-2.2250738585072014e-308), // Smallest negative double
+    SKJSON.CJFloat(-0.0),
+    SKJSON.CJInt(0),
+    SKJSON.CJFloat(2.2250738585072014e-308), // Smallest positive double
+    SKJSON.CJFloat(0.5),
+    SKJSON.CJFloat(before1),
+    SKJSON.CJInt(1),
+    SKJSON.CJFloat(after1),
+    SKJSON.CJInt(9223372036854775807), // INT64_MAX
+    SKJSON.CJFloat(1.7976931348623157e308), // DBL_MAX
+    SKJSON.CJString(""),
+    SKJSON.CJString("\u0000"), // Null character
+    SKJSON.CJString("A"),
+    SKJSON.CJString("a"),
+    SKJSON.CJString("aa"),
+    SKJSON.CJString("ab"),
+    SKJSON.CJString("abc"),
+    SKJSON.CJString("b"),
+    SKJSON.CJString("ba"),
+    SKJSON.CJString("🐫"),
+    SKJSON.CJArray(Array[]),
+    SKJSON.CJArray(Array[SKJSON.CJNull()]),
+    SKJSON.CJArray(Array[SKJSON.CJBool(false), SKJSON.CJInt(1)]),
+    SKJSON.CJArray(Array[SKJSON.CJBool(false), SKJSON.CJInt(2)]),
+    SKJSON.CJArray(Array[SKJSON.CJBool(true)]),
+    SKJSON.CJArray(Array[SKJSON.CJBool(true), SKJSON.CJInt(0)]),
+    SKJSON.CJArray(Array[SKJSON.CJFloat(before1), SKJSON.CJInt(9)]),
+    SKJSON.CJArray(Array[SKJSON.CJInt(1), SKJSON.CJInt(0)]),
+    SKJSON.CJArray(Array[SKJSON.CJFloat(1.0), SKJSON.CJInt(1)]),
+    SKJSON.CJArray(Array[SKJSON.CJInt(1), SKJSON.CJInt(2)]),
+    SKJSON.CJArray(Array[SKJSON.CJFloat(after1), SKJSON.CJInt(-1)]),
+    SKJSON.CJArray(Array[SKJSON.CJArray(Array[])]),
+    SKJSON.CJArray(Array[SKJSON.CJArray(Array[]), SKJSON.CJArray(Array[])]),
+    SKJSON.CJArray(Array[SKJSON.CJArray(Array[SKJSON.CJNull()])]),
+    SKJSON.CJObject(SKJSON.CJFields::create(Array[], x -> x)),
+    SKJSON.CJObject(
+      SKJSON.CJFields::create(Array[("", SKJSON.CJInt(9))], x -> x),
+    ),
+    SKJSON.CJObject(
+      SKJSON.CJFields::create(
+        Array[("b", SKJSON.CJInt(1)), ("a", SKJSON.CJInt(1))],
+        x -> x,
+      ),
+    ),
+    SKJSON.CJObject(
+      SKJSON.CJFields::create(Array[("a", SKJSON.CJInt(2))], x -> x),
+    ),
+    SKJSON.CJObject(
+      SKJSON.CJFields::create(Array[("a", SKJSON.CJInt(3))], x -> x),
+    ),
+    SKJSON.CJObject(
+      SKJSON.CJFields::create(
+        Array[("b", SKJSON.CJInt(1)), ("a", SKJSON.CJInt(3))],
+        x -> x,
+      ),
+    ),
+    SKJSON.CJObject(
+      SKJSON.CJFields::create(Array[("b", SKJSON.CJInt(0))], x -> x),
+    ),
+  ];
+  rng = Random::mcreate(20250219);
+
+  T.expectEq(expectedOrder.reversed().sorted(), expectedOrder);
+
+  v = Vector::mcreateFromItems(expectedOrder);
+  v.shuffle(rng);
+  T.expectEq(v.sorted().collect(Array), expectedOrder)
+}
+
 module end;

--- a/skiplang/skjson/tests/test.sk
+++ b/skiplang/skjson/tests/test.sk
@@ -591,8 +591,8 @@ fun testPatterns(): void {
 
 @test
 fun testOrder(): void {
-  before1 = 0.999999999999999889; // next_after(1.0, 0.0)
-  after1 = 1.00000000000000022; // next_after(1.0, 2.0)
+  before1 = 0.999999999999999889 - 0.001; // next_after(1.0, 0.0)
+  after1 = 1.00000000000000022 + 0.001; // next_after(1.0, 2.0)
   expectedOrder = Array[
     SKJSON.CJNull(),
     SKJSON.CJBool(false),

--- a/skiplang/skjson/ts/binding/src/index.ts
+++ b/skiplang/skjson/ts/binding/src/index.ts
@@ -143,6 +143,12 @@ export function deepFreeze<T>(value: T): T & DepSafe {
  * JSON-serializable values.
  *
  * The `Json` type describes JSON-serializable values and serves as an upper bound on keys and values in the Skip Runtime, ensuring that they can be serialized and managed by the reactive computation engine.
+ *
+ * `Json` values are compared by the Skip Runtime in the following way:
+ * - null < false < true < numbers < strings < arrays < objects
+ * - strings are compared lexicographically
+ * - arrays are compared lexicographically
+ * - objects are compared lexicographically based on their key-value pairs ordered by keys
  */
 export type Json = boolean | number | string | (Json | null)[] | JsonObject;
 

--- a/skiplang/skjson/ts/binding/src/index.ts
+++ b/skiplang/skjson/ts/binding/src/index.ts
@@ -76,9 +76,9 @@ export type DepSafe =
 
 export function checkOrCloneParam<T>(value: T): T {
   if (
-    typeof value == "string" ||
+    typeof value == "boolean" ||
     typeof value == "number" ||
-    typeof value == "boolean"
+    typeof value == "string"
   )
     return value;
   if (typeof value == "object") {
@@ -108,9 +108,9 @@ export function checkOrCloneParam<T>(value: T): T {
  */
 export function deepFreeze<T>(value: T): T & DepSafe {
   if (
-    typeof value == "bigint" ||
     typeof value == "boolean" ||
     typeof value == "number" ||
+    typeof value == "bigint" ||
     typeof value == "string" ||
     typeof value == "symbol"
   ) {
@@ -144,7 +144,7 @@ export function deepFreeze<T>(value: T): T & DepSafe {
  *
  * The `Json` type describes JSON-serializable values and serves as an upper bound on keys and values in the Skip Runtime, ensuring that they can be serialized and managed by the reactive computation engine.
  */
-export type Json = number | boolean | string | (Json | null)[] | JsonObject;
+export type Json = boolean | number | string | (Json | null)[] | JsonObject;
 
 /**
  * Objects containing `Json` values.
@@ -152,9 +152,9 @@ export type Json = number | boolean | string | (Json | null)[] | JsonObject;
 export type JsonObject = { [key: string]: Json | null };
 
 export type Exportable =
-  | Json
   | null
   | undefined
+  | Json
   | ObjectProxy<{ [k: string]: Exportable }>
   | (readonly Exportable[] & Managed);
 
@@ -246,11 +246,11 @@ function interpretPointer<T extends Internal.CJSON>(
   switch (type) {
     case Type.Null:
       return null;
+    case Type.Boolean:
+      return binding.SKIP_SKJSON_asBoolean(pointer);
     case Type.Int:
     case Type.Float:
       return binding.SKIP_SKJSON_asNumber(pointer);
-    case Type.Boolean:
-      return binding.SKIP_SKJSON_asBoolean(pointer);
     case Type.String:
       return binding.SKIP_SKJSON_asString(pointer);
     case Type.Array: {
@@ -353,14 +353,14 @@ export function exportJSON(
 ): Pointer<Internal.CJSON> {
   if (value === null || value === undefined) {
     return binding.SKIP_SKJSON_createCJNull();
+  } else if (typeof value == "boolean") {
+    return binding.SKIP_SKJSON_createCJBool(value);
   } else if (typeof value == "number") {
     if (value === Math.trunc(value)) {
       return binding.SKIP_SKJSON_createCJInt(value);
     } else {
       return binding.SKIP_SKJSON_createCJFloat(value);
     }
-  } else if (typeof value == "boolean") {
-    return binding.SKIP_SKJSON_createCJBool(value);
   } else if (typeof value == "string") {
     return binding.SKIP_SKJSON_createCJString(value);
   } else if (Array.isArray(value)) {
@@ -396,8 +396,8 @@ export function importJSON<T extends Internal.CJSON>(
 export interface JsonConverter {
   importJSON(value: Pointer<Internal.CJSON>, copy?: boolean): Exportable;
   exportJSON(v: null | undefined): Pointer<Internal.CJNull>;
-  exportJSON(v: number): Pointer<Internal.CJFloat | Internal.CJInt>;
   exportJSON(v: boolean): Pointer<Internal.CJBool>;
+  exportJSON(v: number): Pointer<Internal.CJFloat | Internal.CJInt>;
   exportJSON(v: string): Pointer<Internal.CJString>;
   exportJSON(v: any[]): Pointer<Internal.CJArray>;
   exportJSON(v: JsonObject): Pointer<Internal.CJObject>;

--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -247,6 +247,8 @@ export interface EagerCollection<K extends Json, V extends Json>
   /**
    * Create a new eager collection by keeping only the elements whose keys are in the given range.
    *
+   * See {@link Json} for a reference on `Json` value ordering.
+   *
    * @param start - The least key whose entry will be kept in the result.
    * @param end - The greatest key whose entry will be kept in the result.
    * @returns The restricted eager collection.
@@ -256,6 +258,8 @@ export interface EagerCollection<K extends Json, V extends Json>
   /**
    * Create a new eager collection by keeping only the elements whose keys are in at least one of the given ranges.
    *
+   * See {@link Json} for a reference on `Json` value ordering.
+   *
    * @param ranges - The pairs of lower and upper bounds on keys to keep in the result.
    * @returns The restricted eager collection.
    */
@@ -263,6 +267,8 @@ export interface EagerCollection<K extends Json, V extends Json>
 
   /**
    * Create a new eager collection by keeping the first entries.
+   *
+   * See {@link Json} for a reference on `Json` value ordering.
    *
    * @param limit - The number of entries to keep.
    * @returns The restricted eager collection.


### PR DESCRIPTION
- Overrides SKJSON default implementation of `Orderable` which put arrays before booleans.
- Test and document it

First step towards #606 