### PR TITLE
[skip-adapter/postgres] Add option to only receive new rows in postgres adapter

### DIFF
--- a/skipruntime-ts/adapters/postgres/src/index.ts
+++ b/skipruntime-ts/adapters/postgres/src/index.ts
@@ -25,6 +25,7 @@ pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, (x: string) => x);
  *
  * @remarks
  * Subscription `params` **must** include a field `key` whose value is an object with a string field `col` identifying the table column that should be used as the key in the resulting collection, and a field `type` whose value is a Postgres text, integer, or serial type. (i.e. one of `TEXT`, `SERIAL`, `SERIAL2`, `SERIAL4`, `SERIAL8`, `BIGSERIAL`, `SMALLSERIAL`, `INTEGER`, `INT`, `INT2`, `INT4`, `INT8`, `BIGINT`, or `SMALLINT`)
+ * Subscription `params` **may** also specify `ignoreOldData: true` to receive only _new_ rows as they are created, for use with append-only tables whose history is not needed.
  */
 export class PostgresExternalService implements ExternalService {
   private client: pg.Client;
@@ -77,7 +78,9 @@ export class PostgresExternalService implements ExternalService {
    *
    * @param instance - Instance identifier of the external resource.
    * @param resource - Name of the PostgreSQL table to expose as a resource.
-   * @param params - Parameters of the external resource; **must** include a field `key` whose value is an object with a string field `col` identifying the table column that should be used as the key in the resulting collection, and a field `type` whose value is a Postgres text, integer, or serial type. (i.e. one of `TEXT`, `SERIAL`, `SERIAL2`, `SERIAL4`, `SERIAL8`, `BIGSERIAL`, `SMALLSERIAL`, `INTEGER`, `INT`, `INT2`, `INT4`, `INT8`, `BIGINT`, or `SMALLINT`)
+   * @param params - Parameters of the external resource; **must** include a field `key` describing the Postgres column that should be used as the key in the resulting collection
+   * @param params.key - (Required) Object with a field `col` identifying the table column to be used as the key, and a field `type` whose value is a Postgres text, integer, or serial type. (i.e. one of `TEXT`, `SERIAL`, `SERIAL2`, `SERIAL4`, `SERIAL8`, `BIGSERIAL`, `SMALLSERIAL`, `INTEGER`, `INT`, `INT2`, `INT4`, `INT8`, `BIGINT`, or `SMALLINT`)
+   * @param params.ignoreOldData - (Optional) Boolean flag: if true, Skip will ignore pre-existing data and only synchronize updates after subscription
    * @param callbacks - Callbacks to react on error/loading/update.
    * @param callbacks.error - Error callback.
    * @param callbacks.loading - Loading callback.
@@ -92,6 +95,7 @@ export class PostgresExternalService implements ExternalService {
         col: string;
         type: PostgresPKey;
       };
+      ignoreOldData?: boolean;
     },
     callbacks: {
       update: (updates: Entry<Json, Json>[], isInit: boolean) => void;
@@ -108,15 +112,21 @@ export class PostgresExternalService implements ExternalService {
     };
 
     const initData = async () => {
-      callbacks.loading();
-      const init = await this.client.query(format("SELECT * FROM %I;", table));
-      const entries: Map<Json, Json[]> = new Map<Json, Json[]>();
-      for (const row of init.rows as { [col: string]: Json }[]) {
-        const k = row[key.col]!;
-        if (entries.has(k)) entries.get(k)!.push(row);
-        else entries.set(k, [row]);
+      if (params.ignoreOldData) {
+        callbacks.update([], true);
+      } else {
+        callbacks.loading();
+        const init = await this.client.query(
+          format("SELECT * FROM %I;", table),
+        );
+        const entries: Map<Json, Json[]> = new Map<Json, Json[]>();
+        for (const row of init.rows as { [col: string]: Json }[]) {
+          const k = row[key.col]!;
+          if (entries.has(k)) entries.get(k)!.push(row);
+          else entries.set(k, [row]);
+        }
+        callbacks.update(Array.from(entries), true);
       }
-      callbacks.update(Array.from(entries), true);
     };
 
     const setupPgNotify = async () => {

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -1382,9 +1382,7 @@ export function initTests(
       if ("CIRCLECI" in process.env) {
         throw new Error("Failed to set up CircleCI environment with Kafka.");
       }
-      console.warn(
-        "Default pass on testKafka since no local Kafka cluster found;",
-      );
+      console.warn("Skipping testKafka since no local Kafka cluster found;");
       console.warn("To test properly, run the following then retry:");
       console.warn("\tdocker pull apache/kafka:latest");
       console.warn(

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -653,7 +653,10 @@ class StreamingPostgresResource implements Resource<Input_NN> {
       .useExternalResource<number, PostgresRow>({
         service: "postgres",
         identifier: "skip_test",
-        params: { key: { col: "id", type: "INTEGER" }, syncHistoricData: false },
+        params: {
+          key: { col: "id", type: "INTEGER" },
+          syncHistoricData: false,
+        },
       })
       .map(PostgresRowExtract);
   }


### PR DESCRIPTION
As discussed, this could be useful for append-only tables where a full view of the history is not needed.

Some small unit testing refactors as well.

I don't love the `ignoreOldData` option name, but it was the best I could come up with... open to other suggestions