### PR TITLE
Add optional "default" arg to `getUnique` methods

### DIFF
--- a/examples/hackernews/reactive_service/src/hackernews.service.ts
+++ b/examples/hackernews/reactive_service/src/hackernews.service.ts
@@ -67,9 +67,12 @@ class PostsMapper {
   ): Iterable<[[number, number], PostWithUpvoteIds]> {
     const post: Post = values.getUnique();
     const upvotes: number[] = this.upvotes.getArray(key);
-    const author = this.users.getUnique(post.author_id, {
-      ifNone: unknownUser,
-    });
+    let author;
+    try {
+      author = this.users.getUnique(post.author_id);
+    } catch {
+      author = unknownUser;
+    }
     return [[[-upvotes.length, key], { ...post, upvotes, author }]];
   }
 }
@@ -126,9 +129,12 @@ class PostsResource implements Resource<PostsResourceInputs> {
   instantiate(
     collections: PostsResourceInputs,
   ): EagerCollection<number, PostWithUpvoteCount> {
-    const session = collections.sessions.getUnique(this.session_id, {
-      ifNone: null,
-    });
+    let session;
+    try {
+      session = collections.sessions.getUnique(this.session_id);
+    } catch {
+      session = null;
+    }
     return collections.postsWithUpvotes
       .take(this.limit)
       .map(CleanupMapper, session);

--- a/skipruntime-ts/addon/src/tojs.cc
+++ b/skipruntime-ts/addon/src/tojs.cc
@@ -44,7 +44,6 @@ double SkipRuntime_initService(SKService service);
 CJSON SkipRuntime_closeService();
 
 CJArray SkipRuntime_Collection__getArray(char* collection, CJSON key);
-CJSON SkipRuntime_Collection__getUnique(char* collection, CJSON key);
 char* SkipRuntime_Collection__map(char* collection, SKMapper mapper);
 char* SkipRuntime_Collection__mapReduce(char* collection, SKMapper mapper,
                                         SKReducer reducer);
@@ -60,7 +59,6 @@ int64_t SkipRuntime_Collection__size(char* collection);
 CJSON SkipRuntime_NonEmptyIterator__next(SKNonEmptyIterator it);
 
 CJSON SkipRuntime_LazyCollection__getArray(char* handle, CJSON key);
-CJSON SkipRuntime_LazyCollection__getUnique(char* handle, CJSON key);
 
 double SkipRuntime_Runtime__createResource(char* identifier, char* resource,
                                            CJObject jsonParams);
@@ -613,40 +611,6 @@ void GetArrayOfEagerCollection(const FunctionCallbackInfo<Value>& args) {
   });
 }
 
-void GetUniqueOfEagerCollection(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  if (args.Length() != 2) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(
-        Exception::TypeError(FromUtf8(isolate, "Must have two parameters.")));
-    return;
-  }
-  if (!args[0]->IsString()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The first parameter must be a string.")));
-    return;
-  }
-  if (!args[1]->IsExternal()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The first parameter must be a pointer.")));
-    return;
-  }
-  NatTryCatch(isolate, [&args](Isolate* isolate) {
-    char* skCollection = ToSKString(isolate, args[0].As<String>());
-    void* skKey = args[1].As<External>()->Value();
-    void* skResult = SkipRuntime_Collection__getUnique(skCollection, skKey);
-    Local<Value> returnValue;
-    if (skResult != nullptr) {
-      returnValue = External::New(isolate, skResult);
-    } else {
-      returnValue = Null(isolate);
-    }
-    args.GetReturnValue().Set(returnValue);
-  });
-}
-
 void SizeOfEagerCollection(const v8::FunctionCallbackInfo<v8::Value>& args) {
   Isolate* isolate = args.GetIsolate();
   if (args.Length() != 1) {
@@ -949,34 +913,6 @@ void GetArrayOfLazyCollection(const FunctionCallbackInfo<Value>& args) {
   });
 }
 
