### PR TITLE
[skc] Introduce `#env()` macro.

### DIFF
--- a/skiplang/compiler/src/SkipParseTree.sk
+++ b/skiplang/compiler/src/SkipParseTree.sk
@@ -1649,6 +1649,58 @@ class LogMacroTree{
   }
 }
 
+class EnvMacroTree{
+  envKeyword: ParseTree.ParseTree,
+  openParen: ParseTree.ParseTree,
+  varName: ParseTree.ParseTree,
+  closeParen: ParseTree.ParseTree,
+} extends ParseTree.ParseTree {
+  fun getNamedFields(): List<(String, ParseTree.ParseTree)> {
+    List<(String, ParseTree.ParseTree)>[
+      ("envKeyword", this.envKeyword),
+      ("openParen", this.openParen),
+      ("varName", this.varName),
+      ("closeParen", this.closeParen),
+    ];
+  }
+
+  fun getKind(): String {
+    "EnvMacro";
+  }
+
+  fun getChildren(): mutable Iterator<ParseTree.ParseTree> {
+    yield this.envKeyword;
+    yield this.openParen;
+    yield this.varName;
+    yield this.closeParen;
+    yield break;
+  }
+
+  fun transform(
+    codemod: mutable CodeMod,
+  ): (ParseTree.ParseTree, Vector<Subst>) {
+    tx_envKeyword = codemod.transform(this.envKeyword);
+    tx_openParen = codemod.transform(this.openParen);
+    tx_varName = codemod.transform(this.varName);
+    tx_closeParen = codemod.transform(this.closeParen);
+    (
+      EnvMacroTree{
+        range => this.range,
+        envKeyword => tx_envKeyword.i0,
+        openParen => tx_openParen.i0,
+        varName => tx_varName.i0,
+        closeParen => tx_closeParen.i0,
+      },
+      Vector[
+        tx_envKeyword.i1,
+        tx_openParen.i1,
+        tx_varName.i1,
+        tx_closeParen.i1,
+      ].flatten(),
+    );
+  }
+}
+
 class ForEachKeyValueTree{
   key: ParseTree.ParseTree,
   fatArrow: ParseTree.ParseTree,

--- a/skiplang/compiler/src/SkipParser.sk
+++ b/skiplang/compiler/src/SkipParser.sk
@@ -4508,7 +4508,8 @@ mutable class SkipParser{
     | TokenKind.YIELD()
     | TokenKind.FOREACH_FIELD()
     | TokenKind.FOREACH_FUNCTION()
-    | TokenKind.LOG() ->
+    | TokenKind.LOG()
+    | TokenKind.ENV() ->
       true
     // async, untracked, mutable, static and class can start a declaration, so must disambiguate after functions
     // which have pattern branch lists as bodies
@@ -4551,6 +4552,7 @@ mutable class SkipParser{
     | TokenKind.FOREACH_FIELD() -> this.parseForEachFieldMacro()
     | TokenKind.FOREACH_FUNCTION() -> this.parseForEachFunctionMacro()
     | TokenKind.LOG() -> this.parseLogMacro()
+    | TokenKind.ENV() -> this.parseEnvMacro()
     | _ -> this.parseWithExpression()
     }
   }
@@ -4773,6 +4775,31 @@ mutable class SkipParser{
     ParseTree.LogMacroTree{range => this.createRange(start), keyword, params}
   }
 
+  // env:
+  //    #env  (  string-literal  )
+  mutable fun parseEnvMacro(): ParseTree {
+    start = this.mark();
+    envKeyword = this.eatTree(TokenKind.ENV());
+    openParen = this.eatTree(TokenKind.OPEN_PAREN());
+    varName = this.peek() match {
+    | TokenKind.STRING_LITERAL() -> this.eatTree(TokenKind.STRING_LITERAL())
+    | _ ->
+      this.errorResult(
+        errorInvalidEnvMacroArgument,
+        `Unexpected '${this.peekToken().value}'.`,
+      )
+    };
+    closeParen = this.eatTree(TokenKind.CLOSE_PAREN());
+
+    ParseTree.EnvMacroTree{
+      range => this.createRange(start),
+      envKeyword,
+      openParen,
+      varName,
+      closeParen,
+    }
+  }
+
   // for-each-loop-expression:
   //    forEach  (  for-each-value  in  expression  )  binding-expression  else-branch-opt
   mutable fun parseForEachLoopExpression(): ParseTree {
@@ -4945,7 +4972,8 @@ mutable class SkipParser{
     | ParseTree.YieldBreakExpressionTree _
     | ParseTree.ForEachFieldMacroTree _
     | ParseTree.ForEachFunctionMacroTree _
-    | ParseTree.LogMacroTree _ ->
+    | ParseTree.LogMacroTree _
+    | ParseTree.EnvMacroTree _ ->
       void
 
     | ParseTree.CallArrayExpressionTree{func, bang} ->
@@ -5261,5 +5289,6 @@ const errorTooManyForEachFieldArguments: Int = 192;
 const errorLambdaTypeExpected: Int = 193;
 const errorExpectedLogArguments: Int = 194;
 const errorTooManyLogArguments: Int = 195;
+const errorInvalidEnvMacroArgument: Int = 196;
 
 module end;

--- a/skiplang/compiler/src/TokenKind.sk
+++ b/skiplang/compiler/src/TokenKind.sk
@@ -90,6 +90,7 @@ base class SkipTokenKind extends TokenKind {
   | FOREACH_FIELD()
   | FOREACH_FUNCTION()
   | LOG()
+  | ENV()
 
   // 4.3.4.5 Operators and Punctuators
   | OPEN_PAREN()
@@ -191,6 +192,7 @@ base class SkipTokenKind extends TokenKind {
     | FOREACH_FIELD() -> "#forEachField"
     | FOREACH_FUNCTION() -> "#forEachFunction"
     | LOG() -> "#log"
+    | ENV() -> "#env"
 
     | OPEN_PAREN() -> "("
     | CLOSE_PAREN() -> ")"
@@ -282,7 +284,8 @@ extension base class TokenKind {
     | FINAL()
     | FOREACH_FIELD()
     | FOREACH_FUNCTION()
-    | LOG() ->
+    | LOG()
+    | ENV() ->
       true
     | _ -> false
     }
@@ -568,6 +571,7 @@ fun tokenKinds(): List<TokenKind> {
     FOREACH_FIELD(),
     FOREACH_FUNCTION(),
     LOG(),
+    ENV(),
 
     // 4.3.4.5 Operators and Punctuators
     OPEN_PAREN(),

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -243,7 +243,35 @@ fun getOrInitializeBackend(
       };
 
       if (conf.emit == "sklib") {
-        compile_sklib(conf);
+        accessed_env_vars = context.getGlobal(
+          FileCache.kEnvAccessGlobal,
+        ) match {
+        | None() -> SortedSet[]
+        | Some(envMapFile) ->
+          FileCache.EnvMapFile::type(envMapFile)
+            .value.maybeGet(conf.lib_name)
+            .default(SortedSet[])
+        };
+        env_dir = SKStore.EHandle(
+          SKStore.SID::keyType,
+          SKStore.StringFile::type,
+          SKStore.DirName::create(
+            `/packageEnv/${conf.lib_name.default("_default")}/`,
+          ),
+        );
+        env = SortedMap::createFromItems(
+          accessed_env_vars
+            .map(v ->
+              (
+                v,
+                SKStore.StringFile::type(
+                  env_dir.unsafeGetArray(context, SKStore.SID(v))[0],
+                ).value,
+              )
+            )
+            .collect(Array),
+        );
+        compile_sklib(conf, env);
         return void
       };
 
@@ -402,7 +430,10 @@ fun compile_binary(
   })
 }
 
-fun compile_sklib(conf: Config.Config): void {
+fun compile_sklib(
+  conf: Config.Config,
+  env_vars: SortedMap<String, String>,
+): void {
   runCompilerPhase("native/write_sklib", () -> {
     // NOTE: Static libraries (`.a` archives) provided as input files are
     // bundled into the `sklib`.
@@ -411,8 +442,7 @@ fun compile_sklib(conf: Config.Config): void {
       conf.target,
       getcwd(),
     );
-    // FIXME: Do not write available but not accessed env vars to sklib.
-    Environ.vars().each(kv -> sklib.add_env_var(kv.i0, kv.i1));
+    env_vars.each((k, v) -> sklib.add_env_var(k, v));
     conf.direct_dependencies.each(dep_name ->
       sklib.add_dependency(dep_name, conf.dependencies[dep_name].i1)
     );

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -411,7 +411,8 @@ fun compile_sklib(conf: Config.Config): void {
       conf.target,
       getcwd(),
     );
-
+    // FIXME: Do not write available but not accessed env vars to sklib.
+    Environ.vars().each(kv -> sklib.add_env_var(kv.i0, kv.i1));
     conf.direct_dependencies.each(dep_name ->
       sklib.add_dependency(dep_name, conf.dependencies[dep_name].i1)
     );

--- a/skiplang/compiler/src/convertTree.sk
+++ b/skiplang/compiler/src/convertTree.sk
@@ -14,7 +14,7 @@ class Converter{file: FileCache.InputSource} {
     this.file.toString() + tree.toDebugString();
   }
 
-  // Generic functions go here so tehy aren't in the let rec
+  // Generic functions go here so they aren't in the let rec
   fun convertOpt<T>(tree: ParseTree, converter: ParseTree -> T): ?T {
     tree match {
     | ParseTree.EmptyTree _ -> None()
@@ -29,7 +29,9 @@ class Converter{file: FileCache.InputSource} {
     tree match {
     | ParseTree.ParseTreeList{elements} -> elements.map(convertElement)
     | _ ->
-      invariant_violation("Expectd parse tree list: " + this.treeToString(tree))
+      invariant_violation(
+        "Expected parse tree list: " + this.treeToString(tree),
+      )
     }
   }
 

--- a/skiplang/compiler/src/convertTree.sk
+++ b/skiplang/compiler/src/convertTree.sk
@@ -707,6 +707,8 @@ class Converter{file: FileCache.InputSource} {
       this.convertForEachFunctionMacro(this.convertRange(range), params, body)
     | ParseTree.LogMacroTree{range, params} ->
       this.convertLogMacro(this.convertRange(range), params)
+    | ParseTree.EnvMacroTree{range, varName} ->
+      this.convertEnvMacro(this.convertRange(range), varName)
     | _ ->
       invariant_violation("Unexpected expression: " + this.treeToString(tree))
     }
@@ -876,6 +878,13 @@ class Converter{file: FileCache.InputSource} {
       this.convertExpression(args[0]),
       Array[],
       Positional(Array[(0, this.convertExpression(args[1])), (1, metadata)]),
+    )
+  }
+
+  fun convertEnvMacro(_range: FileRange, varName: ParseTree): SkipAst.Expr_ {
+    SkipAst.EnvMacro(
+      this.createName(varName, varName.getToken().stringLiteralValue()),
+      this.file.pkg_opt,
     )
   }
 

--- a/skiplang/compiler/src/keywords.sk
+++ b/skiplang/compiler/src/keywords.sk
@@ -65,6 +65,7 @@ fun maybeToKeyword(value: String): ?TokenKind.TokenKind {
   | "#forEachField" -> Some(TokenKind.FOREACH_FIELD())
   | "#forEachFunction" -> Some(TokenKind.FOREACH_FUNCTION())
   | "#log" -> Some(TokenKind.LOG())
+  | "#env" -> Some(TokenKind.ENV())
   | _ -> None()
   }
 }
@@ -109,5 +110,6 @@ const kw_final: String = "final";
 const kw_forEach_field: String = "#forEachField";
 const kw_forEach_function: String = "#forEachFunction";
 const kw_log: String = "#log";
+const kw_env: String = "#env";
 
 module end;

--- a/skiplang/compiler/src/printer.sk
+++ b/skiplang/compiler/src/printer.sk
@@ -1942,6 +1942,17 @@ fun printTree(ctx: Context, t: ParseTree): Doc {
   | ParseTree.LogMacroTree{keyword, params} ->
     Doc.Group(Doc.Concat[print(ctx, keyword), Doc.space, print(ctx, params)])
 
+  | ParseTree.EnvMacroTree{envKeyword, openParen, varName, closeParen} ->
+    Doc.Group(
+      Doc.Concat[
+        print(ctx, envKeyword),
+        Doc.space,
+        print(ctx, openParen),
+        print(ctx, varName),
+        print(ctx, closeParen),
+      ],
+    )
+
   | ParseTree.ErrorTree{value} -> Doc.Str(value)
 
   | ParseTree.ParseTreeList _ ->

--- a/skiplang/compiler/src/skipAst.sk
+++ b/skiplang/compiler/src/skipAst.sk
@@ -365,6 +365,7 @@ base class Expr_ {
     functionName: ?Name,
     body: Expr,
   )
+  | EnvMacro(Name, ?String)
   | MacroDot(Expr, Name)
   | MacroStaticDot(Expr, Name)
 }

--- a/skiplang/compiler/src/skipAstPp.sk
+++ b/skiplang/compiler/src/skipAstPp.sk
@@ -861,6 +861,10 @@ fun expr(o: mutable BufferedPrinter.Out, e: SkipAst.Expr): void {
     };
     o.out(") ");
     expr(o, body)
+  | SkipAst.EnvMacro(varName, _) ->
+    o.out("#env (");
+    o.out(literal_to_string(SkipAst.StringLiteral(varName.i1)));
+    o.out(")")
   }
 }
 

--- a/skiplang/compiler/src/skipAstUtils.sk
+++ b/skiplang/compiler/src/skipAstUtils.sk
@@ -341,6 +341,7 @@ fun expr_<Tenv: frozen, Tacc>(
   | Ast.ForEachFunctionMacro(annotation, function, functionName, body) ->
     (!acc, !body) = k(f, env, acc, body);
     (acc, Ast.ForEachFunctionMacro(annotation, function, functionName, body))
+  | x @ Ast.EnvMacro _ -> (acc, x)
   }
 }
 

--- a/skiplang/compiler/src/skipExpand.sk
+++ b/skiplang/compiler/src/skipExpand.sk
@@ -1245,7 +1245,7 @@ fun definition(
 }
 
 /* Classes marked 'native' get a native constructor
- * TODO move the native keyword to cosntructor/field list position
+ * TODO move the native keyword to constructor/field list position
  */
 fun setNativeConstructor(cd: A.Class_def): A.Class_def {
   (cd.native_, cd.params) match {

--- a/skiplang/compiler/src/skipExpand.sk
+++ b/skiplang/compiler/src/skipExpand.sk
@@ -1733,7 +1733,8 @@ fun malias_expr_(
   k = ex -> malias_expr(context, env, ex);
   e match {
   | A.Literal _
-  | A.Var _ ->
+  | A.Var _
+  | A.EnvMacro _ ->
     e
   | A.MacroVar _ ->
     report_macro_usage(env, pos);
@@ -2220,7 +2221,8 @@ fun ext_class_tparams_expr_(
   e match {
   | A.Literal _
   | A.Var _
-  | A.MacroVar _ ->
+  | A.MacroVar _
+  | A.EnvMacro _ ->
     e
   | A.Seq(e1, e2) -> A.Seq(k(e1), k(e2))
   | A.If(e1, e2, e3) -> A.If(k(e1), k(e2), k(e3))
@@ -3420,6 +3422,20 @@ fun expr_(
       functionName,
       expr(context, env, body),
     )
+  | A.EnvMacro(varName, pkg_opt) ->
+    pkg_env = SKStore.EHandle(
+      SKStore.SID::keyType,
+      SKStore.StringFile::type,
+      // FIXME: Ensure package names cannot start with an underscore to avoid clash with `_default`.
+      SKStore.DirName::create(`/packageEnv/${pkg_opt.default("_default")}/`),
+    );
+    name = varName.i1;
+    value = pkg_env.maybeGet(context, SKStore.SID(name)) match {
+    | None() ->
+      SkipError.error(varName.i0, `Environment variable ${name} is not set.`)
+    | Some(v) -> v.value
+    };
+    A.Literal(A.StringLiteral(value))
   }
 }
 

--- a/skiplang/compiler/src/skipExpand.sk
+++ b/skiplang/compiler/src/skipExpand.sk
@@ -3435,6 +3435,20 @@ fun expr_(
       SkipError.error(varName.i0, `Environment variable ${name} is not set.`)
     | Some(v) -> v.value
     };
+    // Record access to env variable.
+    cur_env_map = context.getGlobal(FileCache.kEnvAccessGlobal) match {
+    | None() -> SortedMap[]
+    | Some(envMapFile) -> FileCache.EnvMapFile::type(envMapFile).value
+    };
+    context.setGlobal(
+      FileCache.kEnvAccessGlobal,
+      FileCache.EnvMapFile(
+        cur_env_map.set(
+          pkg_opt,
+          cur_env_map.maybeGet(pkg_opt).default(SortedSet[]).set(name),
+        ),
+      ),
+    );
     A.Literal(A.StringLiteral(value))
   }
 }

--- a/skiplang/compiler/src/skipInherit.sk
+++ b/skiplang/compiler/src/skipInherit.sk
@@ -1400,6 +1400,7 @@ fun replace_inst_expr__(cd: A.Class_def, e_: A.Expr_): A.Expr_ {
   | A.Bind _
   | A.Seq _ ->
     invariant_violation("ICE bind/seq covered in replace_inst_expr_cps")
+  | A.EnvMacro _ -> invariant_violation("ICE #env covered in Expand phase")
   | A.Literal(_)
   | A.Var(_)
   | A.MacroVar(_) ->

--- a/skiplang/compiler/src/skipNaming.sk
+++ b/skiplang/compiler/src/skipNaming.sk
@@ -3816,7 +3816,9 @@ fun expr_(
   | A.Literal(l) -> N.Literal(l)
   | A.Var(n) -> N.Var(n)
   | A.MacroVar(n) -> expandExpressionMacro(env, n)
-  | A.Seq _ -> invariant_violation("assert false")
+  | A.Seq _
+  | A.EnvMacro _ ->
+    invariant_violation("assert false")
   | A.If(e1, e2, e3) ->
     N.If(
       expr(context, acc, env, e1),

--- a/skiplang/compiler/src/skipParse.sk
+++ b/skiplang/compiler/src/skipParse.sk
@@ -236,6 +236,12 @@ fun updatePackageEnv(
   };
 }
 
+const kEnvAccessGlobal: String = "ACCESSED_ENV_MAP";
+
+class EnvMapFile(
+  value: SortedMap<?String, SortedSet<String>>,
+) extends SKStore.File
+
 module end;
 
 module SkipParse;

--- a/skiplang/compiler/src/skipParse.sk
+++ b/skiplang/compiler/src/skipParse.sk
@@ -163,7 +163,8 @@ fun writeFiles(
         FileSystem.readTextFile(src)
       },
       make_input_source_path,
-    )
+    );
+    updatePackageEnv(context, lib_name_opt, Environ.vars().collect(Array));
   };
 
   // For each (transitive) dependency, invalidate files that were
@@ -188,7 +189,8 @@ fun writeFiles(
         dep_meta.sources.find(f -> f.i0 == src).fromSome().i2
       },
       make_input_source_path,
-    )
+    );
+    updatePackageEnv(context, Some(dep_name), dep_meta.env)
   };
 
   if (lib_name_opt is Some _) {
@@ -201,6 +203,37 @@ fun writeFiles(
       make_input_source_path,
     )
   }
+}
+
+fun updatePackageEnv(
+  context: mutable SKStore.Context,
+  pkg_opt: ?String,
+  env: Array<(String, String)>,
+): void {
+  envDirName = SKStore.DirName::create(
+    `/packageEnv/${pkg_opt.default("_default")}/`,
+  );
+  envDir = context.unsafeMaybeGetEagerDir(envDirName) match {
+  | Some _ ->
+    SKStore.EHandle(SKStore.SID::keyType, SKStore.StringFile::type, envDirName)
+  | None _ ->
+    context.mkdir(SKStore.SID::keyType, SKStore.StringFile::type, envDirName)
+  };
+  previousEnvKeys = SortedSet::createFromIterator(
+    envDir.items(context).map(kv -> SKStore.SID::keyType(kv.i0).value),
+  );
+  seenEnvKeys = SortedSet[];
+  for ((key, value) in env) {
+    envDir.writeArray(
+      context,
+      SKStore.SID(key),
+      Array[SKStore.StringFile(value)],
+    );
+    !seenEnvKeys = seenEnvKeys.set(key);
+  };
+  for (key in previousEnvKeys.difference(seenEnvKeys)) {
+    envDir.writeArray(context, SKStore.SID(key), Array[])
+  };
 }
 
 module end;

--- a/skiplang/compiler/src/sklib.sk
+++ b/skiplang/compiler/src/sklib.sk
@@ -10,6 +10,7 @@ class Metadata{
   hash: String,
   pkg_dir: String,
   sources: Array<(String, Int, String)>,
+  env: Array<(String, String)>,
   dependencies: Array<(String, String)>,
   links: Array<String>,
   preambles: Array<String>,
@@ -31,6 +32,13 @@ class Metadata{
               "contents" => JSON.String(contents),
             ]
           }),
+        ),
+      ),
+      "env" => JSON.Array(
+        Vector::createFromItems(
+          this.env.map(e ->
+            JSON.Array(Vector[JSON.String(e.i0), JSON.String(e.i1)])
+          ),
         ),
       ),
       "dependencies" => JSON.Array(
@@ -78,6 +86,19 @@ class Metadata{
           )
         })
         .collect(Array),
