### PR TITLE
Prep for building node addon against precompiled skipruntime

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -54,7 +54,7 @@ jobs:
           submodules: true
       - run:
           name: Typecheck and lint typescript sources
-          command: SKIPRUNTIME=$(pwd)/build/skipruntime npm install && npm run build && npm run lint
+          command: make check-ts
 
   compiler:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ SKARGO_PROFILE?=release
 SKDB_WASM=sql/target/wasm32-unknown-unknown/$(SKARGO_PROFILE)/skdb.wasm
 SKDB_BIN=sql/target/host/$(SKARGO_PROFILE)/skdb
 SDKMAN_DIR?=$(HOME)/.sdkman
-SKIPRUNTIME?=$(CURDIR)/build/skipruntime
-
-export SKIPRUNTIME
 
 ################################################################################
 # skdb wasm + js client
@@ -73,9 +70,9 @@ check:
 	find * -name Skargo.toml -exec sh -c 'bin/cd_sh $$(dirname {}) "skargo check"' \;
 
 .PHONY: check-ts
-check-ts:
-	npm install
-	bin/check-ts.sh
+check-ts:	
+#	delegate to pick up build-time config for libskipruntime
+	${MAKE} -C skipruntime-ts check-ts
 
 .PHONY: check-sh
 check-sh:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
 # this builds the artifacts of this repository, orchestrating the
 # various build systems
 
-.PHONY: all
-all: npm build/skdb build/init.sql
+.PHONY: default
+default: check check-ts
 
 PLAYWRIGHT_REPORTER?="line"
 SKARGO_PROFILE?=release
 SKDB_WASM=sql/target/wasm32-unknown-unknown/$(SKARGO_PROFILE)/skdb.wasm
 SKDB_BIN=sql/target/host/$(SKARGO_PROFILE)/skdb
 SDKMAN_DIR?=$(HOME)/.sdkman
+
+.PHONY: skdb
+skdb: npm build/skdb build/init.sql
 
 ################################################################################
 # skdb wasm + js client

--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -2,20 +2,31 @@ SHELL := /bin/bash
 
 SKARGO_PROFILE?=release
 NPM_WORKSPACES=$(shell jq --raw-output "[.workspaces[] | select((startswith(\"sql\") or contains(\"examples\")) | not)] | map(\"-w \" + .) | .[]" ../package.json)
-SKIPRUNTIME?=$(realpath $(CURDIR)/..)/build/skipruntime
 
-export SKIPRUNTIME
+.PHONY: default
+default: install
+
+export LDFLAGS=-L$(realpath $(CURDIR)/..)/build/skipruntime/
+export LD_LIBRARY_PATH=$(realpath $(CURDIR)/..)/build/skipruntime/
+
+.PHONY: libskipruntime
+libskipruntime:
+	skargo build --release --lib --manifest-path=skiplang/ffi/Skargo.toml --out-dir=../build/skipruntime/
 
 .PHONY: install
-install:
+install: libskipruntime
 	../bin/cd_sh .. "npm install $(NPM_WORKSPACES)"
 
 .PHONY: install-all
-install-all:
+install-all: libskipruntime
 	../bin/cd_sh .. "npm install"
 
+.PHONY: check-ts
+check-ts: install-all
+	../bin/check-ts.sh
+
 .PHONY: build
-build:
+build: libskipruntime
 	../bin/cd_sh .. "npm run build $(NPM_WORKSPACES) --if-present"
 
 bunrun-%: build
@@ -42,7 +53,6 @@ nodeserver-%:
 clean:
 	make -C .. clean
 
-.PHONY: run-test
 run-test:
 	../bin/cd_sh tests "npm run test"
 

--- a/skipruntime-ts/addon/binding.gyp
+++ b/skipruntime-ts/addon/binding.gyp
@@ -11,7 +11,7 @@
       ],
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      "libraries": ["-L<!(realpath $SKIPRUNTIME) -lskipruntime -Wl,--require-defined=SKIP_new_Obstack"],
+      "libraries": ["-lskipruntime -Wl,--require-defined=SKIP_new_Obstack"],
     }
   ]
 }

--- a/skipruntime-ts/addon/binding.gyp
+++ b/skipruntime-ts/addon/binding.gyp
@@ -11,7 +11,7 @@
       ],
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      "libraries": ["-L<!(realpath $SKIPRUNTIME) -lskip-runtime-ts -Wl,--require-defined=SKIP_new_Obstack"],
+      "libraries": ["-L<!(realpath $SKIPRUNTIME) -lskipruntime -Wl,--require-defined=SKIP_new_Obstack"],
     }
   ]
 }

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -7,8 +7,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
-    "prepare": "skargo build -r --lib --manifest-path=../skiplang/ffi/Skargo.toml --out-dir=../../build/skipruntime",
-    "build": "skargo build -r --lib --manifest-path=../skiplang/ffi/Skargo.toml --out-dir=../../build/skipruntime && tsc && SKIPRUNTIME=$(realpath ../../build/skipruntime) node-gyp configure && node-gyp build",
+    "build": "tsc && node-gyp configure && node-gyp build",
     "clean": "rm -rf dist && node-gyp clean",
     "lint": "eslint"
   },

