### PR TITLE
Skc: option to canonize paths in generated ll

### DIFF
--- a/skiplang/compiler/Skargo.toml
+++ b/skiplang/compiler/Skargo.toml
@@ -8,6 +8,8 @@ test-harness = "SkcTests.main"
 std = { path = "../prelude" }
 cli = { path = "../cli" }
 arparser = { path = "../arparser" }
+
+[dev-dependencies]
 sktest = { path = "../sktest" }
 
 [[bin]]

--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -1021,6 +1021,7 @@ fun writeOutputFiles(
   // arbitrarily pick some unique input file as the CU for this output file.
   metadata = AsmOutput.Metadata::create(
     defs,
+    config.cwd,
     if (!inputFiles.isEmpty()) {
       inputFiles[0]
     } else {
@@ -1645,6 +1646,8 @@ mutable class Metadata{
   // List of LLVM metadata
   metadata: mutable Vector<String> = mutable Vector[],
 
+  cwd: Config.WorkingDirectory,
+
   diFileCache: mutable UnorderedMap<Filename, DIFile> = mutable UnorderedMap[],
 
   // TODO: Right now we only support a single generic subroutine type.  Once we
@@ -1672,9 +1675,10 @@ mutable class Metadata{
 } {
   static fun create(
     defs: readonly AsmDefIDToAsmDef,
+    cwd: Config.WorkingDirectory,
     compilationUnit: String,
   ): mutable Metadata {
-    metadata = mutable Metadata{defs};
+    metadata = mutable Metadata{defs, cwd};
 
     // Reserve the slot for kEmptyBlockIndex since we may have already
     // handed it out.
@@ -1715,7 +1719,7 @@ mutable class Metadata{
           str.printf2(
             "!DIFile(filename: %r, directory: %r)",
             filename,
-            getcwd(),
+            this.cwd.toString(),
           );
           str.toString()
         }),

--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -1718,7 +1718,7 @@ mutable class Metadata{
           str = mutable TextOutputStream.StringTextOutputStream{};
           str.printf2(
             "!DIFile(filename: %r, directory: %r)",
-            filename,
+            this.cwd.makeRelative(filename),
             this.cwd.toString(),
           );
           str.toString()

--- a/skiplang/compiler/src/Config.sk
+++ b/skiplang/compiler/src/Config.sk
@@ -63,6 +63,7 @@ private class Config{
   static_libraries: Array<String>,
   link_args: Array<String>,
   preambles: Array<String>,
+  cwd: WorkingDirectory,
 } {
   static fun make(results: Cli.ParseResults): this {
     optConfig = Optimize.Config::make(
@@ -213,6 +214,7 @@ private class Config{
       skcPreamble.split(Path.listSeparator).toArray()
     | _ -> Array[]
     };
+    cwd = WorkingDirectory::create();
     static{
       release,
       verbose,
@@ -248,11 +250,21 @@ private class Config{
       static_libraries,
       link_args,
       preambles,
+      cwd,
     }
   }
 
   fun isWasm(): Bool {
     this.target.startsWith("wasm32");
+  }
+}
+
+value class WorkingDirectory(private value: String) {
+  static fun create(): this {
+    static(getcwd())
+  }
+  fun toString(): String {
+    this.value
   }
 }
 

--- a/skiplang/compiler/src/Config.sk
+++ b/skiplang/compiler/src/Config.sk
@@ -214,7 +214,8 @@ private class Config{
       skcPreamble.split(Path.listSeparator).toArray()
     | _ -> Array[]
     };
-    cwd = WorkingDirectory::create();
+    canonize_paths = results.getBool("canonize-paths");
+    cwd = WorkingDirectory::create(canonize_paths);
     static{
       release,
       verbose,
@@ -259,16 +260,37 @@ private class Config{
   }
 }
 
-value class WorkingDirectory(private value: String) {
-  static fun create(): this {
-    static(getcwd())
+value class WorkingDirectory{
+  private abs_cwd: String,
+  private rel_cwd: ?String,
+} {
+  static fun create(anonymize: Bool): this {
+    abs_cwd = getcwd();
+    rel_cwd = if (anonymize) {
+      Some(
+        {
+          repo = abs_cwd;
+          while (!FileSystem.exists(Path.join(repo, ".git"))) {
+            if (Path.isRoot(repo)) {
+              break Path.currentDirectory
+            };
+            !repo = Path.parentname(repo);
+          } else {
+            Path.relativeTo{path => abs_cwd, base => repo}
+          }
+        },
+      )
+    } else {
+      None()
+    };
+    static{abs_cwd, rel_cwd}
   }
   fun toString(): String {
-    this.value
+    this.rel_cwd.default(this.abs_cwd)
   }
   /* Makes a path relative to this working directory. */
   fun makeRelative(path: String): String {
-    Path.relativeTo{path, base => this.value}
+    Path.relativeTo{path, base => this.abs_cwd}
   }
 }
 

--- a/skiplang/compiler/src/Config.sk
+++ b/skiplang/compiler/src/Config.sk
@@ -266,6 +266,10 @@ value class WorkingDirectory(private value: String) {
   fun toString(): String {
     this.value
   }
+  /* Makes a path relative to this working directory. */
+  fun makeRelative(path: String): String {
+    Path.relativeTo{path, base => this.value}
+  }
 }
 
 module end;

--- a/skiplang/compiler/src/Config.sk
+++ b/skiplang/compiler/src/Config.sk
@@ -63,6 +63,7 @@ private class Config{
   static_libraries: Array<String>,
   link_args: Array<String>,
   preambles: Array<String>,
+  canonize_paths: Bool,
   cwd: WorkingDirectory,
 } {
   static fun make(results: Cli.ParseResults): this {
@@ -252,6 +253,7 @@ private class Config{
       link_args,
       preambles,
       cwd,
+      canonize_paths,
     }
   }
 

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -358,11 +358,20 @@ fun compile(
     Array[TickConfigFile((context.tick.value, config))],
   );
 
+  make_input_source_path = (pkg_base_dir, src_path) ~> {
+    res = Path.join(pkg_base_dir, src_path);
+    if (config.canonize_paths) {
+      !res = config.cwd.makeRelative(res);
+    };
+    res
+  };
+
   FileCache.writeFiles(
     context,
     fileNames,
     config.dependencies,
     config.lib_name,
+    make_input_source_path,
   );
 
   context.update()

--- a/skiplang/compiler/src/main.sk
+++ b/skiplang/compiler/src/main.sk
@@ -49,6 +49,7 @@ fun main(): void {
     // These are handled in skipUtils.sk
     // Just allow them to be ignored here
     .arg(Cli.Arg::bool("profile"))
+    .arg(Cli.Arg::bool("canonize-paths").negatable())
     .arg(Cli.Arg::string("data"))
     .arg(Cli.Arg::string("init"))
     .arg(Cli.Arg::bool("check").about("Run the front end only."))

--- a/skiplang/compiler/src/skipParse.sk
+++ b/skiplang/compiler/src/skipParse.sk
@@ -111,6 +111,7 @@ fun updatePackageFiles(
   name: ?String,
   pkg: InputPackageFiles,
   get_file_contents: String ~> String,
+  make_input_source_path: (String, String) ~> String,
 ): void {
   (modified_files, removed_files) = packageDir.unsafeMaybeGet(
     context,
@@ -122,14 +123,14 @@ fun updatePackageFiles(
   for ((pkg_base_dir, src_path) in modified_files) {
     fileDir.writeArray(
       context,
-      InputSource(name, Path.join(pkg_base_dir, src_path)),
+      InputSource(name, make_input_source_path(pkg_base_dir, src_path)),
       Array[SKStore.StringFile(get_file_contents(src_path))],
     )
   };
   for ((pkg_base_dir, src_path) in removed_files) {
     fileDir.writeArray(
       context,
-      InputSource(name, Path.join(pkg_base_dir, src_path)),
+      InputSource(name, make_input_source_path(pkg_base_dir, src_path)),
       Array[SKStore.StringFile("")],
     )
   };
@@ -141,6 +142,7 @@ fun writeFiles(
   file_names: Array<String>,
   dependencies: Map<String, (String, Sklib.Metadata)>,
   lib_name_opt: ?String,
+  make_input_source_path: (String, String) ~> String,
 ): void {
   // TODO: If `lib_name_opt` is `Some(_)`, ensure there is a
   // `Skargo.toml` in the cwd.
@@ -153,9 +155,15 @@ fun writeFiles(
         .map(fn -> (fn, FileSystem.getLastModificationTime(fn)))
         .collect(Array),
     );
-    updatePackageFiles(context, lib_name_opt, pkg, src ~> {
-      FileSystem.readTextFile(src)
-    })
+    updatePackageFiles(
+      context,
+      lib_name_opt,
+      pkg,
+      src ~> {
+        FileSystem.readTextFile(src)
+      },
+      make_input_source_path,
+    )
   };
 
   // For each (transitive) dependency, invalidate files that were
@@ -172,14 +180,26 @@ fun writeFiles(
       dep_meta.pkg_dir,
       dep_meta.sources.map(s -> (s.i0, s.i1)).collect(Array),
     );
-    updatePackageFiles(context, Some(dep_name), pkg, src ~> {
-      dep_meta.sources.find(f -> f.i0 == src).fromSome().i2
-    })
+    updatePackageFiles(
+      context,
+      Some(dep_name),
+      pkg,
+      src ~> {
+        dep_meta.sources.find(f -> f.i0 == src).fromSome().i2
+      },
+      make_input_source_path,
+    )
   };
 
   if (lib_name_opt is Some _) {
     // Invalidate non-package source files when building a package.
-    updatePackageFiles(context, None(), InputPackageFiles("", Array[]), _ ~> "")
+    updatePackageFiles(
+      context,
+      None(),
+      InputPackageFiles("", Array[]),
+      _ ~> "",
+      make_input_source_path,
+    )
   }
 }
 

--- a/skiplang/compiler/src/syntaxError.sk
+++ b/skiplang/compiler/src/syntaxError.sk
@@ -37,9 +37,4 @@ fun create(
   }
 }
 
-// TODO: Remove this ...
-fun errorsToString(errors: Array<SyntaxError>): String {
-  "Errors\n" + errors.map(error ~> error.toString()).join("\n") + "\n"
-}
-
 module end;


### PR DESCRIPTION
The checked in bootstrap `.ll.gz` files contain absolute paths that only make sense for the person building them.
Paths are found in `!DIFile` directives (both absolute CWD `directory` and absolute file path `filename`) and other positions (e.g. those found in messages for unreachableMethodCall calls).
This PR:
- makes `!DIFile`'s `filename` relative to the `directory`, _all the time_, from what I could find, this seems legit
- makes all file names relative to `CWD`, **if** `--canonize-paths` is given

Hence, to compile `skc` with canonized paths, use `skargo build --skcopt --canonize-paths`