### PR TITLE
Bootstrap improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 Dockerfile
 **/target/
 node_modules/
-/skiplang/compiler/bootstrap/*.ll
 /skiplang/prelude/runtime/*.bc
 /skiplang/prelude/runtime/*.a
 /skiplang/prelude/runtime/*.o

--- a/skiplang/compiler/.gitignore
+++ b/skiplang/compiler/.gitignore
@@ -1,5 +1,5 @@
 build/*.a
-bootstrap/*.ll
+build/*.ll
 stage*/
 tests/**/*.bin
 tests/**/*.bin.ll

--- a/skiplang/compiler/.gitignore
+++ b/skiplang/compiler/.gitignore
@@ -1,4 +1,4 @@
-bootstrap/*.a
+build/*.a
 bootstrap/*.ll
 stage*/
 tests/**/*.bin

--- a/skiplang/compiler/Makefile
+++ b/skiplang/compiler/Makefile
@@ -21,16 +21,16 @@ stage%:
 bootstrap/%.ll: bootstrap/%.ll.gz
 	gunzip -c $< > $@
 
-.PHONY: bootstrap/libskip_runtime64.a bootstrap/libbacktrace.a
-bootstrap/libskip_runtime64.a bootstrap/libbacktrace.a:
-	OUT_DIR=$$(realpath ./bootstrap) $(MAKE) -C ../prelude
+.PHONY: build/libskip_runtime64.a build/libbacktrace.a
+build/libskip_runtime64.a build/libbacktrace.a:
+	OUT_DIR=$$(realpath ./build) $(MAKE) -C ../prelude
 
 .PHONY: stage0/lib/libstd.sklib
 stage0/lib/libstd.sklib:
 	mkdir -p $(@D)
 	PATH=$$(realpath stage0/bin):$(PATH) OUT_DIR=$$(realpath stage0/lib) $(MAKE) -C ../prelude bootstrap
 
-stage0/bin/skc: bootstrap/skc_out64.ll bootstrap/libskip_runtime64.a bootstrap/libbacktrace.a
+stage0/bin/skc: bootstrap/skc_out64.ll build/libskip_runtime64.a build/libbacktrace.a
 	mkdir -p $(@D)
 	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g3
 
@@ -101,8 +101,8 @@ install: stage$(STAGE)
 
 .PHONY: clean
 clean:
