### PR TITLE
[skargo] Fix fingerprinting.

### DIFF
--- a/skiplang/skargo/src/build_context.sk
+++ b/skiplang/skargo/src/build_context.sk
@@ -263,6 +263,7 @@ private fun compute_deps(
       unit with {
         arch => TargetArchHost(),
         mode => CompileModeBuild(),
+        profile => "dev",
         build_opts => unit.build_opts with {relocation_model => "static"},
       },
     ]

--- a/skiplang/skargo/src/build_context.sk
+++ b/skiplang/skargo/src/build_context.sk
@@ -166,6 +166,7 @@ private fun generate_root_units(
         package,
         target,
         build_config.requested_arch,
+        build_config.requested_profile,
         CompileModeBuild(),
         UnitBuildOptions{
           relocation_model => if (
@@ -281,6 +282,7 @@ private fun compute_deps(
         unit.pkg,
         unit.pkg.manifest.lib_target().fromSome(),
         unit.arch,
+        unit.profile,
         CompileModeBuild(),
         unit.build_opts,
       ),
@@ -293,6 +295,7 @@ private fun compute_deps(
           unit.pkg,
           target,
           unit.arch,
+          unit.profile,
           CompileModeRunBuildScript(),
           unit.build_opts,
         ),
@@ -319,6 +322,7 @@ private fun compute_deps(
         dep_package,
         dep_package.manifest.lib_target().fromSome(),
         unit.arch,
+        unit.profile,
         CompileModeBuild(),
         unit.build_opts,
       ),

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -573,21 +573,17 @@ private fun hash_of(
       dep_hashes.push(hash_of(dep, bctx, out))
     };
 
-    out.set(unit, compute_hash(unit, dep_hashes.collect(Array), bctx))
+    out.set(unit, compute_hash(unit, dep_hashes.collect(Array)))
   };
 
   out[unit]
 }
 
-private fun compute_hash(
-  unit: Unit,
-  dep_hashes: Array<Int>,
-  bctx: BuildContext,
-): Int {
+private fun compute_hash(unit: Unit, dep_hashes: Array<Int>): Int {
   (
     unit.pkg.manifest.package_id,
     dep_hashes,
-    bctx.build_config.requested_profile,
+    unit.profile,
     unit.arch,
     unit.mode,
     unit.target.name,

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -240,16 +240,15 @@ mutable class BuildRunner(
   }
 
   private mutable fun run_build_script(unit: Unit): BuildScriptOutput {
+    assert(unit.target.kind is CustomBuildTarget _);
+    assert(unit.mode is CompileModeRunBuildScript _);
+    build_script_unit = this.bctx.unit_graph[unit].find(u ->
+      u.mode is CompileModeBuild _ && u.target.is_build_script()
+    ).fromSome();
     cmd = ProcessBuilder::create{
       cmd => Path.join(
-        this.build_dir_for(
-          unit with {
-            arch => TargetArchHost(),
-            mode => CompileModeBuild(),
-            build_opts => unit.build_opts with {relocation_model => "static"},
-          },
-        ),
-        unit.target.name,
+        this.build_dir_for(build_script_unit),
+        build_script_unit.target.name,
       ),
     };
 

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -133,7 +133,6 @@ mutable class BuildRunner(
           )
           .collect(Array),
         this.bctx.unit_graph[unit].map(dep -> this.fingerprint_for(dep)),
-        this.bctx.build_config,
         if (
           unit.target.is_build_script() &&
           unit.mode is CompileModeRunBuildScript _

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -63,11 +63,7 @@ mutable class BuildRunner(
   build_script_outputs: mutable Map<Unit, BuildScriptOutput> = mutable Map[],
 ) {
   static fun create(bctx: BuildContext): mutable BuildRunner {
-    host_layout = Layout::create(
-      bctx,
-      "host",
-      bctx.build_config.requested_profile,
-    );
+    host_layout = Layout::create(bctx, "host", "dev");
     target_layout = bctx.build_config.requested_arch match {
     | TargetArchHost() -> host_layout
     | TargetArchTriple(t) ->

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -450,16 +450,9 @@ mutable class BuildRunner(
   }
 
   private readonly fun build_script_unit_for(unit: Unit): ?Unit {
-    for (dep in this.bctx.unit_graph[unit]) {
-      if (
-        dep.target.is_build_script() &&
-        dep.mode is CompileModeRunBuildScript _
-      ) {
-        return Some(dep)
-      }
-    };
-
-    None()
+    this.bctx.unit_graph[unit].find(u ->
+      u.target.is_build_script() && u.mode is CompileModeRunBuildScript _
+    )
   }
 
   private readonly fun outputs_for(unit: Unit): Array<OutputFile> {

--- a/skiplang/skargo/src/compile_options.sk
+++ b/skiplang/skargo/src/compile_options.sk
@@ -6,7 +6,6 @@ const kAvailableProfiles: Array<(String, String)> = Array[
   ("release", "Release profile: with optimizations"),
 ];
 
-// TODO: Rename CompileKind to TargetArch.
 class BuildConfig{
   // TODO: Support multiple requested arches (array `--target` flag).
   requested_arch: TargetArch,

--- a/skiplang/skargo/src/unit.sk
+++ b/skiplang/skargo/src/unit.sk
@@ -4,6 +4,7 @@ class Unit(
   pkg: Package,
   target: Target,
   arch: TargetArch,
+  profile: String,
   mode: CompileMode,
   build_opts: UnitBuildOptions,
 ) uses Equality, Hashable


### PR DESCRIPTION
This PR fixes an invalidation issue that causes build script
units (along with their dependencies) to be invalidated each time the
requested target triple changes.