### PR TITLE
Improve native Reducer docs

### DIFF
--- a/skipruntime-ts/helpers/src/utils.ts
+++ b/skipruntime-ts/helpers/src/utils.ts
@@ -1,9 +1,5 @@
-import {
-  type NativeStub,
-  type Nullable,
-  sknative,
-} from "../skiplang-std/index.js";
-import type { Reducer, Json } from "@skipruntime/core";
+import { type NativeStub, sknative } from "../skiplang-std/index.js";
+import type { Nullable, Reducer, Json } from "@skipruntime/core";
 
 /**
  * `Reducer` to maintain the sum of input values.

--- a/skipruntime-ts/helpers/src/utils.ts
+++ b/skipruntime-ts/helpers/src/utils.ts
@@ -7,6 +7,7 @@ import type { Nullable, Reducer, Json } from "@skipruntime/core";
  * A `Reducer` that maintains the sum of values as they are added and removed from a collection.
  */
 export class Sum implements NativeStub, Reducer<number, number> {
+  /** @hidden */
   [sknative] = "sum";
 
   // Lie to TypeScript that this implements Reducer, but leave out any implementations
@@ -22,6 +23,7 @@ export class Sum implements NativeStub, Reducer<number, number> {
  * A `Reducer` that maintains the minimum of values as they are added and removed from a collection.
  */
 export class Min implements NativeStub, Reducer<number, number> {
+  /** @hidden */
   [sknative] = "min";
 
   // Lie to TypeScript that this implements Reducer, but leave out any implementations
@@ -37,6 +39,7 @@ export class Min implements NativeStub, Reducer<number, number> {
  * A `Reducer` that maintains the maximum of values as they are added and removed from a collection.
  */
 export class Max implements NativeStub, Reducer<number, number> {
+  /** @hidden */
   [sknative] = "max";
 
   // Lie to TypeScript that this implements Reducer, but leave out any implementations
@@ -52,6 +55,7 @@ export class Max implements NativeStub, Reducer<number, number> {
  * A `Reducer` that maintains the number of values as they are added and removed from a collection.
  */
 export class Count<T extends Json> implements Reducer<T, number>, NativeStub {
+  /** @hidden */
   [sknative] = "count";
 
   // Lie to TypeScript that this implements Reducer, but leave out any implementations

--- a/skipruntime-ts/helpers/src/utils.ts
+++ b/skipruntime-ts/helpers/src/utils.ts
@@ -1,4 +1,4 @@
-import { type NativeStub, sknative } from "../skiplang-std/index.js";
+import { /* type NativeStub, */ sknative } from "../skiplang-std/index.js";
 import type { Nullable, Reducer, Json } from "@skipruntime/core";
 
 /**
@@ -6,7 +6,7 @@ import type { Nullable, Reducer, Json } from "@skipruntime/core";
  *
  * A `Reducer` that maintains the sum of values as they are added and removed from a collection.
  */
-export class Sum implements NativeStub, Reducer<number, number> {
+export class Sum implements /* NativeStub, */ Reducer<number, number> {
   /** @hidden */
   [sknative] = "sum";
 
@@ -22,7 +22,7 @@ export class Sum implements NativeStub, Reducer<number, number> {
  *
  * A `Reducer` that maintains the minimum of values as they are added and removed from a collection.
  */
-export class Min implements NativeStub, Reducer<number, number> {
+export class Min implements /* NativeStub, */ Reducer<number, number> {
   /** @hidden */
   [sknative] = "min";
 
@@ -38,7 +38,7 @@ export class Min implements NativeStub, Reducer<number, number> {
  *
  * A `Reducer` that maintains the maximum of values as they are added and removed from a collection.
  */
-export class Max implements NativeStub, Reducer<number, number> {
+export class Max implements /* NativeStub, */ Reducer<number, number> {
   /** @hidden */
   [sknative] = "max";
 
@@ -54,7 +54,9 @@ export class Max implements NativeStub, Reducer<number, number> {
  *
  * A `Reducer` that maintains the number of values as they are added and removed from a collection.
  */
-export class Count<T extends Json> implements Reducer<T, number>, NativeStub {
+export class Count<T extends Json>
+  implements /* NativeStub, */ Reducer<T, number>
+{
   /** @hidden */
   [sknative] = "count";
 


### PR DESCRIPTION
- import Nullable from core since it is documented there
  Just to make the docs generator able to find it.

- hide sknative properties in docs
  They are an internal implementation detail.
  
- hide `implements NativeStub`
  There does not seem to be a way to hide this implementation detail in the
  documentation. So this change comments it out entirely, since the
  implementation is based on checking the sknative property, and the
  NativeStub superclass is surface-only.