### PR TITLE
[skipruntime/server] Add an optional env variable prefix to stream UUIDs

### DIFF
--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -16,7 +16,8 @@ export function controlService(service: ServiceInstance): express.Express {
     try {
       const uuid = crypto.randomUUID();
       service.instantiateResource(uuid, req.params.resource, req.body as Json);
-      res.status(201).send(uuid);
+      const prefix = process.env["SKIP_RESOURCE_PREFIX"];
+      res.status(201).send(prefix ? `${prefix}/${uuid}` : uuid);
     } catch (e: unknown) {
       console.log(e);
       res.status(500).json(e instanceof Error ? e.message : e);


### PR DESCRIPTION
This is cherry-picked from #835; needs to be in public release for that example to work without npm-pack.

Should've included in 0.0.14, alas.  Will cut an 0.0.15 including this.