### PR TITLE
Persistent Queue + simplify lazyGets

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -361,8 +361,7 @@ mutable class Context{
   mutable canReuse: CanReuse = CRIfMatch(),
   mutable arrowStack: List<(ArrowKey, TimeStack)> = List[],
   mutable lazyGets: SortedSet<Path> = SortedSet[],
-  private mutable lazyGetsQueueIn: List<Array<Path>> = List[],
-  private mutable lazyGetsQueueOut: List<Array<Path>> = List[],
+  private mutable lazyGetsQueue: Queue<Array<Path>> = Queue[],
   private mutable lazyGetsRefCount: SortedMap<Path, Int> = SortedMap[],
   mutable sessions: SortedMap<Int, Sub> = SortedMap[],
   mutable removeSubDirs: Bool = true,
@@ -450,8 +449,7 @@ mutable class Context{
       canReuse => this.canReuse,
       arrowStack => this.arrowStack,
       lazyGets => this.lazyGets,
-      lazyGetsQueueIn => this.lazyGetsQueueIn,
-      lazyGetsQueueOut => this.lazyGetsQueueOut,
+      lazyGetsQueue => this.lazyGetsQueue,
       lazyGetsRefCount => this.lazyGetsRefCount,
       sessions => this.sessions,
       removeSubDirs => this.removeSubDirs,
@@ -487,8 +485,7 @@ mutable class Context{
       canReuse => this.canReuse,
       arrowStack => this.arrowStack,
       lazyGets => this.lazyGets,
-      lazyGetsQueueIn => this.lazyGetsQueueIn,
-      lazyGetsQueueOut => this.lazyGetsQueueOut,
+      lazyGetsQueue => this.lazyGetsQueue,
       lazyGetsRefCount => this.lazyGetsRefCount,
       sessions => this.sessions,
       removeSubDirs => this.removeSubDirs,
@@ -527,8 +524,7 @@ mutable class Context{
     this.!canReuse = ctx.canReuse;
     this.!arrowStack = ctx.arrowStack;
     this.!lazyGets = ctx.lazyGets;
-    this.!lazyGetsQueueIn = ctx.lazyGetsQueueIn;
-    this.!lazyGetsQueueOut = ctx.lazyGetsQueueOut;
+    this.!lazyGetsQueue = ctx.lazyGetsQueue;
     this.!lazyGetsRefCount = ctx.lazyGetsRefCount;
     this.!sessions = ctx.sessions;
     this.!removeSubDirs = ctx.removeSubDirs;
@@ -678,48 +674,33 @@ mutable class Context{
       };
       this.!lazyGetsRefCount[path] = refCount + 1;
     };
-    this.!lazyGetsQueueIn = List.Cons(
-      this.lazyGets.toArray(),
-      this.lazyGetsQueueIn,
-    );
+    this.!lazyGetsQueue = this.lazyGetsQueue.push(this.lazyGets.toArray());
     this.!lazyGets = SortedSet[];
-    if (this.tick <= Tick(this.lazyCapacity)) return void;
-    queue = this.lazyGetsQueueOut match {
-    | List.Nil() ->
-      invariant(this.lazyGetsQueueIn is List.Cons _);
-      this.!lazyGetsQueueOut = this.lazyGetsQueueIn.reversed();
-      this.!lazyGetsQueueIn = List[];
-      this.lazyGetsQueueOut
-    | l -> l
-    };
-    queue match {
-    | List.Nil() -> invariant_violation("LazyGets reached empty queue")
-    | List.Cons(lazyGets, rl) ->
-      this.!lazyGetsQueueOut = rl;
-      toRemove = mutable Map[];
-      for (path in lazyGets) {
-        this.lazyGetsRefCount.maybeGet(path) match {
-        | None() ->
-          // Not found, but since the aim is to remove them, we can do nothing.
-          void
-        | Some(refCount) ->
-          !refCount = refCount - 1;
-          if (refCount == 0) {
-            this.!lazyGetsRefCount = this.lazyGetsRefCount.remove(path);
-            if (!toRemove.containsKey(path.dirName)) {
-              toRemove![path.dirName] = SortedSet[];
-            };
-            toRemove![path.dirName] = toRemove[path.dirName].set(path.baseName);
-          } else {
-            this.!lazyGetsRefCount[path] = refCount;
-          }
-        };
+    if (this.lazyGetsQueue.size() <= this.lazyCapacity) return void;
+    (this.!lazyGetsQueue, lazyGets) = this.lazyGetsQueue.pop().fromSome();
+    toRemove = mutable Map[];
+    for (path in lazyGets) {
+      this.lazyGetsRefCount.maybeGet(path) match {
+      | None() ->
+        // Not found, but since the aim is to remove them, we can do nothing.
+        void
+      | Some(refCount) ->
+        !refCount = refCount - 1;
+        if (refCount == 0) {
+          this.!lazyGetsRefCount = this.lazyGetsRefCount.remove(path);
+          if (!toRemove.containsKey(path.dirName)) {
+            toRemove![path.dirName] = SortedSet[];
+          };
+          toRemove![path.dirName] = toRemove[path.dirName].set(path.baseName);
+        } else {
+          this.!lazyGetsRefCount[path] = refCount;
+        }
       };
-      for (dirName => keys in toRemove) {
-        dir = this.unsafeGetLazyDir(dirName);
-        this.setDir(dir.removeKeys(keys))
-      }
     };
+    for (dirName => keys in toRemove) {
+      dir = this.unsafeGetLazyDir(dirName);
+      this.setDir(dir.removeKeys(keys))
+    }
   }
 
   mutable fun update(): void {

--- a/skiplang/prelude/src/stdlib/collections/persistent/List.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/List.sk
@@ -368,6 +368,18 @@ mutable base class .List<+T>
     result
   }
 
+  /* a.revAppend(b) is a faster a.reversed().concat(b)
+     This version is constrained by b being non-empty so that the result is
+     proven to be non-empty as well.
+     If b is empty, just use a.reversed() */
+  readonly fun revAppend<U>[T: U](tail: Cons<U>): Cons<U> {
+    result: Cons<U> = tail;
+    for (x in this) {
+      !result = Cons(x, result)
+    };
+    result
+  }
+
   readonly fun sorted[T: readonly Orderable](
     compare: (T, T) ~> Order = (x, y) ~> x.compare(y),
   ): List<T> {

--- a/skiplang/prelude/src/stdlib/collections/persistent/List.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/List.sk
@@ -360,25 +360,12 @@ mutable base class .List<+T>
     (acc, list)
   }
 
-  readonly fun reversed(): List<T> {
-    result: List<T> = Nil();
-    for (x in this) {
-      !result = Cons(x, result)
-    };
-    result
-  }
+  readonly overridable fun reversed(): List<T>
+  | Nil() -> Nil()
+  | Cons _ -> this.revAppend(Nil())
 
-  /* a.revAppend(b) is a faster a.reversed().concat(b)
-     This version is constrained by b being non-empty so that the result is
-     proven to be non-empty as well.
-     If b is empty, just use a.reversed() */
-  readonly fun revAppend<U>[T: U](tail: Cons<U>): Cons<U> {
-    result: Cons<U> = tail;
-    for (x in this) {
-      !result = Cons(x, result)
-    };
-    result
-  }
+  /* a.revAppend(b) is a faster a.reversed().concat(b) */
+  readonly fun revAppend<U>[T: U](tail: List<U>): List<U>;
 
   readonly fun sorted[T: readonly Orderable](
     compare: (T, T) ~> Order = (x, y) ~> x.compare(y),
@@ -605,6 +592,30 @@ mutable base class .List<+T>
 
   readonly fun toString[T: readonly Show](): String {
     `List[${this.join(", ")}]`
+  }
+}
+
+extension class Nil {
+  readonly fun reversed(): Nil<T> {
+    Nil()
+  }
+
+  readonly fun revAppend<U>[T: U](tail: List<U>): List<U> {
+    tail
+  }
+}
+
+extension class Cons {
+  readonly fun reversed(): Cons<T> {
+    this.revAppend(Nil())
+  }
+
+  readonly fun revAppend<U>[T: U](tail: List<U>): Cons<U> {
+    result: Cons<U> = Cons(this.head, tail);
+    for (x in this.tail) {
+      !result = Cons(x, result)
+    };
+    result
   }
 }
 

--- a/skiplang/prelude/src/stdlib/collections/persistent/List.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/List.sk
@@ -40,8 +40,8 @@ mutable base class .List<+T>
     Nil()
   }
 
-  static fun of<E>(element: E): List<E> {
-    List[element]
+  static fun of(element: T): Cons<T> {
+    Cons(element, Nil())
   }
 
   static fun createFromItems<C: readonly Sequence<T>>(items: C): List<T> {

--- a/skiplang/prelude/src/stdlib/collections/persistent/Queue.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/Queue.sk
@@ -41,8 +41,8 @@ class .Queue<+T> private {
     | Queue{head => List.Nil(), reversedTail => List.Nil(), siz} ->
       invariant(siz == 0);
       None()
-    | Queue{head => List.Nil(), reversedTail => List.Cons(rhd, rtl), siz} ->
-      rtl.revAppend(List::of(rhd)) match {
+    | Queue{head => List.Nil(), reversedTail => rt @ List.Cons _, siz} ->
+      rt.reversed() match {
       | List.Cons(res, head) ->
         Some((Queue{head, siz => siz - 1, reversedTail => List.Nil()}, res))
       }

--- a/skiplang/prelude/src/stdlib/collections/persistent/Queue.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/Queue.sk
@@ -1,0 +1,124 @@
+module Queue;
+
+/* A persistent First-In First-Out queue */
+class .Queue<+T> private {
+  private siz: Int,
+  private head: List<T>,
+  private reversedTail: List<T>,
+} extends Sequence<T> uses Equality[T: Equality], Orderable[T: Orderable] {
+  /* Invariant:
+     - this.size() == this.head.size() + this.reversedTail.size()
+     - The whole queue is the concatenation of head and reversedTail.reversed()
+   */
+  static fun empty(): this {
+    static{siz => 0, head => List.Nil(), reversedTail => List.Nil()}
+  }
+
+  static fun createFromItems<C: readonly Sequence<T>>(items: C): Queue<T> {
+    static{
+      siz => items.size(),
+      head => List.Nil(),
+      reversedTail => List::reverseFromIterator(items.values()),
+    }
+  }
+
+  fun size(): Int {
+    this.siz
+  }
+
+  fun push<U>[T: U](x: U): Queue<U> {
+    Queue<U>{
+      siz => this.siz + 1,
+      head => this.head,
+      reversedTail => List.Cons(x, this.reversedTail),
+    }
+  }
+
+  fun pop(): ?(this, T) {
+    this match {
+    | Queue{head => List.Cons(res, head), siz} ->
+      Some((this with {head, siz => siz - 1}, res))
+    | Queue{head => List.Nil(), reversedTail => List.Nil(), siz} ->
+      invariant(siz == 0);
+      None()
+    | Queue{head => List.Nil(), reversedTail => List.Cons(rhd, rtl), siz} ->
+      rtl.revAppend(List::of(rhd)) match {
+      | List.Cons(res, head) ->
+        Some((Queue{head, siz => siz - 1, reversedTail => List.Nil()}, res))
+      }
+    }
+  }
+
+  fun values(): mutable Iterator<T> {
+    loop {
+      this.pop() match {
+      | Some((q, x)) ->
+        yield x;
+        !this = q
+      | None() -> yield break
+      }
+    }
+  }
+
+  fun toArray(): Array<T> {
+    Array::fillBy(this.siz, _i -> {
+      (!this, x) = this.pop().fromSome();
+      x
+    })
+  }
+
+  fun compare<T2: Orderable>[T: T2](other: Queue<T2>): Order {
+    loop {
+      (this.pop(), other.pop()) match {
+      | (None(), None()) -> return EQ()
+      | (None(), Some(_)) -> return LT()
+      | (Some(_), None()) -> return GT()
+      | (Some((q1, x1)), Some((q2, x2))) ->
+        cmp = x1.compare(x2);
+        if (cmp != EQ()) {
+          return cmp
+        };
+        !this = q1;
+        !other = q2
+      }
+    }
+  }
+
+  fun <<T2: Orderable>[T: T2](x: Queue<T2>): Bool {
+    this.compare(x) == LT()
+  }
+
+  fun ><T2: Orderable>[T: T2](x: Queue<T2>): Bool {
+    this.compare(x) == GT()
+  }
+
+  fun <=<T2: Orderable>[T: T2](x: Queue<T2>): Bool {
+    this.compare(x) != GT()
+  }
+
+  fun >=<T2: Orderable>[T: T2](x: Queue<T2>): Bool {
+    this.compare(x) != LT()
+  }
+
+  fun ==<T2: Equality>[T: T2](other: Queue<T2>): Bool {
+    if (this.siz != other.siz) return false;
+    loop {
+      (this.pop(), other.pop()) match {
+      | (None(), None()) -> return true
+      | (None(), Some(_))
+      | (Some(_), None()) ->
+        invariant_violation("Queue: broken invariant")
+      | (Some((q1, x1)), Some((q2, x2))) ->
+        if (x1 != x2) return false;
+        !this = q1;
+        !other = q2
+      }
+    }
+  }
+
+  fun !=<T2: Equality>[T: T2](other: Queue<T2>): Bool {
+    !(this == other)
+  }
+}
+
+module end;

--- a/skiplang/prelude/tests/List.sk
+++ b/skiplang/prelude/tests/List.sk
@@ -1,0 +1,18 @@
+module alias T = SKTest;
+
+module ListTest;
+
+@test
+fun testRevAppend(): void {
+  T.expectEq(List[].revAppend(List::of(1)), List[1]);
+  T.expectEq(List[].revAppend(List.Cons(1, List[2, 3, 4])), List[1, 2, 3, 4]);
+  T.expectEq(List[1].revAppend(List::of(2)), List[1, 2]);
+  T.expectEq(List[1].revAppend(List.Cons(2, List[3, 4])), List[1, 2, 3, 4]);
+  T.expectEq(List[3, 2, 1].revAppend(List::of(4)), List[1, 2, 3, 4]);
+  T.expectEq(
+    List[3, 2, 1].revAppend(List.Cons(4, List[5, 6])),
+    List[1, 2, 3, 4, 5, 6],
+  );
+}
+
+module end;

--- a/skiplang/prelude/tests/Queue.sk
+++ b/skiplang/prelude/tests/Queue.sk
@@ -1,0 +1,85 @@
+module alias T = SKTest;
+
+module QueueTest;
+
+fun checkEmpty<V: frozen & Equality>(q: Queue<V>): void {
+  T.expectEq(q.size(), 0);
+  T.expectEq(q.isEmpty(), true);
+  T.expectEq(q.toArray(), Array[]);
+  T.expectEq(q.values().collect(Array), Array[]);
+  T.expectEq(q.pop(), None());
+}
+
+@test
+fun testEmpty(): void {
+  checkEmpty(Queue[]);
+  checkEmpty(Queue::empty());
+}
+
+@test
+fun testCreateFromItems(): void {
+  four = Queue[1, 2, 3, 4];
+  T.expectEq(four.size(), 4);
+  T.expectEq(four.isEmpty(), false);
+  T.expectEq(four.toArray(), Array[1, 2, 3, 4]);
+  T.expectEq(four.collect(Array), Array[1, 2, 3, 4]);
+  T.expectEq(four.values().collect(Array), Array[1, 2, 3, 4]);
+}
+
+@test
+fun testPushPopTwo(): void {
+  q = Queue[];
+  !q = q.push(1);
+  T.expectEq(q.toArray(), Array[1]);
+  !q = q.push(2);
+  T.expectEq(q.toArray(), Array[1, 2]);
+  (!q, x) = q.pop().fromSome();
+  T.expectEq(x, 1);
+  T.expectEq(q.toArray(), Array[2]);
+  (!q, !x) = q.pop().fromSome();
+  T.expectEq(x, 2);
+  T.expectEq(q.toArray(), Array[]);
+  T.expectEq(q.isEmpty(), true);
+}
+
+@test
+fun testPushPopMore(): void {
+  q = Queue[];
+  !q = q.push(1);
+  !q = q.push(2);
+  (!q, x) = q.pop().fromSome();
+  T.expectEq(x, 1);
+  !q = q.push(3);
+  !q = q.push(4);
+  (!q, !x) = q.pop().fromSome();
+  T.expectEq(x, 2);
+  !q = q.push(5);
+  !q = q.push(6);
+  (!q, !x) = q.pop().fromSome();
+  T.expectEq(x, 3);
+  (!q, !x) = q.pop().fromSome();
+  T.expectEq(x, 4);
+  (!q, !x) = q.pop().fromSome();
+  T.expectEq(x, 5);
+  (!q, !x) = q.pop().fromSome();
+  T.expectEq(x, 6);
+  !q = q.push(7);
+  (!q, !x) = q.pop().fromSome();
+  T.expectEq(x, 7);
+  T.expectEq(q.toArray(), Array[]);
+}
+
+@test
+fun testCompare(): void {
+  T.expectEq(Queue[1, 2, 3], Queue[1, 2, 3]);
+  T.expectEq(Queue[1, 2, 3].compare(Queue[1, 2, 4]), LT());
+  T.expectEq(Queue[1, 2, 3].compare(Queue[1, 2, 3, 4]), LT());
+  T.expectEq(Queue[1, 2, 3, 4].compare(Queue[1, 2, 3]), GT());
+  T.expectEq(Queue[1, 2].pop().fromSome().i0.push(3), Queue[2, 3]);
+  T.expectEq(
+    Queue[1, 2].pop().fromSome().i0.pop().fromSome().i0.push(3),
+    Queue[3],
+  );
+}
+
+module end;


### PR DESCRIPTION
Adds persistent queues to the standard library and use it in the context to make the `lazyGetsQueue` easier to understand. As a side effect, the queue is now sensitive to changes of `lazyCapacity`