### PR TITLE
Skdate cleanup

### DIFF
--- a/skiplang/cc/src/lib.sk
+++ b/skiplang/cc/src/lib.sk
@@ -1,5 +1,19 @@
 module Cc;
 
+const kRecommendedCflags: Array<String> = Array[
+  "-Werror",
+  "-Wall",
+  "-Wextra",
+  "-Wno-sign-conversion",
+  "-Wno-sometimes-uninitialized",
+  "-Wno-c2x-extensions",
+  "-Wsign-compare",
+  "-Wextra-semi-stmt",
+  // To add: -Wcast-align -Wcast-qual -Wimplicit-int-conversion -Wmissing-noreturn -Wpadded -Wreserved-identifier -Wshorten-64-to-32 -Wtautological-unsigned-zero-compare
+  // -Watomic-implicit-seq-cst ?
+  // If using -Weverything, you may want to add -Wno-declaration-after-statement -Wno-missing-prototypes -Wno-missing-variable-declarations -Wno-shadow -Wno-strict-prototypes -Wno-zero-length-array -Wno-unreachable-code-break -Wno-unreachable-code-return
+];
+
 class Build(
   files_: Array<String> = Array[],
   compiler_: ?String = None(),

--- a/skiplang/prelude/build.sk
+++ b/skiplang/prelude/build.sk
@@ -1,17 +1,3 @@
-const kCflags: Array<String> = Array[
-  "-Werror",
-  "-Wall",
-  "-Wextra",
-  "-Wno-sign-conversion",
-  "-Wno-sometimes-uninitialized",
-  "-Wno-c2x-extensions",
-  "-Wsign-compare",
-  "-Wextra-semi-stmt",
-  // To add: -Wcast-align -Wcast-qual -Wimplicit-int-conversion -Wmissing-noreturn -Wpadded -Wreserved-identifier -Wshorten-64-to-32 -Wtautological-unsigned-zero-compare
-  // -Watomic-implicit-seq-cst ?
-  // If using -Weverything, you may want to add -Wno-declaration-after-statement -Wno-missing-prototypes -Wno-missing-variable-declarations -Wno-shadow -Wno-strict-prototypes -Wno-zero-length-array -Wno-unreachable-code-break -Wno-unreachable-code-return
-];
-
 fun main(): void {
   // FIXME: This should be passed by Skargo.
   Environ.set_var("DEBUG", "true");
@@ -51,7 +37,11 @@ fun main(): void {
     "runtime/xoroshiro128plus.c",
   ];
 
-  cfg = Cc.Build().pic(pic).flags(kCflags).files(srcs).file(magic_c);
+  cfg = Cc.Build()
+    .pic(pic)
+    .flags(Cc.kRecommendedCflags)
+    .files(srcs)
+    .file(magic_c);
   srcs.each(f -> print_string(`skargo:rerun-if-changed=${f}`));
 
   // TODO: `skargo:rerun-if-changed` on sources.

--- a/skiplang/skdate/Skargo.toml
+++ b/skiplang/skdate/Skargo.toml
@@ -9,4 +9,4 @@ std = { path = "../prelude" }
 sktest = { path = "../sktest" }
 
 [build-dependencies]
-skbuild = { path = "../skbuild" }
+cc = { path = "../cc" }

--- a/skiplang/skdate/build.sk
+++ b/skiplang/skdate/build.sk
@@ -9,34 +9,4 @@ fun main(): void {
   | Failure(err) -> skipExit(err.code)
   | _ -> void
   };
-
-  file_path = Path.join(Environ.var("OUT_DIR"), "current_time_millis.sk");
-  file = IO.File::open(
-    file_path,
-    IO.OpenOptions{create => true, truncate => true, write => true},
-  );
-
-  contents = Environ.varOpt("TARGET") match {
-  | Some(t) if (t.startsWith("wasm32")) ->
-    `module SKDate;
-@cpp_extern("SKIP_JS_currenttimemillis")
-native fun jsCurrentTimeMillis(): Float;
-
-fun currentTimeMillis(): Int {
-  (jsCurrentTimeMillis() * 1000.0).toInt()
-}
-module end;`
-  | _ ->
-    `module SKDate;
-@cpp_extern("SKIP_currenttimemillis")
-native fun currentTimeMillis(): Int;
-module end;`
-  };
-  file.write_all(contents.bytes()) match {
-  | Success _ -> void
-  | Failure(err) ->
-    print_error(`Could not write ${file_path}: ${err}`);
-    skipExit(1)
-  };
-  print_string(`skargo:skc-extra-source=${file_path}`)
 }

--- a/skiplang/skdate/build.sk
+++ b/skiplang/skdate/build.sk
@@ -1,12 +1,19 @@
-@skbuild_source_dirs
-fun source_dirs(env: Skbuild.Env): Array<String> {
-  if (env.isWasm32()) Array[] else Array["extern/src"]
-}
-
-@debug
 fun main(): void {
-  Skbuild.build() match {
-  | Failure(err) -> skipExit(err.code)
-  | _ -> void
+  Environ.set_var("DEBUG", "true");
+
+  profile = Environ.var("PROFILE");
+  target = Environ.var("TARGET");
+  isWasm32 = target.startsWith("wasm32");
+
+  profile match {
+  | "release" -> Environ.set_var("OPT_LEVEL", "3")
+  | "debug" | "dev" -> Environ.set_var("OPT_LEVEL", "0")
+  | p -> invariant_violation(`Unrecognized profile ${p}`)
   };
+
+  if (!isWasm32) {
+    src = "extern/src/date.c";
+    print_string("skargo:rerun-if-changed=${src}");
+    Cc.Build().flags(Cc.kRecommendedCflags).file(src).compile("date")
+  }
 }

--- a/skiplang/skdate/extern/src/date.c
+++ b/skiplang/skdate/extern/src/date.c
@@ -44,7 +44,7 @@ char* SKIP_locale(uint32_t code, int32_t value) {
   } else if (c == 'b') {
     locale = nl_langinfo(ABMON_1 + ((value - 1) % 12));
   } else {
-    char tmp[] = {'%', '%', c};
+    char tmp[] = {'%', '%', c, 0};
     locale = tmp;
   }
   return sk_string_create(locale, strlen(locale));

--- a/skiplang/skdate/extern/src/date.c
+++ b/skiplang/skdate/extern/src/date.c
@@ -1,12 +1,8 @@
-
-
 #include <langinfo.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/time.h>
 #include <time.h>
-
-extern "C" {
 
 uint32_t SKIP_String_byteSize(char*);
 char* sk_string_create(const char* buffer, uint32_t size);
@@ -74,7 +70,7 @@ int32_t SKIP_localetimezone(uint32_t year, uint32_t month, uint32_t day) {
 }
 
 int64_t SKIP_currenttimemillis() {
-  timeval curTime;
+  struct timeval curTime;
   gettimeofday(&curTime, 0);
   return time(NULL) * 1000 + curTime.tv_usec / 1000;
 }
@@ -85,5 +81,4 @@ char* SKIP_localetimezonename(uint32_t year, uint32_t month, uint32_t day) {
   localefor(&local, year, month, day);
   size_t size = strftime(buffer, sizeof(buffer), "%Z", &local);
   return sk_string_create(buffer, size);
-}
 }

--- a/skiplang/skdate/extern/src/date.cpp
+++ b/skiplang/skdate/extern/src/date.cpp
@@ -4,8 +4,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/time.h>
-
-#include <ctime>
+#include <time.h>
 
 extern "C" {
 
@@ -77,7 +76,7 @@ int32_t SKIP_localetimezone(uint32_t year, uint32_t month, uint32_t day) {
 int64_t SKIP_currenttimemillis() {
   timeval curTime;
   gettimeofday(&curTime, 0);
-  return std::time(0) * 1000 + curTime.tv_usec / 1000;
+  return time(NULL) * 1000 + curTime.tv_usec / 1000;
 }
 
 char* SKIP_localetimezonename(uint32_t year, uint32_t month, uint32_t day) {

--- a/skiplang/skdate/extern/src/date.cpp
+++ b/skiplang/skdate/extern/src/date.cpp
@@ -1,10 +1,10 @@
 
 
 #include <langinfo.h>
+#include <stdint.h>
 #include <string.h>
 #include <sys/time.h>
 
-#include <cstdint>
 #include <ctime>
 
 extern "C" {

--- a/skiplang/skdate/extern/src/date.cpp
+++ b/skiplang/skdate/extern/src/date.cpp
@@ -4,11 +4,8 @@
 #include <string.h>
 #include <sys/time.h>
 
-#include <chrono>
 #include <cstdint>
 #include <ctime>
-#include <iomanip>
-#include <sstream>
 
 extern "C" {
 

--- a/skiplang/skdate/extern/src/date.cpp
+++ b/skiplang/skdate/extern/src/date.cpp
@@ -28,7 +28,7 @@ char* sk_string_create(const char* buffer, uint32_t size);
  * - r => AM/PM Time format string of the locale.
  * - p => AM or PM locale string.
  */
-char* SKIP_locale(u_int32_t code, int32_t value) {
+char* SKIP_locale(uint32_t code, int32_t value) {
   char c = (char)code;
   const char* locale;
   if (c == 'c') {

--- a/skiplang/skdate/src/date.sk
+++ b/skiplang/skdate/src/date.sk
@@ -557,7 +557,7 @@ class Calendar private (
   }
 
   static fun current(): Calendar {
-    Calendar::epoch(currentTimeMillis());
+    Calendar::epoch(Time.time_ms());
   }
 
   static fun parse(str: String, tz: TZKind = TZLocal()): ?Calendar {

--- a/skiplang/skdate/ts/src/sk_date.ts
+++ b/skiplang/skdate/ts/src/sk_date.ts
@@ -15,7 +15,6 @@ interface ToWasm {
     day: int,
   ) => ptr<Internal.String>;
   SKIP_locale: (code: int, value: int) => ptr<Internal.String>;
-  SKIP_JS_currenttimemillis: () => number;
 }
 
 class LinksImpl implements Links {
@@ -98,7 +97,6 @@ class Manager implements ToWasmManager {
       links.SKIP_localetimezonename(year, month, day);
     toWasm.SKIP_locale = (code: int, value: int) =>
       links.SKIP_locale(code, value);
-    toWasm.SKIP_JS_currenttimemillis = () => Date.now() / 1000;
     return links;
   };
 }

--- a/sql/src/SqlDate.sk
+++ b/sql/src/SqlDate.sk
@@ -29,7 +29,7 @@ base class PlusMinus {
 }
 
 fun getUnixTime(): Int {
-  SKDate.currentTimeMillis() / 1000;
+  Time.time_ms() / 1000;
 }
 
 mutable class DateTime(mutable date: SKDate.Calendar) {


### PR DESCRIPTION
- C++ -> C
- simplify build
- use `cc` instead of `skbuild`

As a result, `skbuild` is not used anymore, should it be killed?