### PR TITLE
[skiplang/skc] Defer `ScalarType` construction to specializer.

### DIFF
--- a/skiplang/compiler/src/GIR.sk
+++ b/skiplang/compiler/src/GIR.sk
@@ -225,7 +225,6 @@ class GClass{
   annotations: SSet = SSet[],
   fields: Array<GField> = Array[],
   canInstantiate: Bool = true,
-  scalarType: ?ScalarType = None(),
 } extends HasFileRange uses Orderable {
   fun compare(other: GClass): Order {
     this.name.compare(other.name)

--- a/skiplang/compiler/src/OuterIstToIR.sk
+++ b/skiplang/compiler/src/OuterIstToIR.sk
@@ -935,7 +935,6 @@ class GClassFile(value: GClass) extends SKStore.File
 // Manages the overall conversion from OuterIst to IR.
 class Converter private (
   program: I.Program,
-  private ptrBitSize: Int,
   private funs: SKStore.LHandle<LazyGFunKey, GFunctionFile>,
   private classes: SKStore.LHandle<LazyGClassKey, GClassFile>,
   lower: SKStore.LHandle<I.CallableDefFile, I.CallableDefFile>,
@@ -950,7 +949,6 @@ class Converter private (
 
   static fun create(
     context: mutable SKStore.Context,
-    ptrBitSize: Int,
     name: SKStore.DirName,
     program: I.Program,
   ): this {
@@ -972,7 +970,7 @@ class Converter private (
       I.CallableDefFile::type,
       lowerDirName,
     );
-    converter = static(program, ptrBitSize, funs, classes, lower);
+    converter = static(program, funs, classes, lower);
     _ = SKStore.LHandle::create(
       LazyGFunKey::keyType,
       GFunctionFile::type,
@@ -2240,21 +2238,6 @@ class Converter private (
     classMutable = in_.mutable_.isSome() && kind.isFinal();
     parentMutability = Mutability::fromFlag(classMutable);
 
-    // Magically poke in some LLVM type names for native types.
-    scalarType = classname match {
-    | "Bool" -> Some(ScalarType(1, 1, "i1", IntegerScalarKind()))
-    | "Char" -> Some(ScalarType(32, 32, "i32", IntegerScalarKind()))
-    | "Int" -> Some(ScalarType(64, 64, "i64", IntegerScalarKind()))
-    | "Int8" -> Some(ScalarType(8, 8, "i8", IntegerScalarKind()))
-    | "Int16" -> Some(ScalarType(16, 16, "i16", IntegerScalarKind()))
-    | "Int32" -> Some(ScalarType(32, 32, "i32", IntegerScalarKind()))
-    | "Float" -> Some(ScalarType(64, 64, "double", FloatScalarKind()))
-    | "Runtime.GCPointer" -> Some(ScalarType::gcPointer(this.ptrBitSize))
-    | "Runtime.NonGCPointer" -> Some(ScalarType::nonGCPointer(this.ptrBitSize))
-    | "String" -> Some(ScalarType::gcPointer(this.ptrBitSize))
-    | _ -> None()
-    };
-
     extends_ = this.convertExtends(context, in_, parentMutability);
 
     nonStaticMethods = in_.methods.filter((_, v) ->
@@ -2343,7 +2326,6 @@ class Converter private (
         methodSources => methodSources.chill(),
         annotations => in_.annotations,
         fields => convertedFields,
-        scalarType,
       },
     )
   }

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -189,10 +189,7 @@ fun ensureCompatibleLLVMVersion(): void {
 
 class TickConfigFile(value: (Int, Config.Config)) extends SKStore.File
 
-fun getOrInitializeBackend(
-  context: mutable SKStore.Context,
-  ptrBitSize: Int,
-): SKStore.EagerDir {
+fun getOrInitializeBackend(context: mutable SKStore.Context): SKStore.EagerDir {
   backendDirName = SKStore.DirName::create("/backend/");
   context.unsafeMaybeGetEagerDir(backendDirName) match {
   | Some(dir) -> return dir
@@ -222,7 +219,6 @@ fun getOrInitializeBackend(
 
   converter = OuterIstToIR.Converter::create(
     context,
-    ptrBitSize,
     SKStore.DirName::create("/converter/"),
     outerIst,
   );
@@ -379,9 +375,7 @@ fun compile(
 
   ensureCompatibleLLVMVersion();
 
-  // FIXME: Backend initialization should _not_ peek into the config
-  // as it is likely to change across invocations.
-  getOrInitializeBackend(context, config.ptrBitSize).writeArray(
+  getOrInitializeBackend(context).writeArray(
     context,
     SKStore.UnitID::singleton,
     Array[TickConfigFile((context.tick.value, config))],

--- a/skiplang/compiler/src/specialize.sk
+++ b/skiplang/compiler/src/specialize.sk
@@ -1496,9 +1496,22 @@ mutable class Specializer{
         fields => Array[], // Computed later after being scalarized
         canInstantiate => gclass.canInstantiate,
         ptrBitSize => this.config.ptrBitSize,
-        scalarType => gclass.scalarType match {
-        | some @ Some _ -> some
-        | None() ->
+        // Magically poke in some LLVM type names for native types.
+        scalarType => gclass.name.id match {
+        | "Bool" -> Some(ScalarType(1, 1, "i1", IntegerScalarKind()))
+        | "Char" -> Some(ScalarType(32, 32, "i32", IntegerScalarKind()))
+        | "Int" -> Some(ScalarType(64, 64, "i64", IntegerScalarKind()))
+        | "Int8" -> Some(ScalarType(8, 8, "i8", IntegerScalarKind()))
+        | "Int16" -> Some(ScalarType(16, 16, "i16", IntegerScalarKind()))
+        | "Int32" -> Some(ScalarType(32, 32, "i32", IntegerScalarKind()))
+        | "Float" -> Some(ScalarType(64, 64, "double", FloatScalarKind()))
+        | "Runtime.GCPointer" ->
+          Some(ScalarType::gcPointer(this.config.ptrBitSize))
+        | "Runtime.NonGCPointer" ->
+          Some(ScalarType::nonGCPointer(this.config.ptrBitSize))
+        | "String" -> Some(ScalarType::gcPointer(this.config.ptrBitSize))
+
+        | _ ->
           kind match {
           | KBase()
           | KClass() ->


### PR DESCRIPTION
The `scalarType` field of `GClass` was not used beyond being copied when building the `SClass`es. Storing it on `GClass` forced the front end to know about the target platform's pointer size, and prevented sharing when compiling the same code for multiple platforms.