+      env => try {
+        json["env"]
+          .expectArray()
+          .value.map(a -> {
+            kv = a.expectArray().value;
+            (kv[0].expectString(), kv[1].expectString())
+          })
+          .collect(Array)
+      } catch {
+      // TODO: Get rid of this once bootstrap is updated.
+      | JSON.KeyNotFoundError("env") -> Array[]
+      | e -> throw e
+      },
       dependencies => json["dependencies"]
         .expectArray()
         .value.map(o -> {
@@ -124,6 +145,7 @@ mutable class .SklibBuilder(
   name: String,
   target: String,
   pkg_dir: String,
+  env: mutable Vector<(String, String)> = mutable Vector[],
   sources: mutable Vector<(String, Int, String)> = mutable Vector[],
   dependencies: mutable Vector<(String, String)> = mutable Vector[],
   links: mutable Vector<String> = mutable Vector[],
@@ -170,12 +192,17 @@ mutable class .SklibBuilder(
     )
   }
 
+  mutable fun add_env_var(key: String, value: String): void {
+    this.env.push((key, value))
+  }
+
   readonly fun hash(): Int {
     // TODO: Digest everything, including compiler version.
     (
       this.name,
       this.target,
       this.sources.sortedBy(s ~> s.i0).collect(Array),
+      this.env.sorted(),
       // FIXME: Bytes should implement Hashable. For now, we convert to String.
       this.files.sortedBy(f ~> Path.basename(f.i0)).map(f ->
         (f.i0, f.i1.toString())
@@ -200,6 +227,7 @@ mutable class .SklibBuilder(
         hash => this.hash().toString(),
         pkg_dir => this.pkg_dir,
         sources => this.sources.collect(Array),
+        env => this.env.collect(Array),
         dependencies => this.dependencies.collect(Array),
         links => this.links.collect(Array),
         preambles => this.preambles.collect(Array),


### PR DESCRIPTION
The `#env()` macro takes a single string literal as parameter, and
expands to the value of the corresponding environment variable at
compile time. It plays a somewhat similar role as the `-D` option of
gcc in that it allows injecting values into the program from the
command line.

This will make it easier to handle things such as embedding the git
commit hash of a given build into programs and displaying it with a
`--version` option.

Note: The environment is frozen when building an `sklib`, i.e. a call
to `#env("foo")` within a package `pkg` will always expand to the
value of the `foo` environment variable at the time of compilation of
`pkg`, even when `libpkg.sklib` is used as a dependency of an other
program/library.