--- a/skipruntime-ts/skiplang/ffi/Skargo.toml
+++ b/skipruntime-ts/skiplang/ffi/Skargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "skip-runtime-ts"
+name = "skipruntime"
 version = "0.1.0"
 
 [dependencies]

--- a/skipruntime-ts/tests/examples/database.sh
+++ b/skipruntime-ts/tests/examples/database.sh
@@ -14,7 +14,7 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'database' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/database.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/database.js >/dev/null &
 else
     echo "Running 'database' example on @skipruntime/wasm"
     node dist/database.js >/dev/null &

--- a/skipruntime-ts/tests/examples/departures.sh
+++ b/skipruntime-ts/tests/examples/departures.sh
@@ -14,7 +14,7 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'departures' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/departures.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/departures.js >/dev/null &
 else
     echo "Running 'departures' example on @skipruntime/wasm"
     node dist/departures.js >/dev/null &

--- a/skipruntime-ts/tests/examples/groups.sh
+++ b/skipruntime-ts/tests/examples/groups.sh
@@ -14,7 +14,7 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'groups' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/groups.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/groups.js >/dev/null &
 else
     echo "Running 'groups' example on @skipruntime/wasm"
     node dist/groups.js >/dev/null &

--- a/skipruntime-ts/tests/examples/remote.sh
+++ b/skipruntime-ts/tests/examples/remote.sh
@@ -14,8 +14,8 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'remote' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/sum.js >/dev/null &
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/remote.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/sum.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/remote.js >/dev/null &
 else
     echo "Running 'remote' example on @skipruntime/wasm"
     node dist/sum.js >/dev/null &

--- a/skipruntime-ts/tests/examples/sheet.sh
+++ b/skipruntime-ts/tests/examples/sheet.sh
@@ -14,7 +14,7 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'sheet' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/sheet.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/sheet.js >/dev/null &
 else
     echo "Running 'sheet' example on @skipruntime/wasm"
     node dist/sheet.js >/dev/null &

--- a/skipruntime-ts/tests/examples/sum.sh
+++ b/skipruntime-ts/tests/examples/sum.sh
@@ -14,7 +14,7 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'sum' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/sum.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/sum.js >/dev/null &
 else
     echo "Running 'sum' example on @skipruntime/wasm"
     node dist/sum.js >/dev/null &

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "lint": "eslint src/",
-    "test": "LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) mocha"
+    "test": "mocha"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/skipruntime-ts/wasm/src/skipruntime_init.ts
+++ b/skipruntime-ts/wasm/src/skipruntime_init.ts
@@ -26,13 +26,13 @@ async function wasmUrl(): Promise<URL | string> {
   //@ts-expect-error  ImportMeta is incomplete
   if (import.meta.env || import.meta.webpack) {
     const imported = (await import(
-      //@ts-expect-error  Cannot find module './skstore.wasm?url' or its corresponding type declarations.
-      "./libskip-runtime-ts.wasm?url"
+      //@ts-expect-error  Cannot find module './libskipruntime.wasm?url' or its corresponding type declarations.
+      "./libskipruntime.wasm?url"
     )) as Imported;
     return imported.default;
   }
 
-  return new URL("./libskip-runtime-ts.wasm", import.meta.url);
+  return new URL("./libskipruntime.wasm", import.meta.url);
 }
 
 export async function initServiceFor(

--- a/sql/Makefile
+++ b/sql/Makefile
@@ -3,9 +3,6 @@ SHELL := /bin/bash
 SKARGO_PROFILE?=release
 
 SCRIPT_DIR=$(shell dirname $(shell realpath $(firstword $(MAKEFILE_LIST))))
-SKIPRUNTIME?=$(realpath $(SCRIPT_DIR)/..)/build/skipruntime
-
-export SKIPRUNTIME
 
 .PHONY: check-src
 check-src: build
@@ -20,7 +17,8 @@ check-all: check-src check-tests
 
 .PHONY: build
 build:
-	../bin/cd_sh .. "npm install && npm run build -w skdb -w skdb-tests"
+	${MAKE} -C ../skipruntime-ts install-all
+	../bin/cd_sh .. "npm run build -w skdb -w skdb-tests"
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This PR changes the build in preparation for building the native node addon against a precompiled skipruntime library. The aim is to enable end users to first install the binary skip runtime to their host and then install the addon just as a standard npm dependency, without needing to build the skiplang toolchain or have it installed. To this end, this PR:

- adapts the npm build (package.json and binding.gyp files) to expect the skipruntime library to be installed on the host;

- adapts the dev build (Makefiles) to build the skipruntime library from the current sources, and set the other builds and tests to use this current version.

At a high level, what this means is that the `npm` commands use the host-installed skipruntime, and are therefore meant for use by end users; while the `make` commands use the skipruntime built from current sources, and are therefore meant for development and testing use.