### PR TITLE
[skargo] Rename `PCK_DIR` to `SKARGO_MANIFEST_DIR`.

### DIFF
--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -257,7 +257,7 @@ mutable class BuildRunner(
 
     cmd.cwd(unit.pkg.root());
 
-    cmd.env("PCK_DIR", unit.pkg.root());
+    cmd.env("SKARGO_MANIFEST_DIR", unit.pkg.root());
     cmd.env(
       "OUT_DIR",
       FileSystem.realpath(Path.join(this.build_dir_for(unit), "out")),


### PR DESCRIPTION
For consistency with variables set when invoking `skc`.