-void GetUniqueOfLazyCollection(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  if (args.Length() != 2) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(
-        Exception::TypeError(FromUtf8(isolate, "Must have two parameters.")));
-    return;
-  }
-  if (!args[0]->IsString()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The first parameter must be a string.")));
-    return;
-  }
-  if (!args[1]->IsExternal()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The first parameter must be a pointer.")));
-    return;
-  }
-  NatTryCatch(isolate, [&args](Isolate* isolate) {
-    char* skCollection = ToSKString(isolate, args[0].As<String>());
-    void* skKey = args[1].As<External>()->Value();
-    void* skResult = SkipRuntime_LazyCollection__getUnique(skCollection, skKey);
-    args.GetReturnValue().Set(External::New(isolate, skResult));
-  });
-}
-
 void CreateResourceOfRuntime(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   if (!args[0]->IsString() || !args[1]->IsString() || !args[2]->IsExternal()) {
@@ -1199,8 +1135,6 @@ void GetToJSBinding(const FunctionCallbackInfo<Value>& args) {
   //
   AddFunction(isolate, binding, "SkipRuntime_Collection__getArray",
               GetArrayOfEagerCollection);
-  AddFunction(isolate, binding, "SkipRuntime_Collection__getUnique",
-              GetUniqueOfEagerCollection);
   AddFunction(isolate, binding, "SkipRuntime_Collection__map",
               MapOfEagerCollection);
   AddFunction(isolate, binding, "SkipRuntime_Collection__mapReduce",
@@ -1225,8 +1159,6 @@ void GetToJSBinding(const FunctionCallbackInfo<Value>& args) {
   //
   AddFunction(isolate, binding, "SkipRuntime_LazyCollection__getArray",
               GetArrayOfLazyCollection);
-  AddFunction(isolate, binding, "SkipRuntime_LazyCollection__getUnique",
-              GetUniqueOfLazyCollection);
   //
   AddFunction(isolate, binding, "SkipRuntime_Runtime__createResource",
               CreateResourceOfRuntime);

--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -85,14 +85,16 @@ export interface Reducer<V extends Json, A extends Json> {
 }
 
 /**
- * An iterable collection of dependency-safe values.
+ * A non-empty iterable sequence of dependency-safe values.
  */
 export interface Values<T> extends Iterable<T & DepSafe> {
   /**
    * Return the first value, if there is exactly one.
-   * @throws {@link SkipNonUniqueValueError} if this iterable contains either zero or multiple values.
+   * @param _default
+   * @param _default.ifMany - Default value to use instead of throwing if there are multiple values.
+   * @throws {@link SkipNonUniqueValueError} if this iterable contains multiple values.
    */
-  getUnique(): T & DepSafe;
+  getUnique(_default?: { ifMany?: T }): T & DepSafe;
 
   /**
    * Return all the values.
@@ -124,10 +126,13 @@ export interface LazyCollection<K extends Json, V extends Json>
    * For collections that do not use the generality of associating multiple values to a key, `getUnique` saves some boilerplate over `getArray`.
    *
    * @param key - The key to query.
+   * @param _default
+   * @param _default.ifNone - Default value for the case where **zero** values are associated to the given key
+   * @param _default.ifMany - Default value for the case where **multiple** values are associated to the given key
    * @returns The value associated to `key`.
-   * @throws {@link SkipNonUniqueValueError} if `key` is associated to either zero or multiple values.
+   * @throws {@link SkipNonUniqueValueError} if `key` is associated to either zero or multiple values and no suitable default is provided.
    */
-  getUnique(key: K): V & DepSafe;
+  getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): V & DepSafe;
 }
 
 /**
@@ -154,10 +159,13 @@ export interface EagerCollection<K extends Json, V extends Json>
    * For collections that do not use the generality of associating multiple values to a key, `getUnique` saves some boilerplate over `getArray`.
    *
    * @param key - The key to query.
+   * @param _default
+   * @param _default.ifNone - Default value for the case where **zero** values are associated to the given key
+   * @param _default.ifMany - Default value for the case where **multiple** values are associated to the given key
    * @returns The value associated to `key`.
-   * @throws {@link SkipNonUniqueValueError} if `key` is associated to either zero or multiple values.
+   * @throws {@link SkipNonUniqueValueError} if `key` is associated to either zero or multiple values and no suitable default is provided.
    */
-  getUnique(key: K): V & DepSafe;
+  getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): V & DepSafe;
 
   /**
    * Create a new eager collection by mapping a function over the values in this one.

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -118,11 +118,6 @@ export interface FromBinding {
     key: Pointer<Internal.CJSON>,
   ): Pointer<Internal.CJArray<Internal.CJSON>>;
 
-  SkipRuntime_Collection__getUnique(
-    collection: string,
-    key: Pointer<Internal.CJSON>,
-  ): Nullable<Pointer<Internal.CJSON>>;
-
   SkipRuntime_Collection__map(
     collection: string,
     mapper: Pointer<Internal.Mapper>,
@@ -168,11 +163,6 @@ export interface FromBinding {
     collection: string,
     key: Pointer<Internal.CJSON>,
   ): Pointer<Internal.CJArray<Internal.CJSON>>;
-
-  SkipRuntime_LazyCollection__getUnique(
-    collection: string,
-    key: Pointer<Internal.CJSON>,
-  ): Pointer<Internal.CJSON>;
 
   // Notifier
 

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -33,19 +33,14 @@ class DeparturesResource implements Resource<ResourceInputs> {
     cs: ResourceInputs,
     context: Context,
   ): EagerCollection<number, Departure> {
-    const get = (name: string, def: string) => {
-      try {
-        return cs.config.getUnique(name).join(",");
-      } catch (_e) {
-        return def;
-      }
-    };
+    const readConfig = (key: string, ifNone: string[]) =>
+      cs.config.getUnique(key, { ifNone }).join(",");
     const params = {
       page: 1,
-      year: get("year", "2016,2017"),
-      origin: get("origin", "MMR,SYR"),
-      asylum: get("asylum", "JOR,LBN"),
-      resettlement: get("resettlement", "NOR,USA"),
+      year: readConfig("year", ["2016", "2017"]),
+      origin: readConfig("origin", ["MMR", "SYR"]),
+      asylum: readConfig("asylum", ["JOR", "LBN"]),
+      resettlement: readConfig("resettlement", ["NOR", "USA"]),
     };
 
     return context.useExternalResource({

--- a/skipruntime-ts/native/src/Extern.sk
+++ b/skipruntime-ts/native/src/Extern.sk
@@ -380,13 +380,6 @@ fun getArrayOfCollection(
 ): SKJSON.CJArray {
   SKJSON.CJArray(collectionForName(collection).getArray(key))
 }
-@export("SkipRuntime_Collection__getUnique")
-fun getUniqueOfCollection(
-  collection: String,
-  key: SKJSON.CJSON,
-): ?SKJSON.CJSON {
-  collectionForName(collection).getUnique(key)
-}
 
 @export("SkipRuntime_Collection__map")
 fun mapOfCollection(collection: String, mapper: Mapper): String {
@@ -463,10 +456,6 @@ fun sizeOfCollection(collection: String): Int {
 @export("SkipRuntime_LazyCollection__getArray")
 fun getArrayOfLazyCollection(lazy: String, key: SKJSON.CJSON): SKJSON.CJArray {
   SKJSON.CJArray(lazyForName(lazy).getArray(key))
-}
-@export("SkipRuntime_LazyCollection__getUnique")
-fun getUniqueOfLazyCollection(lazy: String, key: SKJSON.CJSON): SKJSON.CJSON {
-  lazyForName(lazy).getUnique(key)
 }
 
 /************  Notifier ****************/

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -14,7 +14,7 @@ import type {
   ExternalService,
   ServiceInstance,
 } from "@skipruntime/core";
-import { SkipNonUniqueValueError } from "@skipruntime/core";
+
 import { Count, Sum } from "@skipruntime/helpers";
 
 import { it as mit, type AsyncFunc } from "mocha";
@@ -475,14 +475,9 @@ class MockExternalCheck implements Mapper<number, number, number, number[]> {
   constructor(private readonly external: EagerCollection<number, number>) {}
 
   mapEntry(key: number, values: Values<number>): Iterable<[number, number[]]> {
-    try {
-      const result = this.external.getUnique(key);
-      return [[key, [...values, result]]];
-    } catch (e) {
-      if (e instanceof SkipNonUniqueValueError)
-        return [[key, values.toArray()]];
-      throw e;
-    }
+    const result = this.external.getUnique(key, { ifNone: NaN });
+    if (Number.isNaN(result)) return [[key, values.toArray()]];
+    return [[key, [...values, result]]];
   }
 }
 

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -129,11 +129,6 @@ export interface FromWasm {
     key: ptr<Internal.CJSON>,
   ): ptr<Internal.CJArray<Internal.CJSON>>;
 
-  SkipRuntime_Collection__getUnique(
-    collection: ptr<Internal.String>,
-    key: ptr<Internal.CJSON>,
-  ): Nullable<ptr<Internal.CJSON>>;
-
   SkipRuntime_Collection__map(
     collection: ptr<Internal.String>,
     mapper: ptr<Internal.Mapper>,
@@ -182,11 +177,6 @@ export interface FromWasm {
     collection: ptr<Internal.String>,
     key: ptr<Internal.CJSON>,
   ): ptr<Internal.CJArray<Internal.CJSON>>;
-
-  SkipRuntime_LazyCollection__getUnique(
-    collection: ptr<Internal.String>,
-    key: ptr<Internal.CJSON>,
-  ): ptr<Internal.CJSON>;
 
   // Notifier
 
@@ -524,18 +514,6 @@ export class WasmFromBinding implements FromBinding {
     );
   }
 
-  SkipRuntime_Collection__getUnique(
-    collection: string,
-    key: Pointer<Internal.CJSON>,
-  ): Nullable<Pointer<Internal.CJSON>> {
-    return toNullablePointer(
-      this.fromWasm.SkipRuntime_Collection__getUnique(
-        this.utils.exportString(collection),
-        toPtr(key),
-      ),
-    );
-  }
-
   SkipRuntime_Collection__map(
     collection: string,
     mapper: Pointer<Internal.Mapper>,
@@ -644,16 +622,6 @@ export class WasmFromBinding implements FromBinding {
     key: Pointer<Internal.CJSON>,
   ): Pointer<Internal.CJArray<Internal.CJSON>> {
     return this.fromWasm.SkipRuntime_LazyCollection__getArray(
-      this.utils.exportString(collection),
-      toPtr(key),
-    );
-  }
-
-  SkipRuntime_LazyCollection__getUnique(
-    collection: string,
-    key: Pointer<Internal.CJSON>,
-  ): Pointer<Internal.CJSON> {
-    return this.fromWasm.SkipRuntime_LazyCollection__getUnique(
       this.utils.exportString(collection),
       toPtr(key),
     );


### PR DESCRIPTION
This allows to replace patterns like

```
let foo;
try {
  foo = bar.getUnique(key);
} catch {
  foo = defaultVal;
}
```

with the imo-much-nicer 

```
const foo = bar.getUnique(key, { ifNone: defaultVal });
```

`getUnique` on collections (which can have 0, 1, or many values per key) has separate and optional  `ifNone` and `ifMany` defaults, while `getUnique` on `Values` (which can have 1 or many values) has only the `ifMany` optional default.