### PR TITLE
[skipruntime/helpers] asLeader/asFollower utilities for distributed skip services

### DIFF
--- a/skipruntime-ts/helpers/src/index.ts
+++ b/skipruntime-ts/helpers/src/index.ts
@@ -9,6 +9,6 @@ export {
   PolledExternalService,
   type PolledHTTPResource,
 } from "./external.js";
-export { SkipExternalService } from "./remote.js";
+export { SkipExternalService, asLeader, asFollower } from "./remote.js";
 export { SkipServiceBroker, fetchJSON, type Entrypoint } from "./rest.js";
 export { Count, Max, Min, Sum } from "./utils.js";

--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@skipruntime/core": "0.0.13",
-    "@skipruntime/helpers": "0.0.13",
     "express": "^4.21.1"
   },
   "optionalDependencies": {

--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@skipruntime/core": "0.0.13",
+    "@skipruntime/helpers": "0.0.13",
     "express": "^4.21.1"
   },
   "optionalDependencies": {

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -203,6 +203,13 @@ class LeaderResource implements Resource {
   }
 }
 
+/**
+ * Run a `SkipService` as the *leader* in a leader-follower topology.
+ *
+ * Instead of running a `service` on one machine, it can be distributed across multiple in a leader-follower architecture, with one "leader" maintaining the shared computation graph and one or more "followers" across which client-requested resource instances are distributed.
+ *
+ * @returns The *leader* component to run `service` in such a configuration.
+ */
 export function asLeader(service: SkipService): SkipService {
   //TODO: add mechanism to split externals between leader/follower
   return {
@@ -211,6 +218,13 @@ export function asLeader(service: SkipService): SkipService {
   };
 }
 
+/**
+ * Run a `SkipService` as a *follower* in a leader-follower topology.
+ *
+ * Instead of running a `service` on one machine, it can be distributed across multiple in a leader-follower architecture, with one "leader" maintaining the shared computation graph and one or more "followers" across which client-requested resource instances are distributed.
+ *
+ * @returns The *follower* component to run `service` in such a configuration, given the leader's address and the names of the shared computation graph collections to be mirrored from it (typically the `ResourceInputs` of `service`).
+ */
 export function asFollower(
   service: SkipService,
   leader: {

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -4,16 +4,7 @@
  * @packageDocumentation
  */
 
-import type {
-  Context,
-  EagerCollection,
-  Json,
-  NamedCollections,
-  Resource,
-  SkipService,
-} from "@skipruntime/core";
-import { SkipError } from "@skipruntime/core";
-import { SkipExternalService } from "@skipruntime/helpers";
+import type { SkipService } from "@skipruntime/core";
 import { controlService, streamingService } from "./rest.js";
 import type { Express, Request, Response, NextFunction } from "express";
 import express from "express";
@@ -182,73 +173,4 @@ function no_cors(req: Request, res: Response, next: NextFunction) {
   } else {
     next();
   }
-}
-
-class LeaderResource implements Resource {
-  private collection: string;
-
-  constructor(param: Json) {
-    if (typeof param == "string") this.collection = param;
-    else
-      throw new SkipError(
-        "Followers must specify a shared collection to mirror from leader.",
-      );
-  }
-
-  instantiate(collections: NamedCollections): EagerCollection<Json, Json> {
-    if (this.collection in collections) return collections[this.collection]!;
-    throw new SkipError(
-      `Unknown shared collection in leader: ${this.collection}`,
-    );
-  }
-}
-
-/**
- * Run a `SkipService` as the *leader* in a leader-follower topology.
- *
- * Instead of running a `service` on one machine, it can be distributed across multiple in a leader-follower architecture, with one "leader" maintaining the shared computation graph and one or more "followers" across which client-requested resource instances are distributed.
- *
- * @returns The *leader* component to run `service` in such a configuration.
- */
-export function asLeader(service: SkipService): SkipService {
-  //TODO: add mechanism to split externals between leader/follower
-  return {
-    ...service,
-    resources: { leader: LeaderResource },
-  };
-}
-
-/**
- * Run a `SkipService` as a *follower* in a leader-follower topology.
- *
- * Instead of running a `service` on one machine, it can be distributed across multiple in a leader-follower architecture, with one "leader" maintaining the shared computation graph and one or more "followers" across which client-requested resource instances are distributed.
- *
- * @returns The *follower* component to run `service` in such a configuration, given the leader's address and the names of the shared computation graph collections to be mirrored from it (typically the `ResourceInputs` of `service`).
- */
-export function asFollower(
-  service: SkipService,
-  leader: {
-    leader: { host: string; streaming_port: number; control_port: number };
-    collections: string[];
-  },
-): SkipService {
-  return {
-    ...service,
-    initialData: {},
-    externalServices: {
-      ...service.externalServices,
-      __skip_leader: SkipExternalService.direct(leader.leader),
-    },
-    createGraph(_inputs: object, context: Context): NamedCollections {
-      const mirroredCollections: NamedCollections = {};
-      for (const collection of leader.collections) {
-        mirroredCollections[collection] = context.useExternalResource({
-          service: "__skip_leader",
-          identifier: "leader",
-          params: collection,
-        });
-      }
-      return mirroredCollections;
-    },
-  };
 }


### PR DESCRIPTION
This PR cherry-picks the non-example changes from #835, which includes example usages and more documentation of these utilities.
I would like to land this PR and cut a release, so that one can get merged without `npm pack` pulling non-released changes into the docker-compose examples.

The further improvements/followups that are on my radar but I think are non-blocking are:
 * using HAProxy maps to scale out dynamically
 * running web-service -> skip-service traffic through the load balancer to put round-robin logic there instead of docker's DNS resolver
 * adding a mechanism to specify which externals to instantiate in leaders and followers
 * putting together an example using kubernetes to spin up/orchestrate services instead of docker compose