### PR TITLE
Catch package-lock.json up to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,16 +61,6 @@
         "@skiplabs/tsconfig": "^0.0.1"
       }
     },
-    "examples/hackernews/reactive_service/node_modules/@skipruntime/native": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.11.tgz",
-      "integrity": "sha512-4eAHWk1IhcWaz1waUMaIqIiILwzExQ7G7w3Ayxepe1MzpOxdvhIIjf3q/Y4fTs+6XnWbPI8cFRP+zcsmo0xR/Q==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@skipruntime/core": "0.0.11"
-      }
-    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.49.0",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.49.0.tgz",


### PR DESCRIPTION
This got left out of some PR recently (looks like #786, my bad), just catching it up now.