### PR TITLE
Help needed / Less set garbage

### DIFF
--- a/skiplang/prelude/runtime/native_eq.c
+++ b/skiplang/prelude/runtime/native_eq.c
@@ -129,6 +129,6 @@ SkipInt SKIP_isEq(char* obj1, char* obj2) {
   return 0;
 }
 
-uint32_t SKIP_unsafe_compare_sets(char* obj1, char* obj2) {
+uint32_t SKIP_physEq(char* obj1, char* obj2) {
   return (obj1 == obj2);
 }

--- a/skiplang/prelude/src/native/Runtime.sk
+++ b/skiplang/prelude/src/native/Runtime.sk
@@ -78,3 +78,6 @@ module end;
 // Cf: runtime/native_eq.c
 @cpp_extern("SKIP_isEq")
 native fun native_eq<T: frozen>(T, T): Int;
+
+@cpp_extern("SKIP_physEq")
+native fun phys_eq<T>(T, T): Bool;

--- a/skiplang/prelude/src/native/Runtime.sk
+++ b/skiplang/prelude/src/native/Runtime.sk
@@ -73,7 +73,7 @@ private fun throwInvariantViolation(msg: String): void {
 module end;
 
 // May return true if two objects are equal.
-// Definitely returns true if two objects are different.
+// Definitely returns false if two objects are different.
 // This function cannot be used as a replacement for equality.
 // Cf: runtime/native_eq.c
 @cpp_extern("SKIP_isEq")

--- a/skiplang/prelude/src/stdlib/collections/persistent/SortedMap.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/SortedMap.sk
@@ -723,12 +723,9 @@ base class .SortedMap<+K: Orderable, +V> uses  //  extends KeyedSequence<K, V>
     k: K2,
     v: V2,
   ): SortedMap<K2, V2>
-  | Nil() ->
-    new_static: Concrete<SortedMap<K2, V2>> = static;
-    new_static::node(k, v, Nil(), Nil())
+  | Nil() -> SortedMap::node(k, v, Nil(), Nil())
   | Node _ ->
-    new_static: Concrete<SortedMap<K2, V2>> = static;
-    new_static::balance(
+    SortedMap::balance(
       this.key,
       this.value,
       this.left,

--- a/skiplang/prelude/src/stdlib/collections/persistent/SortedMap.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/SortedMap.sk
@@ -325,7 +325,7 @@ base class .SortedMap<+K: Orderable, +V> uses  //  extends KeyedSequence<K, V>
     value: V2,
     f: (V2, V2) -> V2,
   ): SortedMap<K2, V2>
-  | Nil() -> SortedMap::node(key, value, Nil(), Nil())
+  | Nil() -> SortedMap::singleton(key, value)
   | Node _ ->
     l: SortedMap<K2, V2> = this.left;
     r: SortedMap<K2, V2> = this.right;
@@ -617,6 +617,10 @@ base class .SortedMap<+K: Orderable, +V> uses  //  extends KeyedSequence<K, V>
   | Nil() -> 0
   | Node _ -> this.h
 
+  static fun singleton(k: K, v: V): Node<K, V> {
+    Node{n => 1, h => 1, key => k, value => v, left => Nil(), right => Nil()}
+  }
+
   protected static fun node<K2: Orderable, V2>[K: K2, V: V2](
     k: K2,
     v: V2,
@@ -710,7 +714,7 @@ base class .SortedMap<+K: Orderable, +V> uses  //  extends KeyedSequence<K, V>
     k: K2,
     v: V2,
   ): SortedMap<K2, V2>
-  | Nil() -> SortedMap::node(k, v, Nil(), Nil())
+  | Nil() -> SortedMap::singleton(k, v)
   | Node _ ->
     SortedMap::balance(
       this.key,
@@ -723,7 +727,7 @@ base class .SortedMap<+K: Orderable, +V> uses  //  extends KeyedSequence<K, V>
     k: K2,
     v: V2,
   ): SortedMap<K2, V2>
-  | Nil() -> SortedMap::node(k, v, Nil(), Nil())
+  | Nil() -> SortedMap::singleton(k, v)
   | Node _ ->
     SortedMap::balance(
       this.key,

--- a/skiplang/prelude/src/stdlib/collections/persistent/SortedMap.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/SortedMap.sk
@@ -332,12 +332,18 @@ base class .SortedMap<+K: Orderable, +V> uses  //  extends KeyedSequence<K, V>
     k: K2 = this.key;
     v: V2 = this.value;
     compare(key, this.key) match {
-    | LT() -> SortedMap::balance(k, v, l.setWith(key, value, f), r)
+    | LT() ->
+      newL = l.setWith(key, value, f);
+      if (phys_eq(newL, l)) this else SortedMap::balance(k, v, newL, r)
     | EQ() ->
       newV = f(v, value);
-      node: Node<K2, V2> = n;
-      node with {value => newV}
-    | GT() -> SortedMap::balance(k, v, l, r.setWith(key, value, f))
+      if (phys_eq(newV, v)) this else {
+        node: Node<K2, V2> = n;
+        node with {value => newV}
+      }
+    | GT() ->
+      newR = r.setWith(key, value, f);
+      if (phys_eq(newR, r)) this else SortedMap::balance(k, v, l, newR)
     }
 
   fun remove<K2: Orderable>[K: K2](key: K2): SortedMap<K, V>

--- a/skiplang/prelude/src/stdlib/collections/persistent/SortedMap.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/SortedMap.sk
@@ -326,14 +326,17 @@ base class .SortedMap<+K: Orderable, +V> uses  //  extends KeyedSequence<K, V>
     f: (V2, V2) -> V2,
   ): SortedMap<K2, V2>
   | Nil() -> SortedMap::singleton(key, value)
-  | Node _ ->
+  | n @ Node _ ->
     l: SortedMap<K2, V2> = this.left;
     r: SortedMap<K2, V2> = this.right;
     k: K2 = this.key;
     v: V2 = this.value;
     compare(key, this.key) match {
     | LT() -> SortedMap::balance(k, v, l.setWith(key, value, f), r)
-    | EQ() -> SortedMap::node(k, f(v, value), l, r)
+    | EQ() ->
+      newV = f(v, value);
+      node: Node<K2, V2> = n;
+      node with {value => newV}
     | GT() -> SortedMap::balance(k, v, l, r.setWith(key, value, f))
     }
 

--- a/skiplang/prelude/src/stdlib/collections/persistent/SortedSet.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/SortedSet.sk
@@ -30,7 +30,8 @@ class .SortedSet<+T: Orderable>(
   }
 
   fun set<U: Orderable>[T: U](s: U): SortedSet<U> {
-    SortedSet(this.inner.set(s, void))
+    inner = this.inner.set(s, void);
+    if (phys_eq(inner, this.inner)) this else SortedSet(inner)
   }
 
   fun remove<U: Orderable>[T: U](s: U): SortedSet<U> {

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -2681,7 +2681,7 @@ extension class EagerDir {
   }
 }
 
-@cpp_extern("SKIP_unsafe_compare_sets")
+@cpp_extern("SKIP_physEq")
 native fun unsafeCompareSets(
   SortedMap<SKStore.Path, SortedSet<SKStore.ArrowKey>>,
   SortedMap<SKStore.Path, SortedSet<SKStore.ArrowKey>>,


### PR DESCRIPTION
I was trying to reduce the temporary garbage added by #886 by optimizing `SortedSet/Map` when the same element is added over and over again, by using **physical equality** as I would do in OCaml, though SKDB wasm tests are not happy with it, they throw an `unreachable` exception, e.g.
```
 Error: page.evaluate: unreachable executed
    .LSKIP_physEq_bitcast_invalid@http://127.0.0.1:8100/node_modules/skdb/dist/skipwasm-std/sk_types.js line 550 > WebAssembly.instantiate:wasm-function[1681]:0x20afb
    sk.SortedMap_Node__setWith.26@http://127.0.0.1:8100/node_modules/skdb/dist/skipwasm-std/sk_types.js line 550 > WebAssembly.instantiate:wasm-function[2466]:0x39616
```
Anyone knowledgeable with compilation to WASM has an idea on this?