### PR TITLE
Allow passing extra args to skc from skargo

### DIFF
--- a/skiplang/skargo/src/build_context.sk
+++ b/skiplang/skargo/src/build_context.sk
@@ -108,7 +108,7 @@ fun create_bctx(
     | TargetArchHost _ -> Array[]
     | TargetArchTriple(triple) -> Array[triple]
     },
-    opts.skc_extra_options,
+    opts.build_config.skc_extra_options,
   );
   unit_graph = build_unit_dependencies(roots, resolved_packages);
   target_dir = ws.target_dir();

--- a/skiplang/skargo/src/build_context.sk
+++ b/skiplang/skargo/src/build_context.sk
@@ -108,6 +108,7 @@ fun create_bctx(
     | TargetArchHost _ -> Array[]
     | TargetArchTriple(triple) -> Array[triple]
     },
+    opts.skc_extra_options,
   );
   unit_graph = build_unit_dependencies(roots, resolved_packages);
   target_dir = ws.target_dir();

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -240,8 +240,8 @@ mutable class BuildRunner(
   }
 
   private mutable fun run_build_script(unit: Unit): BuildScriptOutput {
-    cmd = mutable ProcessBuilder{
-      process_cmd => Path.join(
+    cmd = ProcessBuilder::create{
+      cmd => Path.join(
         this.build_dir_for(
           unit with {
             arch => TargetArchHost(),

--- a/skiplang/skargo/src/commands/build.sk
+++ b/skiplang/skargo/src/commands/build.sk
@@ -35,7 +35,8 @@ fun build(): (Cli.Command, (GlobalContext, Cli.ParseResults) ~> void) {
       )
       .arg(Cli.Arg::bool("bins").about("Build all binaries"))
       .arg(Cli.Arg::bool("tests").about("Build all tests"))
-      .arg(Cli.Arg::bool("all-targets").about("Build all targets")),
+      .arg(Cli.Arg::bool("all-targets").about("Build all targets"))
+      .arg(kSkcOptArg),
     execBuild,
   )
 }

--- a/skiplang/skargo/src/commands/check.sk
+++ b/skiplang/skargo/src/commands/check.sk
@@ -22,7 +22,8 @@ fun check(): (Cli.Command, (GlobalContext, Cli.ParseResults) ~> void) {
           .value_name("PATH")
           .about("Directory for all generated artifacts"),
       )
-      .args(kProfileArgs),
+      .args(kProfileArgs)
+      .arg(kSkcOptArg),
     execCheck,
   )
 }

--- a/skiplang/skargo/src/commands/run.sk
+++ b/skiplang/skargo/src/commands/run.sk
@@ -22,6 +22,7 @@ fun runner(): (Cli.Command, (GlobalContext, Cli.ParseResults) ~> void) {
           .value_name("NAME")
           .about("Build only the specified binary"),
       )
+      .arg(kSkcOptArg)
       .extra(),
     execRun,
   )

--- a/skiplang/skargo/src/commands/test.sk
+++ b/skiplang/skargo/src/commands/test.sk
@@ -51,7 +51,8 @@ fun test(): (Cli.Command, (GlobalContext, Cli.ParseResults) ~> void) {
         Cli.Arg::string("junitxml")
           .value_name("PATH")
           .about("Generate a JUnit XML report"),
-      ),
+      )
+      .arg(kSkcOptArg),
     execTest,
   )
 }

--- a/skiplang/skargo/src/compile_options.sk
+++ b/skiplang/skargo/src/compile_options.sk
@@ -21,11 +21,11 @@ class CompileOptions{
   skc_extra_options: Array<String>,
 }
 
