### PR TITLE
Add blog post about external services / adapters

### DIFF
--- a/www/blog/adapters.md
+++ b/www/blog/adapters.md
@@ -36,18 +36,25 @@ const service = {
 }
 ```
 
-Then, anywhere in that service, you can pull in a database table as a Skip collection by specifying a table name and a column to use as the key of the collection, e.g. as follows for a table with schema `CREATE TABLE t (id SERIAL PRIMARY KEY, value TEXT)`.
+Then, anywhere in that service, you can pull in a database table as a Skip collection by specifying a table name and a column to use as the key of the collection.
+For example, given a PostgreSQL table `my_table` with schema
+
+```sql
+CREATE TABLE my_table (id SERIAL PRIMARY KEY, value TEXT);
+```
+
+we can use it as a collection `myTable` in a Skip reactive service as follows.
 
 ```typescript
-const t: EagerCollection<number, { id: number, value: string }> =
+const myTable: EagerCollection<number, { id: number, value: string }> =
   context.useExternalResource({
     service: "postgres",
-    identifier: "t",
+    identifier: "my_table",
     params: { key: { col: "id", type: "SERIAL" } },
   });
 ```
 
-Under the hood, Skip will maintain this collection up-to-date by watching the database for changes to `t`; within your Skip service, you can define arbitrary reactive computations mapping over and accessing `t`, which will update incrementally the same as any other Skip collection.
+Under the hood, Skip will maintain this collection up-to-date by watching the database for changes to `my_table`; the collection `myTable` will update incrementally the same as any other Skip collection and can be used in reactive computations combining multiple tables or any other Skip collection.
 
 Note that, although the `key` column specified here is the primary key column `id` of the table, it need not be a primary key or even unique -- it can be convenient to use a foreign key or other column to group multiple rows per key in the resulting Skip collection.
 
@@ -116,7 +123,7 @@ This [`PolledExternalService`](https://skiplabs.io/docs/api/helpers/classes/Poll
 
 Of course, polling necessarily introduces some latency in the reactive service: data can become stale between polls.
 On the other hand, increasing the request frequency can place undue load on the target non-reactive API.
-As such, care should be taken when setting up a polled dependency to choose a reasonable interval, and where possible polling should be avoided in favor of proper reactive updates.
+As such, care should be taken when setting up a polled dependency to choose a reasonable interval, and where possible polling should be avoided in favor of genuinely reactive updates.
 
 
 ## What's next?

--- a/www/blog/adapters.md
+++ b/www/blog/adapters.md
@@ -1,0 +1,129 @@
+---
+title: Skip services with non-reactive dependencies
+description: External integrations for the Skip framework
+slug: non-reactive-dependencies
+date: 2025-04-04
+authors: benno
+---
+
+The Skip framework is a tool for designing and building incremental backend services, simplifying the challenges of engineering complex reactive systems.
+
+While Skip reactive services compose naturally with *each other*, they must also coexist with other backend systems with non-reactive semantics and APIs.
+
+This blog post describes some recent improvements we've made to the Skip framework to make it easy to navigater the reactive/non-reactive interface for common backend systems like PostgreSQL and Kafka, and shows how you can make similar integrations with other systems and APIs.
+
+<!--truncate-->
+
+## Postgres
+
+PostgreSQL is one of the most popular relational databases in use today, serving as a highly scalable and resilient source-of-truth for critical application data.
+
+It can be tricky to maintain an up-to-date view of application state over a relational data model, though, as different data sources add and modify values in an interconnected relational data model: you can either re-query and re-build the world periodically, or build some ad-hoc logic to propagate deltas.
+
+Using Skip's [Postgres adapter](https://skiplabs.io/docs/api/adapters/postgres/classes/PostgresExternalService), you can instead define some computation over your Postgres state and have the Skip framework watch for changes in the relevant tables and recompute only the minimal affected outputs.
+
+First, when defining your Skip service, specify one (or more) databases in the `externalServices` field:
+
+```typescript
+const service = {
+  initialData: ...,
+  resources: ...,
+  createGraph: ...,
+  externalServices: {
+    postgres: new PostgresExternalService({ host, port, database, ... }),
+    ...,
+  },
+}
+```
+
+Then, anywhere in that service, you can pull in a database table as a Skip collection by specifying a table name and a column to use as the key of the collection, e.g. as follows for a table with schema `CREATE TABLE t (id SERIAL PRIMARY KEY, value TEXT)`.
+
+```typescript
+const t: EagerCollection<number, { id: number, value: string }> =
+  context.useExternalResource({
+    service: "postgres",
+    identifier: "t",
+    params: { key: { col: "id", type: "SERIAL" } },
+  });
+```
+
+Under the hood, Skip will maintain this collection up-to-date by watching the database for changes to `t`; within your Skip service, you can define arbitrary reactive computations mapping over and accessing `t`, which will update incrementally the same as any other Skip collection.
+
+Note that, although the `key` column specified here is the primary key column `id` of the table, it need not be a primary key or even unique -- it can be convenient to use a foreign key or other column to group multiple rows per key in the resulting Skip collection.
+
+A more-involved example of a reactive service with computations over several Postgres tables is available [here](https://github.com/SkipLabs/skip/tree/main/examples/hackernews).
+
+## Kafka
+
+Apache [Kafka](https://kafka.apache.org) is another backend component with widespread adoption for high-throughput messaging and event streaming, often used to power real-time features.
+
+Integrating a Kafka cluster with a Skip service is a natural way to build reactive logic on top of streaming data; as such, we provide an ExternalService [adapter](https://skiplabs.io/docs/api/adapters/kafka/classes/KafkaExternalService) which handles the plumbing for you and abstracts Kafka message streams as Skip collections.
+
+First, specify connection information and configuration in the `externalServices` field of your service:
+
+```typescript
+const service = {
+  initialData: ...,
+  resources: ...,
+  createGraph: ...,
+  externalServices: {
+    kafka: new KafkaExternalService({ clientId, brokers, ... }),
+    ...,
+  },
+}
+```
+
+then, consume messages into a reactive collection with a `usExternalResource` call, e.g.
+
+```typescript
+const myKafkaTopic: EagerCollection<string, string> =
+  context.useExternalResource({
+    service: "kafka",
+    identifier: "my-kafka-topic",
+    params: {},
+  });
+```
+
+By default, messages are interpreted as their string key and value, but a "`messageProcessor`" can be provided to parse message payloads into other types, manipulate key structure, or pull in "topic" identifiers or other message metadata.
+
+
+## Other external APIs
+
+Of course, modern backends include a diverse array of different technologies and systems and you may need to integrate those with Skip.
+The simplest option for many non-reactive APIs is to periodically poll an HTTP endpoint; we provide a simple interface to specify a polled dependency on a non-reactive API:
+
+```typescript
+const service = {
+  initialData: ...
+  resources: ...
+  createGraph: ...
+  externalServices: {
+    myExternalService: new PolledExternalService({
+      my_resource: {
+        // HTTP endpoint
+        url: "https://api.example.com/my_resource",
+        // Polling interval, in milliseconds
+        interval: 5000,
+        // data processing into `Entry<K, V>[]` key/values structure
+        conv: (data: Json) => Array.from(data, (v, k) => [k, [v]])
+      }
+    }),
+  },
+};
+```
+
+This [`PolledExternalService`](https://skiplabs.io/docs/api/helpers/classes/PolledExternalService) specifies a single endpoint polled every 5 seconds, but in general can include any number of endpoints with different polling intervals and converter/parser functions.
+
+Of course, polling necessarily introduces some latency in the reactive service: data can become stale between polls.
+On the other hand, increasing the request frequency can place undue load on the target non-reactive API.
+As such, care should be taken when setting up a polled dependency to choose a reasonable interval, and where possible polling should be avoided in favor of proper reactive updates.
+
+
+## What's next?
+
+These three adapters ([`PostgresExternalService`](https://skiplabs.io/docs/api/adapters/postgres/classes/PostgresExternalService), [`KafkaExternalService`](https://skiplabs.io/docs/api/adapters/kafka/classes/KafkaExternalService), and [`PolledExternalService`](https://skiplabs.io/docs/api/helpers/classes/PolledExternalService)) are provided to make it easy to integrate with common backend systems, but all three are built using only public APIs and can easily be extended or tweaked in user code.
+
+If your application would benefit from additional adapters for other components and technologies, you can implement an [`ExternalService`](https://skiplabs.io/docs/api/core/interfaces/ExternalService) to wrap non-reactive systems as inputs to your Skip service.
+
+We welcome and support open-source contributions and feature requests and are always happy to answer questions or help out on Discord.
+

--- a/www/blog/adapters.md
+++ b/www/blog/adapters.md
@@ -2,15 +2,15 @@
 title: Skip services with non-reactive dependencies
 description: External integrations for the Skip framework
 slug: non-reactive-dependencies
-date: 2025-04-04
+date: 2025-04-14
 authors: benno
 ---
 
-The Skip framework is a tool for designing and building incremental backend services, simplifying the challenges of engineering complex reactive systems.
+The Skip framework is a system for building and running incremental backend services, simplifying the challenges of engineering complex reactive systems.
 
 While Skip reactive services compose naturally with *each other*, they must also coexist with other backend systems with non-reactive semantics and APIs.
 
-This blog post describes some recent improvements we've made to the Skip framework to make it easy to navigater the reactive/non-reactive interface for common backend systems like PostgreSQL and Kafka, and shows how you can make similar integrations with other systems and APIs.
+This blog post describes some recent enhancements we've made to the Skip framework to make it easy to bridge the reactive/non-reactive interface for popular systems like PostgreSQL and Kafka, and shows how you can build similar integrations with other systems and APIs.
 
 <!--truncate-->
 
@@ -18,11 +18,12 @@ This blog post describes some recent improvements we've made to the Skip framewo
 
 PostgreSQL is one of the most popular relational databases in use today, serving as a highly scalable and resilient source-of-truth for critical application data.
 
-It can be tricky to maintain an up-to-date view of application state over a relational data model, though, as different data sources add and modify values in an interconnected relational data model: you can either re-query and re-build the world periodically, or build some ad-hoc logic to propagate deltas.
+For incremental computation, it can be tricky to maintain an up-to-date view of an application's state over a relational data model.
+Different data sources add and modify values in an interconnected relational data model: you can either re-query and re-build the world periodically, or build some ad-hoc logic to propagate deltas.
 
-Using Skip's [Postgres adapter](https://skiplabs.io/docs/api/adapters/postgres/classes/PostgresExternalService), you can instead define some computation over your Postgres state and have the Skip framework watch for changes in the relevant tables and recompute only the minimal affected outputs.
+Using Skip's [Postgres adapter](https://skiplabs.io/docs/api/adapters/postgres/classes/PostgresExternalService), developers can define some computation over their Postgres state and use the Skip framework to watch for changes in the relevant tables and recompute only the minimal affected outputs.
 
-First, when defining your Skip service, specify one (or more) databases in the `externalServices` field:
+To use the Postgres addapter, when defining your Skip service, specify one (or more) databases in the `externalServices` field:
 
 ```typescript
 const service = {
@@ -43,7 +44,7 @@ For example, given a PostgreSQL table `my_table` with schema
 CREATE TABLE my_table (id SERIAL PRIMARY KEY, value TEXT);
 ```
 
-we can use it as a collection `myTable` in a Skip reactive service as follows.
+we can use the table as a collection `myTable` in a Skip reactive service as follows.
 
 ```typescript
 const myTable: EagerCollection<number, { id: number, value: string }> =
@@ -56,7 +57,7 @@ const myTable: EagerCollection<number, { id: number, value: string }> =
 
 Under the hood, Skip will maintain this collection up-to-date by watching the database for changes to `my_table`; the collection `myTable` will update incrementally the same as any other Skip collection and can be used in reactive computations combining multiple tables or any other Skip collection.
 
-Note that, although the `key` column specified here is the primary key column `id` of the table, it need not be a primary key or even unique -- it can be convenient to use a foreign key or other column to group multiple rows per key in the resulting Skip collection.
+Although the `key` column specified here is the primary key column `id` of the table, it need not be a primary key or even unique -- it can be convenient to use a foreign key or other column to group multiple rows per key in the resulting Skip collection.
 
 A more-involved example of a reactive service with computations over several Postgres tables is available [here](https://github.com/SkipLabs/skip/tree/main/examples/hackernews).
 
@@ -64,7 +65,8 @@ A more-involved example of a reactive service with computations over several Pos
 
 Apache [Kafka](https://kafka.apache.org) is another backend component with widespread adoption for high-throughput messaging and event streaming, often used to power real-time features.
 
-Integrating a Kafka cluster with a Skip service is a natural way to build reactive logic on top of streaming data; as such, we provide an ExternalService [adapter](https://skiplabs.io/docs/api/adapters/kafka/classes/KafkaExternalService) which handles the plumbing for you and abstracts Kafka message streams as Skip collections.
+Integrating a Kafka cluster with a Skip service is a natural way to build reactive logic on top of streaming data.
+As such, we provide an ExternalService [adapter](https://skiplabs.io/docs/api/adapters/kafka/classes/KafkaExternalService) which handles the plumbing for you and abstracts Kafka message streams as Skip collections.
 
 First, specify connection information and configuration in the `externalServices` field of your service:
 
@@ -96,7 +98,7 @@ By default, messages are interpreted as their string key and value, but a "`mess
 
 ## Other external APIs
 
-Of course, modern backends include a diverse array of different technologies and systems and you may need to integrate those with Skip.
+Of course, there are many other technologies and systems and you may need to integrate those with Skip.
 The simplest option for many non-reactive APIs is to periodically poll an HTTP endpoint; we provide a simple interface to specify a polled dependency on a non-reactive API:
 
 ```typescript

--- a/www/blog/authors.yml
+++ b/www/blog/authors.yml
@@ -5,3 +5,8 @@ jverlaguet:
 
 skiplabsteam:
   name: SkipLabs Team
+
+benno:
+  name: Benno Stein
+  title: Senior Engineer
+  url: https://bennostein.org

--- a/www/docs/deploying.md
+++ b/www/docs/deploying.md
@@ -73,7 +73,7 @@ To handle that scenario, you can run your Skip service in a *leader-follower* to
     * one *leader* instance to maintain the shared computation graph and/or pull in data from external dependencies like databases or polled APIs, and
     * one or more *followers* which synchronize that shared data from the leader, among which resource instances are distributed in a round-robin fashion.
 
-Utilities are available to run a Skip service in [leader](api/server/functions/asLeader) or [follower](api/server/functions/asFollower) mode, making it easy to scale out from a single-machine deployment to a distributed one.
+Utilities are available to run a Skip service in [leader](api/helpers/functions/asLeader) or [follower](api/helpers/functions/asFollower) mode, making it easy to scale out from a single-machine deployment to a distributed one.
 
 An example of such a deployment can be seen in [this example](https://github.com/SkipLabs/skip/tree/main/examples/hackernews); `./compose.distributed.yml` and `./reverse-proxy/haproxy.distributed.cfg` show a configuration with equivalent client-visible behavior to `compose.yml` and `reverse-proxy/haproxy.cfg` but running with one leader and three followers instead of just one reactive service.
 

--- a/www/docs/externals.md
+++ b/www/docs/externals.md
@@ -147,9 +147,9 @@ const service = {
       my_resource: {
         // HTTP endpoint
         url: "https://api.example.com/my_resource",
-	    // Polling interval, in milliseconds
+        // Polling interval, in milliseconds
         interval: 5000,
-	    // data processing into `Entry<K, V>[]` key/values structure
+        // data processing into `Entry<K, V>[]` key/values structure
         conv: (data: Json) => Array.from(data, (v, k) => [k, [v]])
       }
     }),


### PR DESCRIPTION
Here's a quick blog post about non-reactive dependencies and our new Postgres/Kafka adapters.  Putting up as a PR for high-level and/or copy-edit feedback!