### PR TITLE
Fix ArrowKey for Lazy gets

### DIFF
--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -162,9 +162,9 @@ class LazyDir protected {
         print_string("LRemoved: " + Path::create(this.dirName, key).toString())
       };
       arrow = context.currentArrow() match {
-      | Some(a) ->
+      | Some(_a) ->
         Some(
-          ArrowKey{parentName => a.childName, childName => this.dirName, key},
+          ArrowKey{parentName => this.dirName, childName => this.dirName, key},
         )
       | _ -> None()
       };

--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -161,16 +161,14 @@ class LazyDir protected {
       if (x is Some(LRemoved _) && context.debugMode) {
         print_string("LRemoved: " + Path::create(this.dirName, key).toString())
       };
-      arrow = context.currentArrow() match {
-      | Some(_a) ->
-        Some(
-          ArrowKey{parentName => this.dirName, childName => this.dirName, key},
-        )
-      | _ -> None()
+      arrow = ArrowKey{
+        parentName => this.dirName,
+        childName => this.dirName,
+        key,
       };
-      arrow.each(a -> context.enter(a, this.timeStack));
+      context.enter(arrow, this.timeStack);
       res = this.lazyFun(context, key);
-      arrow.each(context.leave);
+      context.leave(arrow);
       res
     | Some(x) -> x
     };


### PR DESCRIPTION
In `LazyDir#unsafeGetArray`, the `ArrowKey` is created with `a.childName` as the `parentName`, `a` being the current arrow.
This breaks the invariant that the key in an `ArrowKey` refers to a key of the parent.
Also always defining an arrow allows to strictly forbidding the creation of eager dirs from lazy gets.