-fun build_config(
+fun build_config{
   target_opt: ?String,
   profile_opt: ?String,
   release: Bool,
-): BuildConfig {
+}: BuildConfig {
   BuildConfig{
     requested_arch => target_opt match {
     | Some(t) -> TargetArchTriple(TargetTriple::fromString(t))
@@ -51,11 +51,11 @@ fun build_config(
 
 // TODO: Return Result<...>.
 fun compile_options(args: Cli.ParseResults): CompileOptions {
-  build_config = build_config(
-    args.maybeGetString("target", false),
-    args.maybeGetString("profile"),
-    args.getBool("release"),
-  );
+  build_config = build_config{
+    target_opt => args.maybeGetString("target", false),
+    profile_opt => args.maybeGetString("profile"),
+    release => args.getBool("release"),
+  };
   filter = CompileFilter::from_raw_arguments(
     args.getBool("lib", Some(false)),
     args.getArray("bin", Some(Array[])),

--- a/skiplang/skargo/src/compile_options.sk
+++ b/skiplang/skargo/src/compile_options.sk
@@ -12,19 +12,20 @@ class BuildConfig{
   requested_arch: TargetArch,
   requested_profile: String,
   export_dir: ?String,
+  skc_extra_options: Array<String>,
 } uses Equality, Hashable
 
 class CompileOptions{
   build_config: BuildConfig,
   /// Filter to apply to the root package to select which targets will be built.
   filter: CompileFilter,
-  skc_extra_options: Array<String>,
 }
 
 fun build_config{
   target_opt: ?String,
   profile_opt: ?String,
   release: Bool,
+  skc_extra_options: Array<String>,
 }: BuildConfig {
   BuildConfig{
     requested_arch => target_opt match {
@@ -46,6 +47,7 @@ fun build_config{
       }
     },
     export_dir => None(),
+    skc_extra_options,
   };
 }
 
@@ -55,6 +57,7 @@ fun compile_options(args: Cli.ParseResults): CompileOptions {
     target_opt => args.maybeGetString("target", false),
     profile_opt => args.maybeGetString("profile"),
     release => args.getBool("release"),
+    skc_extra_options => args.getArray("skcopt", Some(Array[])),
   };
   filter = CompileFilter::from_raw_arguments(
     args.getBool("lib", Some(false)),
@@ -63,9 +66,8 @@ fun compile_options(args: Cli.ParseResults): CompileOptions {
     args.getBool("tests", Some(false)),
     args.getBool("all-targets", Some(false)),
   );
-  skc_extra_options = args.getArray("skcopt", Some(Array[]));
 
-  CompileOptions{build_config, filter, skc_extra_options}
+  CompileOptions{build_config, filter}
 }
 
 const kSkcOptArg: Cli.Arg = Cli.Arg::string("skcopt")

--- a/skiplang/skargo/src/compile_options.sk
+++ b/skiplang/skargo/src/compile_options.sk
@@ -18,6 +18,7 @@ class CompileOptions{
   build_config: BuildConfig,
   /// Filter to apply to the root package to select which targets will be built.
   filter: CompileFilter,
+  skc_extra_options: Array<String>,
 }
 
 fun build_config(
@@ -62,9 +63,15 @@ fun compile_options(args: Cli.ParseResults): CompileOptions {
     args.getBool("tests", Some(false)),
     args.getBool("all-targets", Some(false)),
   );
+  skc_extra_options = args.getArray("skcopt", Some(Array[]));
 
-  CompileOptions{build_config, filter}
+  CompileOptions{build_config, filter, skc_extra_options}
 }
+
+const kSkcOptArg: Cli.Arg = Cli.Arg::string("skcopt")
+  .repeatable()
+  .value_name("option")
+  .about("Pass the given option to skc");
 
 const kProfileArgs: Array<Cli.Arg> = Array[
   Cli.Arg::string("profile")

--- a/skiplang/skargo/src/skc.sk
+++ b/skiplang/skargo/src/skc.sk
@@ -2,7 +2,7 @@ module Skargo;
 
 class Skc(cmd: String) {
   fun process(): mutable ProcessBuilder {
-    mutable ProcessBuilder{process_cmd => this.cmd}
+    ProcessBuilder::create{cmd => this.cmd}
   }
 }
 
@@ -12,6 +12,10 @@ mutable class ProcessBuilder{
   process_env: mutable Map<String, String> = mutable Map[],
   mutable process_cwd: ?String = None(),
 } {
+  static fun create{cmd: String}: mutable this {
+    mutable static{process_cmd => cmd}
+  }
+
   mutable fun arg(value: String): void {
     this.process_args.push(value)
   }

--- a/skiplang/skargo/src/skc.sk
+++ b/skiplang/skargo/src/skc.sk
@@ -7,15 +7,11 @@ class Skc(cmd: String) {
 }
 
 mutable class ProcessBuilder{
-  mutable process_cmd: String,
+  process_cmd: String,
   process_args: mutable Vector<String> = mutable Vector[],
   process_env: mutable Map<String, String> = mutable Map[],
   mutable process_cwd: ?String = None(),
 } {
-  mutable fun cmd(value: String): void {
-    this.!process_cmd = value
-  }
-
   mutable fun arg(value: String): void {
     this.process_args.push(value)
   }

--- a/skiplang/skargo/src/skc.sk
+++ b/skiplang/skargo/src/skc.sk
@@ -1,19 +1,23 @@
 module Skargo;
 
-class Skc(cmd: String) {
+class Skc(cmd: String, extra_options: Array<String>) {
   fun process(): mutable ProcessBuilder {
-    ProcessBuilder::create{cmd => this.cmd}
+    ProcessBuilder::create{cmd => this.cmd, args => this.extra_options}
   }
 }
 
 mutable class ProcessBuilder private {
   private process_cmd: String,
-  private process_args: mutable Vector<String> = mutable Vector[],
+  private process_args: mutable Vector<String>,
   private process_env: mutable Map<String, String> = mutable Map[],
   private mutable process_cwd: ?String = None(),
 } {
-  static fun create{cmd: String}: mutable this {
-    mutable static{process_cmd => cmd}
+  static fun create{
+    cmd: String,
+    args: readonly Sequence<String> = Array[],
+  }: mutable this {
+    process_args = Vector::mcreateFromItems(args);
+    mutable static{process_cmd => cmd, process_args}
   }
 
   mutable fun arg(value: String): void {

--- a/skiplang/skargo/src/skc.sk
+++ b/skiplang/skargo/src/skc.sk
@@ -28,14 +28,6 @@ mutable class ProcessBuilder{
     this.!process_cwd = Some(path)
   }
 
-  mutable fun clone(): mutable ProcessBuilder {
-    mutable ProcessBuilder{
-      process_cmd => this.process_cmd,
-      process_args => this.process_args.clone(),
-      process_env => this.process_env.clone(),
-    }
-  }
-
   readonly fun get_cmd(): String {
     this.process_cmd
   }

--- a/skiplang/skargo/src/skc.sk
+++ b/skiplang/skargo/src/skc.sk
@@ -6,11 +6,11 @@ class Skc(cmd: String) {
   }
 }
 
-mutable class ProcessBuilder{
-  process_cmd: String,
-  process_args: mutable Vector<String> = mutable Vector[],
-  process_env: mutable Map<String, String> = mutable Map[],
-  mutable process_cwd: ?String = None(),
+mutable class ProcessBuilder private {
+  private process_cmd: String,
+  private process_args: mutable Vector<String> = mutable Vector[],
+  private process_env: mutable Map<String, String> = mutable Map[],
+  private mutable process_cwd: ?String = None(),
 } {
   static fun create{cmd: String}: mutable this {
     mutable static{process_cmd => cmd}

--- a/skiplang/skargo/src/target_info.sk
+++ b/skiplang/skargo/src/target_info.sk
@@ -8,8 +8,9 @@ class SkcTargetData{
   static fun create(
     gctx: GlobalContext,
     requested_arches: Array<TargetTriple>,
+    extra_options: Array<String>,
   ): SkcTargetData {
-    skc = Skc(Environ.varOpt("SKC").default("skc"));
+    skc = Skc(Environ.varOpt("SKC").default("skc"), extra_options);
     host_target = get_host_target(gctx);
 
     SkcTargetData{skc, requested_arches, host_target}


### PR DESCRIPTION
For example `skargo build --skcopt --no-inline --skcopt --no-peephole` will make calls to `skc` start with `--no-inline --no-peephole`.

Inspired by `ocamlc`'s `-ccopt`
