### PR TITLE
Check TG_OP to determine trigger type in postgres

### DIFF
--- a/skipruntime-ts/adapters/postgres/src/index.ts
+++ b/skipruntime-ts/adapters/postgres/src/index.ts
@@ -206,9 +206,9 @@ export class PostgresExternalService implements ExternalService {
             `
 CREATE OR REPLACE FUNCTION %I() RETURNS TRIGGER AS $f$
 BEGIN
-  IF NEW IS NOT NULL THEN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
     PERFORM pg_notify(%L, NEW.%I::text);
-  ELSIF OLD IS NOT NULL THEN
+  ELSE
     PERFORM pg_notify(%L, OLD.%I::text);
   END IF;
   RETURN NULL;


### PR DESCRIPTION
See [discord thread](https://discord.com/channels/1093901946441703434/1345016769634500698) for context -- triggers were failing to fire on certain updates with null fields, since a row "IS NOT NULL" in postgres only when ALL of its fields are non-null.