### PR TITLE
Git: add a mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,34 @@
+# This file maps "correct" name/email to "wrong" name/email so that git shortlog
+# considers them as the same person.
+
+# When the same person appears at two different places in `git shortlog -se`,
+# please add an entry in this file. Please keep it sorted.
+
+# The following principles have been used:
+# - use the person full name if it appears at least once as is, or can be
+#   guessed from the e-mail address, capitalize it,
+# - use the person's most used e-mail,
+# - or use the person's up-to-date institutional e-mail if it makes more sense
+# For each person, always add a line to normalize the name, then lines to
+# normalize emails.
+Andrey Gritsaenko <gricaenko.95a@gmail.com>
+Andrey Gritsaenko <gricaenko.95a@gmail.com> <andrey.gritsaenko@sast-mfa.com>
+
+Daniel Lopes <daniel@skiplabs.io>
+Daniel Lopes <daniel@skiplabs.io> <118663842+skiplabsdaniel@users.noreply.github.com>
+
+Hugo Venturini <hugo@skiplabs.io>
+Hugo Venturini <hugo@skiplabs.io> <hubyrod@users.noreply.github.com>
+
+Josh Berdine <josh@skiplabs.io>
+Josh Berdine <josh@skiplabs.io> <josh@berdine.net>
+
+Julien Verlaguet <julien@skiplabs.io>
+Julien Verlaguet <julien@skiplabs.io> <julien.verlaguet@gmail.com>
+Julien Verlaguet <julien@skiplabs.io> <pikatchu@users.noreply.github.com>
+
+Lucas Hosseini <lucas@skiplabs.io>
+Lucas Hosseini <lucas@skiplabs.io> <lucas.hosseini@gmail.com>
+
+Mehdi Bouaziz <mehdi@skiplabs.io>
+Mehdi Bouaziz <mehdi@skiplabs.io> <mbouaziz@users.noreply.github.com>


### PR DESCRIPTION
From `man gitmailmap`:

```
If the file .mailmap exists at the toplevel of the repository [...], it is used to map author and committer names and email addresses to canonical real names and email addresses.
```

As a consequence, it is also used to merge authors appearing with different names or e-mail addresses in the stats.

After this commit, `git shortlog -se` should show no duplicate entries for the same person.