### PR TITLE
[skiplang] Embed version info in skc and skargo binaries.

### DIFF
--- a/skiplang/compiler/Makefile
+++ b/skiplang/compiler/Makefile
@@ -71,7 +71,7 @@ stage3/bin/skargo: stage2
 stageD/bin/skc:
 	mkdir -p $(@D)
 	OUT_DIR=$$(realpath stageD/lib) $(MAKE) -C ../prelude default
-	SKC_PREAMBLE=../prelude/preamble/preamble64.ll skc --link-args -lpthread --no-std --export-function-as main=skip_main -o stageD/bin/skc $(OLEVEL) stageD/lib/libskip_runtime64.a stageD/lib/libbacktrace.a $(shell find ../prelude/src ../arparser/src ../cli/src src -name '*.sk')
+	SKC_PREAMBLE=../prelude/preamble/preamble64.ll SKARGO_PKG_NAME=skc SKARGO_PKG_VERSION=stageD GIT_COMMIT_HASH=$(shell git rev-parse --short HEAD) skc --link-args -lpthread --no-std --export-function-as main=skip_main -o stageD/bin/skc $(OLEVEL) stageD/lib/libskip_runtime64.a stageD/lib/libbacktrace.a $(shell find ../prelude/src ../arparser/src ../cli/src src -name '*.sk')
 	mkdir -p stage$(STAGE)/target/host/$(SKARGO_PROFILE)/deps/ && mv stage$(STAGE)/bin/skc.ll stage$(STAGE)/target/host/$(SKARGO_PROFILE)/deps/skc-d.ll
 
 stageD/lib/libstd.sklib: stageD/bin/skc

--- a/skiplang/compiler/build.sk
+++ b/skiplang/compiler/build.sk
@@ -1,0 +1,11 @@
+fun main(): void {
+  git_hash = System.subprocess(
+    Array["git", "rev-parse", "--short", "HEAD"],
+  ) match {
+  | Success(p) -> p.stdout
+  | Failure(err) ->
+    print_string(`Error getting git commit hash: ${err}`);
+    skipExit(1)
+  };
+  print_string(`skargo:skc-env=GIT_COMMIT_HASH=${git_hash}`)
+}

--- a/skiplang/compiler/src/main.sk
+++ b/skiplang/compiler/src/main.sk
@@ -94,7 +94,10 @@ fun main(): void {
   };
 
   if (results.getBool("version")) {
-    print_string(getBuildVersion());
+    pkg_name = #env ("SKARGO_PKG_NAME");
+    pkg_version = #env ("SKARGO_PKG_VERSION");
+    git_commit = #env ("GIT_COMMIT_HASH");
+    print_string(`${pkg_name} ${pkg_version} (${git_commit})`);
     skipExit(0);
   };
 

--- a/skiplang/skargo/build.sk
+++ b/skiplang/skargo/build.sk
@@ -1,0 +1,11 @@
+fun main(): void {
+  git_hash = System.subprocess(
+    Array["git", "rev-parse", "--short", "HEAD"],
+  ) match {
+  | Success(p) -> p.stdout
+  | Failure(err) ->
+    print_string(`Error getting git commit hash: ${err}`);
+    skipExit(1)
+  };
+  print_string(`skargo:skc-env=GIT_COMMIT_HASH=${git_hash}`);
+}

--- a/skiplang/skargo/src/main.sk
+++ b/skiplang/skargo/src/main.sk
@@ -55,9 +55,11 @@ fun main(): void {
   !cmd = cmd.help();
   args = cmd.parseArgs();
   if (args.getBool("version")) {
-    // FIXME
-    // #env("SKARGO_PKG_VERSION")
-    print_string("skargo " + "FIXME");
+    pkg_name = #env ("SKARGO_PKG_NAME");
+    pkg_version = #env ("SKARGO_PKG_VERSION");
+    git_commit = #env ("GIT_COMMIT_HASH");
+    print_string(`${pkg_name} ${pkg_version} (${git_commit})`);
+    skipExit(0);
   } else {
     gctx = GlobalContext::create(args);
     args.maybeGetSubcommand() match {


### PR DESCRIPTION
Result:
```
$ skc --version
skc 0.1.0 (ffb0c05f0)
$ skargo --version
skargo 0.2.0 (ffb0c05f0)
```