-	OUT_DIR=$$(realpath ./bootstrap) $(MAKE) -C ../prelude clean
-	rm -Rf stage* bootstrap/*.ll bootstrap/libbacktrace.a
+	OUT_DIR=$$(realpath ./build) $(MAKE) -C ../prelude clean
+	rm -Rf stage* bootstrap/*.ll build
 
 .PHONY: test
 test: stage$(STAGE)

--- a/skiplang/compiler/Makefile
+++ b/skiplang/compiler/Makefile
@@ -18,7 +18,8 @@ stage%:
 	mkdir -p $@
 	$(MAKE) $@/bin/skc $@/bin/skfmt $@/bin/skargo $@/lib/libstd.sklib
 
-bootstrap/%.ll: bootstrap/%.ll.gz
+build/%.ll: bootstrap/%.ll.gz
+	mkdir -p $(@D)
 	gunzip -c $< > $@
 
 .PHONY: build/libskip_runtime64.a build/libbacktrace.a
@@ -30,15 +31,15 @@ stage0/lib/libstd.sklib:
 	mkdir -p $(@D)
 	PATH=$$(realpath stage0/bin):$(PATH) OUT_DIR=$$(realpath stage0/lib) $(MAKE) -C ../prelude bootstrap
 
-stage0/bin/skc: bootstrap/skc_out64.ll build/libskip_runtime64.a build/libbacktrace.a
+stage0/bin/skc: build/skc_out64.ll build/libskip_runtime64.a build/libbacktrace.a
 	mkdir -p $(@D)
 	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g3
 
-stage0/bin/skargo: bootstrap/skargo_out64.ll stage0/lib/libstd.sklib
+stage0/bin/skargo: build/skargo_out64.ll stage0/lib/libstd.sklib
 	mkdir -p $(@D)
 	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g3
 
-stage0/bin/skfmt: bootstrap/skfmt_out64.ll stage0/lib/libstd.sklib
+stage0/bin/skfmt: build/skfmt_out64.ll stage0/lib/libstd.sklib
 	mkdir -p $(@D)
 	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g3
 
@@ -102,7 +103,7 @@ install: stage$(STAGE)
 .PHONY: clean
 clean:
 	OUT_DIR=$$(realpath ./build) $(MAKE) -C ../prelude clean
-	rm -Rf stage* bootstrap/*.ll build
+	rm -Rf stage* build
 
 .PHONY: test
 test: stage$(STAGE)

--- a/skiplang/compiler/Makefile
+++ b/skiplang/compiler/Makefile
@@ -1,6 +1,7 @@
 OLEVEL   ?= -O3
 CXXFLAGS ?= $(OLEVEL) -mllvm -inline-threshold=0 # -enable-new-pm=false
 SKARGO_PROFILE ?= release
+SKARGO_ARGS ?= --profile $(SKARGO_PROFILE)
 STAGE    ?= 1
 
 prefix   ?= /usr/local
@@ -41,26 +42,26 @@ stage0/bin/skfmt: bootstrap/skfmt_out64.ll stage0/lib/libstd.sklib
 	clang++ -no-pie $(CXXFLAGS) -o $@ $^ -lpthread -g3
 
 stage1/bin/skc stage1/bin/skfmt: stage0
-	PATH=$$(realpath stage0/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --bins --out-dir stage1/bin --target-dir stage1/target
+	PATH=$$(realpath stage0/bin):$(PATH) skargo build $(SKARGO_ARGS) --bins --out-dir stage1/bin --target-dir stage1/target
 stage1/lib/libstd.sklib: stage0
-	PATH=$$(realpath stage0/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --lib --out-dir stage1/lib --target-dir stage1/target --manifest-path ../prelude/Skargo.toml
+	PATH=$$(realpath stage0/bin):$(PATH) skargo build $(SKARGO_ARGS) --lib --out-dir stage1/lib --target-dir stage1/target --manifest-path ../prelude/Skargo.toml
 stage1/bin/skargo: stage0
-	PATH=$$(realpath stage0/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --bins --out-dir stage1/bin --target-dir stage1/target --manifest-path ../skargo/Skargo.toml
+	PATH=$$(realpath stage0/bin):$(PATH) skargo build $(SKARGO_ARGS) --bins --out-dir stage1/bin --target-dir stage1/target --manifest-path ../skargo/Skargo.toml
 
 stage2/bin/skc stage2/bin/skfmt: stage1
-	PATH=$$(realpath stage1/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --bins --out-dir stage2/bin --target-dir stage2/target
+	PATH=$$(realpath stage1/bin):$(PATH) skargo build $(SKARGO_ARGS) --bins --out-dir stage2/bin --target-dir stage2/target
 stage2/lib/libstd.sklib: stage1
-	PATH=$$(realpath stage1/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --lib --out-dir stage2/lib --target-dir stage2/target --manifest-path ../prelude/Skargo.toml
+	PATH=$$(realpath stage1/bin):$(PATH) skargo build $(SKARGO_ARGS) --lib --out-dir stage2/lib --target-dir stage2/target --manifest-path ../prelude/Skargo.toml
 stage2/bin/skargo: stage1
-	PATH=$$(realpath stage1/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --bins --out-dir stage2/bin --target-dir stage2/target --manifest-path ../skargo/Skargo.toml
+	PATH=$$(realpath stage1/bin):$(PATH) skargo build $(SKARGO_ARGS) --bins --out-dir stage2/bin --target-dir stage2/target --manifest-path ../skargo/Skargo.toml
 
 stage3/bin/skc stage3/bin/skfmt: stage2
-	PATH=$$(realpath stage2/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --bins --out-dir stage3/bin --target-dir stage3/target
+	PATH=$$(realpath stage2/bin):$(PATH) skargo build $(SKARGO_ARGS) --bins --out-dir stage3/bin --target-dir stage3/target
 	-diff -q stage2/bin/skc.ll stage3/bin/skc.ll
 stage3/lib/libstd.sklib: stage2
-	PATH=$$(realpath stage2/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --lib --out-dir stage3/lib --target-dir stage3/target --manifest-path ../prelude/Skargo.toml
+	PATH=$$(realpath stage2/bin):$(PATH) skargo build $(SKARGO_ARGS) --lib --out-dir stage3/lib --target-dir stage3/target --manifest-path ../prelude/Skargo.toml
 stage3/bin/skargo: stage2
-	PATH=$$(realpath stage2/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --bins --out-dir stage3/bin --target-dir stage3/target --manifest-path ../skargo/Skargo.toml
+	PATH=$$(realpath stage2/bin):$(PATH) skargo build $(SKARGO_ARGS) --bins --out-dir stage3/bin --target-dir stage3/target --manifest-path ../skargo/Skargo.toml
 
 # stageD is a "direct" build mode, where skc is built from current compiler
 # and runtime sources using the skc found in PATH, without using skargo or
@@ -79,10 +80,10 @@ stageD/lib/libstd.sklib: stageD/bin/skc
 	PATH=$$(realpath stageD/bin):$(PATH) OUT_DIR=$$(realpath stageD/lib) $(MAKE) -C ../prelude bootstrap
 
 stageD/bin/skargo: stageD/bin/skc stageD/lib/libstd.sklib
-	PATH=$$(realpath stageD/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --bin skargo --out-dir stageD/bin --target-dir stageD/target --manifest-path ../skargo/Skargo.toml
+	PATH=$$(realpath stageD/bin):$(PATH) skargo build $(SKARGO_ARGS) --bin skargo --out-dir stageD/bin --target-dir stageD/target --manifest-path ../skargo/Skargo.toml
 
 stageD/bin/skfmt: stageD/bin/skc stageD/lib/libstd.sklib
-	PATH=$$(realpath stageD/bin):$(PATH) skargo build --profile $(SKARGO_PROFILE) --bin skfmt --out-dir stageD/bin --target-dir stageD/target
+	PATH=$$(realpath stageD/bin):$(PATH) skargo build $(SKARGO_ARGS) --bin skfmt --out-dir stageD/bin --target-dir stageD/target
 
 .PHONY: promote
 promote: stage$(STAGE)

--- a/skiplang/compiler/Makefile
+++ b/skiplang/compiler/Makefile
@@ -92,6 +92,7 @@ promote: stage$(STAGE)
 	cp stage$(STAGE)/target/host/$(SKARGO_PROFILE)/deps/skc-*.ll bootstrap/skc_out64.ll && gzip --best --force bootstrap/skc_out64.ll
 	cp stage$(STAGE)/target/host/$(SKARGO_PROFILE)/deps/skargo-*.ll bootstrap/skargo_out64.ll && gzip --best --force bootstrap/skargo_out64.ll
 	cp stage$(STAGE)/target/host/$(SKARGO_PROFILE)/deps/skfmt-*.ll bootstrap/skfmt_out64.ll && gzip --best --force bootstrap/skfmt_out64.ll
+	@echo "Push to bootstrap repository: cd $$(realpath ./bootstrap); git add -A; git commit -m 'Update to $(shell git describe --always)'; git push; cd -"
 
 .PHONY: install
 install: stage$(STAGE)

--- a/skiplang/compiler/Makefile
+++ b/skiplang/compiler/Makefile
@@ -1,7 +1,8 @@
 OLEVEL   ?= -O3
 CXXFLAGS ?= $(OLEVEL) -mllvm -inline-threshold=0 # -enable-new-pm=false
 SKARGO_PROFILE ?= release
-SKARGO_ARGS ?= --profile $(SKARGO_PROFILE)
+SKC_ARGS ?= --canonize-paths
+SKARGO_ARGS ?= --profile $(SKARGO_PROFILE) $(foreach opt,$(SKC_ARGS),--skcopt $(opt))
 STAGE    ?= 1
 
 prefix   ?= /usr/local
@@ -72,7 +73,7 @@ stage3/bin/skargo: stage2
 stageD/bin/skc:
 	mkdir -p $(@D)
 	OUT_DIR=$$(realpath stageD/lib) $(MAKE) -C ../prelude default
-	SKC_PREAMBLE=../prelude/preamble/preamble64.ll SKARGO_PKG_NAME=skc SKARGO_PKG_VERSION=stageD GIT_COMMIT_HASH=$(shell git rev-parse --short HEAD) skc --link-args -lpthread --no-std --export-function-as main=skip_main -o stageD/bin/skc $(OLEVEL) stageD/lib/libskip_runtime64.a stageD/lib/libbacktrace.a $(shell find ../prelude/src ../arparser/src ../cli/src src -name '*.sk')
+	SKC_PREAMBLE=../prelude/preamble/preamble64.ll SKARGO_PKG_NAME=skc SKARGO_PKG_VERSION=stageD GIT_COMMIT_HASH=$(shell git rev-parse --short HEAD) skc $(SKC_ARGS) --link-args -lpthread --no-std --export-function-as main=skip_main -o stageD/bin/skc $(OLEVEL) stageD/lib/libskip_runtime64.a stageD/lib/libbacktrace.a $(shell find ../prelude/src ../arparser/src ../cli/src src -name '*.sk')
 	mkdir -p stage$(STAGE)/target/host/$(SKARGO_PROFILE)/deps/ && mv stage$(STAGE)/bin/skc.ll stage$(STAGE)/target/host/$(SKARGO_PROFILE)/deps/skc-d.ll
 
 stageD/lib/libstd.sklib: stageD/bin/skc


### PR DESCRIPTION
- Use `--canonize-paths` by default
- Dirty `build/` rather than `bootstrap/` (