### PR TITLE
Restructure pg adapter `subscribe`; improve error messages.

### DIFF
--- a/eslint-config/src/eslint.config.js
+++ b/eslint-config/src/eslint.config.js
@@ -34,6 +34,7 @@ export default tseslint.config(
       "@typescript-eslint/consistent-indexed-object-style": "off",
       "@typescript-eslint/consistent-type-definitions": "off",
       "@typescript-eslint/no-confusing-void-expression": "off",
+      "@typescript-eslint/no-empty-function": "off",
       "@typescript-eslint/no-empty-object-type": [
         "error",
         { allowInterfaces: "with-single-extends" },

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -834,11 +834,17 @@ export class ToBinding {
   ): Pointer<Internal.CJArray> {
     const skjson = this.getJsonConverter();
     const mapper = this.handles.get(skmapper);
-    const result = mapper.mapEntry(
-      skjson.importJSON(key) as Json,
-      new ValuesImpl<Json>(skjson, this.binding, values),
-    );
-    return skjson.exportJSON(Array.from(result));
+    try {
+      const result = mapper.mapEntry(
+        skjson.importJSON(key) as Json,
+        new ValuesImpl<Json>(skjson, this.binding, values),
+      );
+      return skjson.exportJSON(Array.from(result));
+    } catch (e: unknown) {
+      console.error("Uncaught error during Skip runtime reactive update: ", e);
+      // Exception in async context will be dropped -- this `throw` is just to appease typechecker
+      throw e;
+    }
   }
 
   SkipRuntime_deleteMapper(mapper: Handle<JSONMapper>): void {

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -1311,7 +1311,7 @@ export function initTests(
 
     await withAlternateConsoleError(
       () => {},
-      async () => {
+      () => {
         const update = () =>
           service.update("input", [
             [0, [10]],
@@ -1322,6 +1322,7 @@ export function initTests(
             /^(?:Error: )?useExternalResource is not allowed in a lazy computation graph.$/,
           ),
         );
+        return Promise.resolve(undefined);
       },
     );
   });

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -427,7 +427,7 @@ class MockExternal implements ExternalService {
     },
   ) {
     if (resource == "mock") {
-      this.mock(params, callbacks.update);
+      void this.mock(params, callbacks.update);
     }
   }
 


### PR DESCRIPTION
This PR breaks down the async `setup()` of the postgres adapter's `subscribe` method into three separate phases, provides different and more descriptive error messages for errors thrown in each one, and puts the resource into an `error` state when an exception. is caught and logged.