### PR TITLE
CodeQL: disable C/C++ and Java/Kotlin

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,0 +1,9 @@
+disable-default-queries: true
+
+queries:
+  - exclude: 
+      language: cpp
+  - exclude: 
+      language: java
+  - exclude: 
+      language: kotlin


### PR DESCRIPTION
I enabled CodeQL for the repo, which can catch bugs on TypeScript and Python.
The default config automatically detects the languages on the repo but it complains it doesn't know how to compile our C/C++ and our Java stuff, so let's disable them for now.