### PR TITLE
Rewrite Context#updateLazyGets

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -633,6 +633,9 @@ mutable class Context private {
       (this.!lazyGetsQueue, lazyGets) = this.lazyGetsQueue.pop().fromSome();
       lazyGets
     };
+
+    if (this.lazyGets.isEmpty() && deadLazyGets.isEmpty()) return void;
+
     toRemove = mutable Map[];
     for (path in this.lazyGets) {
       refCount = this.lazyGetsRefCount.maybeGet(path) match {

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -650,39 +650,14 @@ mutable class Context private {
           (refCountsOpt is None() || deadKeysOpt is None())
         ) return refCountsOpt;
 
-        refCounts = refCountsOpt.default(SortedMap[]);
-        newKeys = newKeysOpt.default(SortedSet[]);
-        deadKeys = deadKeysOpt.default(SortedSet[]);
-
-        toRemove = mutable Vector[];
-        !refCounts = refCounts.mergeWith2(
-          newKeys.inner,
-          deadKeys.inner,
-          (key, refCountOpt, newOpt, deadOpt) -> {
-            (refCountOpt, newOpt, deadOpt) match {
-            | (_, None(), None())
-            | (_, Some(void), Some(void)) ->
-              refCountOpt
-            | (None(), None(), Some(void)) ->
-              // Not found, but since the aim is to remove them, we can do nothing.
-              refCountOpt
-            | (Some(1), None(), Some(void)) ->
-              toRemove.push(key);
-              None()
-            | _ ->
-              Some(
-                refCountOpt.default(0) +
-                  newOpt.maybe(0, (_: void) -> 1) -
-                  deadOpt.maybe(0, (_: void) -> 1),
-              )
-            }
-          },
+        dir = this.unsafeGetLazyDir(dirName);
+        (!refCountsOpt, dirOpt) = dir.updateLazyGets(
+          refCountsOpt,
+          newKeysOpt,
+          deadKeysOpt,
         );
-        if (!toRemove.isEmpty()) {
-          dir = this.unsafeGetLazyDir(dirName);
-          this.setDir(dir.removeKeys(toRemove))
-        };
-        if (refCounts.isEmpty()) None() else Some(refCounts)
+        dirOpt.each(this.setDir);
+        refCountsOpt
       },
     );
     this.!lazyGets = SortedMap[]

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -331,9 +331,14 @@ mutable class Context private {
   > = SortedMap[],
   mutable canReuse: CanReuse = CRIfMatch(),
   private mutable arrowStack: List<(ArrowKey, TimeStack)> = List[],
-  private mutable lazyGets: SortedSet<Path> = SortedSet[],
-  private mutable lazyGetsQueue: Queue<SortedSet<Path>> = Queue[],
-  private mutable lazyGetsRefCount: SortedMap<Path, Int> = SortedMap[],
+  private mutable lazyGets: SortedMap<DirName, SortedSet<Key>> = SortedMap[],
+  private mutable lazyGetsQueue: Queue<
+    SortedMap<DirName, SortedSet<Key>>,
+  > = Queue[],
+  private mutable lazyGetsRefCount: SortedMap<
+    DirName,
+    SortedMap<Key, Int>,
+  > = SortedMap[],
   private mutable sessions: SortedMap<Int, Sub> = SortedMap[],
   private mutable postponables: List<Postponable> = List[],
   private mutable dirsWithSharedSubDirs: SortedSet<DirName> = SortedSet[],
@@ -628,7 +633,7 @@ mutable class Context private {
   private mutable fun updateLazyGets(): void {
     this.!lazyGetsQueue = this.lazyGetsQueue.push(this.lazyGets);
     deadLazyGets = if (this.lazyGetsQueue.size() <= this.lazyCapacity) {
-      SortedSet[]
+      SortedMap[]
     } else {
       (this.!lazyGetsQueue, lazyGets) = this.lazyGetsQueue.pop().fromSome();
       lazyGets
@@ -636,41 +641,45 @@ mutable class Context private {
 
     if (this.lazyGets.isEmpty() && deadLazyGets.isEmpty()) return void;
 
-    toRemove = mutable Map[];
-    for (path in this.lazyGets) {
-      refCount = this.lazyGetsRefCount.maybeGet(path) match {
-      | None() -> 0
-      | Some(x) -> x
+    for (dirName => keys in this.lazyGets) {
+      refCounts = this.lazyGetsRefCount.maybeGet(dirName).default(SortedMap[]);
+      for (key in keys) {
+        !refCounts[key] = refCounts.maybeGet(key).default(0) + 1;
       };
-      this.!lazyGetsRefCount[path] = refCount + 1;
+      this.!lazyGetsRefCount[dirName] = refCounts;
     };
-    for (path in deadLazyGets) {
-      this.lazyGetsRefCount.maybeGet(path) match {
+    for (dirName => keys in deadLazyGets) {
+      this.lazyGetsRefCount.maybeGet(dirName) match {
       | None() ->
         // Not found, but since the aim is to remove them, we can do nothing.
         void
-      | Some(refCount) ->
-        !refCount = refCount - 1;
-        if (refCount == 0) {
-          this.!lazyGetsRefCount = this.lazyGetsRefCount.remove(path);
-          if (!toRemove.containsKey(path.dirName)) {
-            toRemove![path.dirName] = SortedSet[];
-          };
-          toRemove![path.dirName] = toRemove[path.dirName].set(path.baseName);
-        } else {
-          this.!lazyGetsRefCount[path] = refCount;
-        }
+      | Some(refCounts) ->
+        toRemove = SortedSet[];
+        for (key in keys) {
+          refCounts.maybeGet(key) match {
+          | None() ->
+            // Not found, but since the aim is to remove them, we can do nothing.
+            void
+          | Some(refCount) ->
+            !refCount = refCount - 1;
+            if (refCount <= 0) {
+              !refCounts = refCounts.remove(key);
+              !toRemove = toRemove.set(key);
+            }
+          }
+        };
+        this.!lazyGetsRefCount[dirName] = refCounts;
+        dir = this.unsafeGetLazyDir(dirName);
+        this.setDir(dir.removeKeys(toRemove))
       };
     };
-    for (dirName => keys in toRemove) {
-      dir = this.unsafeGetLazyDir(dirName);
-      this.setDir(dir.removeKeys(keys))
-    };
-    this.!lazyGets = SortedSet[]
+    this.!lazyGets = SortedMap[]
   }
 
   mutable fun addLazyGet(dirName: DirName, key: Key): void {
-    this.!lazyGets = this.lazyGets.set(Path::create(dirName, key))
+    this.!lazyGets[dirName] = this.lazyGets.maybeGet(dirName)
+      .default(SortedSet[])
+      .set(key)
   }
 
   mutable fun addDirty(dirName: DirName, key: Key): void {

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -641,38 +641,50 @@ mutable class Context private {
 
     if (this.lazyGets.isEmpty() && deadLazyGets.isEmpty()) return void;
 
-    for (dirName => keys in this.lazyGets) {
-      refCounts = this.lazyGetsRefCount.maybeGet(dirName).default(SortedMap[]);
-      for (key in keys) {
-        !refCounts[key] = refCounts.maybeGet(key).default(0) + 1;
-      };
-      this.!lazyGetsRefCount[dirName] = refCounts;
-    };
-    for (dirName => keys in deadLazyGets) {
-      this.lazyGetsRefCount.maybeGet(dirName) match {
-      | None() ->
-        // Not found, but since the aim is to remove them, we can do nothing.
-        void
-      | Some(refCounts) ->
-        toRemove = SortedSet[];
-        for (key in keys) {
-          refCounts.maybeGet(key) match {
-          | None() ->
-            // Not found, but since the aim is to remove them, we can do nothing.
-            void
-          | Some(refCount) ->
-            !refCount = refCount - 1;
-            if (refCount <= 0) {
-              !refCounts = refCounts.remove(key);
-              !toRemove = toRemove.set(key);
+    this.!lazyGetsRefCount = this.lazyGetsRefCount.mergeWith2(
+      this.lazyGets,
+      deadLazyGets,
+      (dirName, refCountsOpt, newKeysOpt, deadKeysOpt) -> {
+        if (
+          newKeysOpt is None() &&
+          (refCountsOpt is None() || deadKeysOpt is None())
+        ) return refCountsOpt;
+
+        refCounts = refCountsOpt.default(SortedMap[]);
+        newKeys = newKeysOpt.default(SortedSet[]);
+        deadKeys = deadKeysOpt.default(SortedSet[]);
+
+        toRemove = mutable Vector[];
+        !refCounts = refCounts.mergeWith2(
+          newKeys.inner,
+          deadKeys.inner,
+          (key, refCountOpt, newOpt, deadOpt) -> {
+            (refCountOpt, newOpt, deadOpt) match {
+            | (_, None(), None())
+            | (_, Some(void), Some(void)) ->
+              refCountOpt
+            | (None(), None(), Some(void)) ->
+              // Not found, but since the aim is to remove them, we can do nothing.
+              refCountOpt
+            | (Some(1), None(), Some(void)) ->
+              toRemove.push(key);
+              None()
+            | _ ->
+              Some(
+                refCountOpt.default(0) +
+                  newOpt.maybe(0, (_: void) -> 1) -
+                  deadOpt.maybe(0, (_: void) -> 1),
+              )
             }
-          }
+          },
+        );
+        if (!toRemove.isEmpty()) {
+          dir = this.unsafeGetLazyDir(dirName);
+          this.setDir(dir.removeKeys(toRemove))
         };
-        this.!lazyGetsRefCount[dirName] = refCounts;
-        dir = this.unsafeGetLazyDir(dirName);
-        this.setDir(dir.removeKeys(toRemove))
-      };
-    };
+        if (refCounts.isEmpty()) None() else Some(refCounts)
+      },
+    );
     this.!lazyGets = SortedMap[]
   }
 

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -332,7 +332,7 @@ mutable class Context private {
   mutable canReuse: CanReuse = CRIfMatch(),
   private mutable arrowStack: List<(ArrowKey, TimeStack)> = List[],
   private mutable lazyGets: SortedSet<Path> = SortedSet[],
-  private mutable lazyGetsQueue: Queue<Array<Path>> = Queue[],
+  private mutable lazyGetsQueue: Queue<SortedSet<Path>> = Queue[],
   private mutable lazyGetsRefCount: SortedMap<Path, Int> = SortedMap[],
   private mutable sessions: SortedMap<Int, Sub> = SortedMap[],
   private mutable postponables: List<Postponable> = List[],
@@ -633,7 +633,7 @@ mutable class Context private {
       };
       this.!lazyGetsRefCount[path] = refCount + 1;
     };
-    this.!lazyGetsQueue = this.lazyGetsQueue.push(this.lazyGets.toArray());
+    this.!lazyGetsQueue = this.lazyGetsQueue.push(this.lazyGets);
     this.!lazyGets = SortedSet[];
     if (this.lazyGetsQueue.size() <= this.lazyCapacity) return void;
     (this.!lazyGetsQueue, lazyGets) = this.lazyGetsQueue.pop().fromSome();

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -626,6 +626,14 @@ mutable class Context private {
   }
 
   private mutable fun updateLazyGets(): void {
+    this.!lazyGetsQueue = this.lazyGetsQueue.push(this.lazyGets);
+    deadLazyGets = if (this.lazyGetsQueue.size() <= this.lazyCapacity) {
+      SortedSet[]
+    } else {
+      (this.!lazyGetsQueue, lazyGets) = this.lazyGetsQueue.pop().fromSome();
+      lazyGets
+    };
+    toRemove = mutable Map[];
     for (path in this.lazyGets) {
       refCount = this.lazyGetsRefCount.maybeGet(path) match {
       | None() -> 0
@@ -633,12 +641,7 @@ mutable class Context private {
       };
       this.!lazyGetsRefCount[path] = refCount + 1;
     };
-    this.!lazyGetsQueue = this.lazyGetsQueue.push(this.lazyGets);
-    this.!lazyGets = SortedSet[];
-    if (this.lazyGetsQueue.size() <= this.lazyCapacity) return void;
-    (this.!lazyGetsQueue, lazyGets) = this.lazyGetsQueue.pop().fromSome();
-    toRemove = mutable Map[];
-    for (path in lazyGets) {
+    for (path in deadLazyGets) {
       this.lazyGetsRefCount.maybeGet(path) match {
       | None() ->
         // Not found, but since the aim is to remove them, we can do nothing.
@@ -659,7 +662,8 @@ mutable class Context private {
     for (dirName => keys in toRemove) {
       dir = this.unsafeGetLazyDir(dirName);
       this.setDir(dir.removeKeys(keys))
-    }
+    };
+    this.!lazyGets = SortedSet[]
   }
 
   mutable fun addLazyGet(dirName: DirName, key: Key): void {

--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -48,7 +48,49 @@ class LazyDir protected {
     }
   }
 
-  fun removeKeys(keys: readonly Vector<Key>): this {
+  /* Updates the lazyGets ref counts and return as well a potentially updated
+    LazyDir in which dead keys have been removed. */
+  fun updateLazyGets(
+    refCountsOpt: ?SortedMap<Key, Int>,
+    newKeysOpt: ?SortedSet<Key>,
+    deadKeysOpt: ?SortedSet<Key>,
+  ): (?SortedMap<Key, Int>, ?this) {
+    refCounts = refCountsOpt.default(SortedMap[]);
+    newKeys = newKeysOpt.default(SortedSet[]);
+    deadKeys = deadKeysOpt.default(SortedSet[]);
+
+    toRemove = mutable Vector[];
+    !refCounts = refCounts.mergeWith2(
+      newKeys.inner,
+      deadKeys.inner,
+      (key, refCountOpt, newOpt, deadOpt) -> {
+        (refCountOpt, newOpt, deadOpt) match {
+        | (_, None(), None())
+        | (_, Some(void), Some(void)) ->
+          refCountOpt
+        | (None(), None(), Some(void)) ->
+          // Not found, but since the aim is to remove them, we can do nothing.
+          refCountOpt
+        | (Some(1), None(), Some(void)) ->
+          toRemove.push(key);
+          None()
+        | _ ->
+          Some(
+            refCountOpt.default(0) +
+              newOpt.maybe(0, (_: void) -> 1) -
+              deadOpt.maybe(0, (_: void) -> 1),
+          )
+        }
+      },
+    );
+    dirOpt = if (toRemove.isEmpty()) None() else {
+      Some(this.removeKeys(toRemove))
+    };
+    !refCountsOpt = if (refCounts.isEmpty()) None() else Some(refCounts);
+    (refCountsOpt, dirOpt)
+  }
+
+  private fun removeKeys(keys: readonly Vector<Key>): this {
     data = this.data;
     for (key in keys) {
       data.maybeGet(key) match {

--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -48,7 +48,7 @@ class LazyDir protected {
     }
   }
 
-  fun removeKeys(keys: SortedSet<Key>): this {
+  fun removeKeys(keys: readonly Vector<Key>): this {
     data = this.data;
     for (key in keys) {
       data.maybeGet(key) match {

--- a/skiplang/prelude/src/stdlib/collections/persistent/SortedMap.sk
+++ b/skiplang/prelude/src/stdlib/collections/persistent/SortedMap.sk
@@ -414,6 +414,53 @@ base class .SortedMap<+K: Orderable, +V> uses  //  extends KeyedSequence<K, V>
     maps.foldl((m1, m2) -> m1.merge(m2), SortedMap::create())
   }
 
+  fun mergeWith2<K2: Orderable, U, W, R>[K: K2](
+    other1: SortedMap<K2, U>,
+    other2: SortedMap<K2, W>,
+    f: (K2, ?V, ?U, ?W) -> ?R,
+  ): SortedMap<K2, R> {
+    (this, other1, other2) match {
+    | (Nil(), Nil(), Nil()) -> Nil()
+    | (
+      Node{left => l0, key => k0, value => v0, right => r0, h},
+      _,
+      _,
+    ) if (h >= other1.height() && h >= other2.height()) ->
+      key: K2 = k0;
+      (l1, v1, r1) = other1.split(key);
+      (l2, v2, r2) = other2.split(key);
+      SortedMap::concatOrJoin(
+        key,
+        f(key, Some(v0), v1, v2),
+        l0.mergeWith2(l1, l2, f),
+        r0.mergeWith2(r1, r2, f),
+      )
+    | (
+      _,
+      Node{left => l1, key, value => v1, right => r1, h},
+      _,
+    ) if (h >= this.height() && h >= other2.height()) ->
+      (l0, v0, r0) = this.split(key);
+      (l2, v2, r2) = other2.split(key);
+      SortedMap::concatOrJoin(
+        key,
+        f(key, v0, Some(v1), v2),
+        l0.mergeWith2(l1, l2, f),
+        r0.mergeWith2(r1, r2, f),
+      )
+    | (_, _, Node{left => l2, key, value => v2, right => r2}) ->
+      (l0, v0, r0) = this.split(key);
+      (l1, v1, r1) = other1.split(key);
+      SortedMap::concatOrJoin(
+        key,
+        f(key, v0, v1, Some(v2)),
+        l0.mergeWith2(l1, l2, f),
+        r0.mergeWith2(r1, r2, f),
+      )
+    | _ -> invariant_violation("Nil should have a height smaller than a Node")
+    }
+  }
+
   /* Map and filter */
 
   fun map<V2>(f: (K, V) -> V2): SortedMap<K, V2>


### PR DESCRIPTION
Reduce number of places where unsafe casting will happen by reducing heterogeneous sets/maps by getting rid of usage of `Path`.
Skip doesn't support locally abstract types so move everything regarding keys to `Dir`s themselves