### PR TITLE
[skiplang/skc] Shorthand `-V` alias for version.

### DIFF
--- a/skiplang/compiler/src/main.sk
+++ b/skiplang/compiler/src/main.sk
@@ -25,7 +25,12 @@ fun main(): void {
     .arg(Cli.Arg::bool("autogc").default(true).negatable())
     .arg(Cli.Arg::string("sample-rate").default("0"))
     .arg(Cli.Arg::bool("use-specialized-names"))
-    .arg(Cli.Arg::bool("version").about("Print version info and exit."))
+    .arg(
+      Cli.Arg::bool("version")
+        .long("version")
+        .short("V")
+        .about("Print version info and exit."),
+    )
     // Global config flags
     .arg(Cli.Arg::bool("release").about("Enable release optimizations."))
     .arg(


### PR DESCRIPTION
This brings consistency with `skargo`.