### PR TITLE
Get rid IterHolder

### DIFF
--- a/skiplang/prelude/src/skstore/DMap.sk
+++ b/skiplang/prelude/src/skstore/DMap.sk
@@ -73,35 +73,31 @@ base class DMap<Key: Orderable, Value> {
     }
   }
 
-  private fun itemsAfterKeyHelper(
-    boundary: Boundary<Key>,
-  ): mutable Iterator<(Key, Value)> {
+  private fun keysAfterHelper(boundary: Boundary<Key>): mutable Iterator<Key> {
     this match {
     | Nil() -> void
-    | Node{key, value, left, right} ->
+    | Node{key, left, right} ->
       if (
         boundary match {
         | Inclusive(lastSkipped) -> key >= lastSkipped
         | Exclusive(lastSkipped) -> key > lastSkipped
         }
       ) {
-        for (x in left.itemsAfterKeyHelper(boundary)) {
+        for (x in left.keysAfterHelper(boundary)) {
           yield x;
         };
-        yield (key, value);
+        yield key;
       };
-      for (x in right.itemsAfterKeyHelper(boundary)) {
+      for (x in right.keysAfterHelper(boundary)) {
         yield x;
       }
     }
   }
 
-  fun itemsAfterKey(
-    lastSkippedOpt: ?Boundary<Key>,
-  ): mutable Iterator<(Key, Value)> {
+  fun keysAfter(lastSkippedOpt: ?Boundary<Key>): mutable Iterator<Key> {
     lastSkippedOpt match {
-    | None() -> this.items()
-    | Some(lastSkipped) -> this.itemsAfterKeyHelper(lastSkipped)
+    | None() -> this.items().map(item -> item.i0)
+    | Some(lastSkipped) -> this.keysAfterHelper(lastSkipped)
     }
   }
 

--- a/skiplang/prelude/src/skstore/DMap.sk
+++ b/skiplang/prelude/src/skstore/DMap.sk
@@ -15,12 +15,6 @@ value class TickRange{max: Tick, current: Tick} {
   }
 }
 
-mutable class IterHolder<Key, Value>(iter: mutable Iterator<(Key, Value)>) {
-  mutable fun items(): mutable Iterator<(Key, Value)> {
-    this.iter
-  }
-}
-
 base class Boundary<T> {
   children =
   | Inclusive(T)
@@ -104,13 +98,11 @@ base class DMap<Key: Orderable, Value> {
 
   fun itemsAfterKey(
     lastSkippedOpt: ?Boundary<Key>,
-  ): mutable IterHolder<Key, Value> {
-    mutable IterHolder(
-      lastSkippedOpt match {
-      | None() -> this.items()
-      | Some(lastSkipped) -> this.itemsAfterKeyHelper(lastSkipped)
-      },
-    )
+  ): mutable Iterator<(Key, Value)> {
+    lastSkippedOpt match {
+    | None() -> this.items()
+    | Some(lastSkipped) -> this.itemsAfterKeyHelper(lastSkipped)
+    }
   }
 
   fun itemsWithTick(): mutable Iterator<(Key, Value, TickRange)> {

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -480,16 +480,10 @@ class DataMap{
     }
   }
 
-  fun itemsAfterKeyHelper(
-    lastSkippedOpt: ?Boundary<Key>,
-  ): mutable Iterator<(Key, DMap<Path, (Path, Array<File>)>)> {
-    this.data.itemsAfterKey(lastSkippedOpt).iter
-  }
-
   fun itemsAfterKey(
     lastSkippedOpt: ?Boundary<Key>,
-  ): mutable IterHolder<Key, DMap<Path, (Path, Array<File>)>> {
-    mutable IterHolder(this.itemsAfterKeyHelper(lastSkippedOpt))
+  ): mutable Iterator<(Key, DMap<Path, (Path, Array<File>)>)> {
+    this.data.itemsAfterKey(lastSkippedOpt)
   }
 
   fun getHeight(): Int {
@@ -997,7 +991,7 @@ class EagerDir{
     current = mutable IntRef(currentStart);
     size = 0;
 
-    for (key => _ in parent.data.itemsAfterKey(start)) {
+    for ((key, _) in parent.data.itemsAfterKey(start)) {
       end match {
       | Some(endKey) if (key > endKey) -> break void
       | _ -> void
@@ -1933,7 +1927,7 @@ class EagerDir{
       | Some(key) -> max(0, this.fixedData.data.getPos(key))
       },
     );
-    for (key => _ in this.data.data.itemsAfterKey(
+    for ((key, _) in this.data.data.itemsAfterKey(
       start.map(x -> Inclusive(x)),
     )) {
       while (

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -480,10 +480,8 @@ class DataMap{
     }
   }
 
-  fun itemsAfterKey(
-    lastSkippedOpt: ?Boundary<Key>,
-  ): mutable Iterator<(Key, DMap<Path, (Path, Array<File>)>)> {
-    this.data.itemsAfterKey(lastSkippedOpt)
+  fun keysAfter(lastSkippedOpt: ?Boundary<Key>): mutable Iterator<Key> {
+    this.data.keysAfter(lastSkippedOpt)
   }
 
   fun getHeight(): Int {
@@ -991,7 +989,7 @@ class EagerDir{
     current = mutable IntRef(currentStart);
     size = 0;
 
-    for ((key, _) in parent.data.itemsAfterKey(start)) {
+    for (key in parent.data.keysAfter(start)) {
       end match {
       | Some(endKey) if (key > endKey) -> break void
       | _ -> void
@@ -1927,9 +1925,7 @@ class EagerDir{
       | Some(key) -> max(0, this.fixedData.data.getPos(key))
       },
     );
-    for ((key, _) in this.data.data.itemsAfterKey(
-      start.map(x -> Inclusive(x)),
-    )) {
+    for (key in this.data.data.keysAfter(start.map(x -> Inclusive(x)))) {
       while (
         current.value < this.fixedData.data.size() &&
         this.fixedData.data[current.value].key < key


### PR DESCRIPTION
I don't see the point in keeping this wrapper, it makes reasoning about iterators a bit harder.
And we don't even use the values