### PR TITLE
[www] fixing landing page redirection - Fix #598

### DIFF
--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -53,6 +53,7 @@ const config: Config = {
       logo: {
         alt: "Skip Logo",
         src: "img/logo.svg",
+        href: "https://skiplabs.io/",
       },
       items: [
         {


### PR DESCRIPTION
The third-party provides `/`. But when we click in the upper-left logo, we navigate to our `/` which is unfortunate. 

See [Vercel's documantion](https://vercel.com/docs/project-configuration#redirects).