### PR TITLE
[SKStore] TLazyDir

### DIFF
--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -17,11 +17,7 @@ base class LazyResult<F> {
   | LAbsent()
 }
 
-base class LazyDir protected {
-  protected data: SortedMap<Key, LazyResult<File>> = SortedMap[],
-  protected lazyFun: (mutable Context, DirName, Key) ~> ?Array<File>,
-  protected collect: Bool,
-} extends TDir {
+base class LazyDir protected {protected collect: Bool} extends Dir {
   /* Updates the lazyGets ref counts and return as well a potentially updated
     LazyDir in which dead keys have been removed. */
   fun updateLazyGets(
@@ -38,7 +34,10 @@ base class LazyDir protected {
   fun typed(): TLazyDir;
 }
 
-class TLazyDir extends LazyDir, TDir {
+class TLazyDir{
+  protected data: SortedMap<Key, LazyResult<File>> = SortedMap[],
+  protected lazyFun: (mutable Context, DirName, Key) ~> ?Array<File>,
+} extends LazyDir, TDir {
   fun updateLazyGets(
     refCountsOpt: ?SortedMap<Key, Int>,
     newKeysOpt: ?SortedSet<Key>,

--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -125,7 +125,7 @@ base class LazyDir protected {
   protected fun doGet(context: mutable Context, key: Key): LazyResult<File> {
     dirName = this.dirName;
 
-    dir = context.unsafeGetLazyDir(dirName);
+    dir = context.unsafeGetLazyDir(dirName).typed();
     !dir.data[key] = LCycle();
     context.setDir(dir);
 
@@ -136,7 +136,7 @@ base class LazyDir protected {
       this.lazyFun(context, dirName, key)
     } catch {
     | exn ->
-      !dir = context.unsafeGetLazyDir(dirName);
+      !dir = context.unsafeGetLazyDir(dirName).typed();
       !dir.data[key] = LAbsent();
       context.setDir(dir);
       context.!reads = readsCopy;
@@ -155,7 +155,7 @@ base class LazyDir protected {
     };
     context.updateNewDeps(arrowKey, context.reads);
 
-    !dir = context.unsafeGetLazyDir(dirName);
+    !dir = context.unsafeGetLazyDir(dirName).typed();
     !dir.data[key] = result;
     context.setDir(dir);
 
@@ -220,7 +220,7 @@ class TLazyDir extends LazyDir, TDir {
     collect: Bool = true,
   ): Dir {
     context.maybeGetLazyDir(dirName) match {
-    | Some(ldir) if (native_eq(ldir.lazyFun, lazyFun) == 0) ->
+    | Some(ldir) if (native_eq(ldir.typed().lazyFun, lazyFun) == 0) ->
       if (context.debugMode) {
         print_string(`REUSING: ${dirName}`);
       };

--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -28,6 +28,21 @@ base class LazyDir protected {
     refCountsOpt: ?SortedMap<Key, Int>,
     newKeysOpt: ?SortedSet<Key>,
     deadKeysOpt: ?SortedSet<Key>,
+  ): (?SortedMap<Key, Int>, ?this);
+
+  fun update(
+    context: mutable Context,
+    dirtyReadersOpt: ?SortedMap<DirName, SortedSet<Key>>,
+  ): void;
+
+  fun typed(): TLazyDir;
+}
+
+class TLazyDir extends LazyDir, TDir {
+  fun updateLazyGets(
+    refCountsOpt: ?SortedMap<Key, Int>,
+    newKeysOpt: ?SortedSet<Key>,
+    deadKeysOpt: ?SortedSet<Key>,
   ): (?SortedMap<Key, Int>, ?this) {
     refCounts = refCountsOpt.default(SortedMap[]);
     newKeys = newKeysOpt.default(SortedSet[]);
@@ -205,10 +220,6 @@ base class LazyDir protected {
     this.getArray(context, key).iterator()
   }
 
-  fun typed(): TLazyDir;
-}
-
-class TLazyDir extends LazyDir, TDir {
   fun typed(): this {
     this
   }

--- a/skiplang/prelude/tests/skfs/TestFramework.sk
+++ b/skiplang/prelude/tests/skfs/TestFramework.sk
@@ -18,7 +18,7 @@ fun getData(
   | SKStore.DeletedDir _ ->
     invariant_violation("Trying to write to an empty directory")
   | edir @ SKStore.EagerDir _ -> edir.getArrayRaw(key)
-  | ldir @ SKStore.LazyDir _ -> ldir.unsafeGetArray(context, key)
+  | ldir @ SKStore.LazyDir _ -> ldir.typed().unsafeGetArray(context, key)
   }
 }
 


### PR DESCRIPTION
Moving fields and methods using `Key` and `File` from `LazyDir` to `TLazyDir`.

Based on #936 