### PR TITLE
Print messages for todo runtime errors

### DIFF
--- a/skiplang/prelude/runtime/runtime.c
+++ b/skiplang/prelude/runtime/runtime.c
@@ -27,16 +27,16 @@ SKIP_gc_type_t* get_gc_type(char* skip_object) {
 void SKIP_Regex_initialize() {}
 
 void SKIP_print_stack_trace() {
-  todo();
+  todo("Not implemented", "SKIP_print_stack_trace");
 }
 void SKIP_print_last_exception_stack_trace_and_exit(void*) {
-  todo();
+  todo("Not implemented", "SKIP_print_last_exception_stack_trace_and_exit");
 }
-void SKIP_unreachableMethodCall(void*, void*) {
-  todo();
+void SKIP_unreachableMethodCall(void* msg, void*) {
+  todo("Unreachable method call", msg);
 }
-void SKIP_unreachableWithExplanation(void*) {
-  todo();
+void SKIP_unreachableWithExplanation(void* explanation) {
+  todo("Unreachable", explanation);
 }
 
 void SKIP_Obstack_vectorUnsafeSet(char** arr, char* x) {

--- a/skiplang/prelude/runtime/runtime.h
+++ b/skiplang/prelude/runtime/runtime.h
@@ -372,7 +372,7 @@ void sk_staging();
 char* sk_string_create(const char* buffer, uint32_t size);
 void sk_string_check_c_safe(char* str);
 void throw_Invalid_utf8();
-void todo();
+void todo(char* err, char* msg);
 char* sk_get_external_pointer();
 char* sk_get_external_pointer_destructor(char* obj);
 uint32_t sk_get_external_pointer_value(char* obj);

--- a/skiplang/prelude/runtime/stdlib.c
+++ b/skiplang/prelude/runtime/stdlib.c
@@ -114,9 +114,16 @@ void sk_print_int(uint64_t x) {
   SKIP_print_char('\n');
 }
 
-void todo() {
+#ifdef SKIP64
+void todo(char* err, char* msg) {
+  fprintf(stderr, "%s: %s\n", err, msg);
   SKIP_throw_cruntime(ERROR_TODO);
 }
+#else
+void todo(char*, char*) {
+  SKIP_throw_cruntime(ERROR_TODO);
+}
+#endif
 
 char* SKIP_read_line() {
   int32_t size = SKIP_read_line_fill();


### PR DESCRIPTION
Much better than just `CRuntimeError(1)`