### PR TITLE
[skargo] Fix output directory for non-dev host builds.

### DIFF
--- a/skiplang/skargo/src/build_context.sk
+++ b/skiplang/skargo/src/build_context.sk
@@ -101,14 +101,20 @@ fun create_bctx(
 ): BuildContext {
   resolved_packages = resolve(ws.package);
 
-  roots = generate_root_units(gctx, ws.package, opts.filter, opts.build_config);
   target_data = SkcTargetData::create(
     gctx,
     opts.build_config.requested_arch match {
-    | TargetArchHost _ -> Array[]
-    | TargetArchTriple(triple) -> Array[triple]
+    | Some(triple) -> Array[triple]
+    | None() -> Array[]
     },
     opts.build_config.skc_extra_options,
+  );
+  roots = generate_root_units(
+    gctx,
+    ws.package,
+    opts.filter,
+    opts.build_config,
+    target_data.target_triple_for_arch(TargetArchHost()),
   );
   unit_graph = build_unit_dependencies(roots, resolved_packages);
   target_dir = ws.target_dir();
@@ -128,6 +134,7 @@ private fun generate_root_units(
   package: Package,
   filter: CompileFilter,
   build_config: BuildConfig,
+  host_target_triple: TargetTriple,
 ): Array<Unit> {
   res = mutable Vector[];
 
@@ -165,7 +172,9 @@ private fun generate_root_units(
       Unit(
         package,
         target,
-        build_config.requested_arch,
+        TargetArchTriple(
+          build_config.requested_arch.default(host_target_triple),
+        ),
         build_config.requested_profile,
         CompileModeBuild(),
         UnitBuildOptions{

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -64,11 +64,19 @@ mutable class BuildRunner(
 ) {
   static fun create(bctx: BuildContext): mutable BuildRunner {
     host_layout = Layout::create(bctx, "host", "dev");
-    target_layout = bctx.build_config.requested_arch match {
-    | TargetArchHost() -> host_layout
-    | TargetArchTriple(t) ->
-      Layout::create(bctx, t.toString(), bctx.build_config.requested_profile)
+    target_layout_dest = bctx.build_config.requested_arch match {
+    | None() -> "host"
+    | Some(
+      t,
+    ) if (t == bctx.target_data.target_triple_for_arch(TargetArchHost())) ->
+      "host"
+    | Some(t) -> t.toString()
     };
+    target_layout = Layout::create(
+      bctx,
+      target_layout_dest,
+      bctx.build_config.requested_profile,
+    );
     fingerprint_dir = Path.join(bctx.target_dir, ".fingerprints");
 
     hashes = mutable Map[];
@@ -211,12 +219,8 @@ mutable class BuildRunner(
       } else {
         // NOTE: While the unit is fresh, `skargo` may have been invoked with a
         // custom `--out-dir`, where we should still copy final artifacts.
-        for (output in this.outputs_for(unit)) {
-          output.export_path match {
-          | Some(dst) -> this.link_or_copy(output.path, dst)
-          | None _ -> void
-          }
-        };
+        this.prepare_unit(unit);
+        this.link_targets(unit);
         this.bctx.gctx.console.status("Fresh", unit_name)
       }
     }

--- a/skiplang/skargo/src/compile_options.sk
+++ b/skiplang/skargo/src/compile_options.sk
@@ -8,7 +8,7 @@ const kAvailableProfiles: Array<(String, String)> = Array[
 
 class BuildConfig{
   // TODO: Support multiple requested arches (array `--target` flag).
-  requested_arch: TargetArch,
+  requested_arch: ?TargetTriple,
   requested_profile: String,
   export_dir: ?String,
   skc_extra_options: Array<String>,
@@ -27,10 +27,7 @@ fun build_config{
   skc_extra_options: Array<String>,
 }: BuildConfig {
   BuildConfig{
-    requested_arch => target_opt match {
-    | Some(t) -> TargetArchTriple(TargetTriple::fromString(t))
-    | None() -> TargetArchHost()
-    },
+    requested_arch => target_opt.map(t -> TargetTriple::fromString(t)),
     requested_profile => (release, profile_opt) match {
     | (false, None()) -> kDefaultProfile
     | (true, None())


### PR DESCRIPTION
TL;DR: Fix bug causing `skargo build -r` to generate artifacts in `target/host/dev` instead of `target/host/release`.

Previously, dev dependencies were always built with the same profile as the build targets. Since #a25c0e1, dev dependencies are always built with the dev profile. This causes issues when building a release build for the host platform because all build units end up using *the* host layout, which causes all artifacts to end up in `target/host/dev/`.

This commit fixes the issue by properly generating build targets with an explicit target triple even when building for the host platform.