### PR TITLE
[SKStore] KeySets

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -649,11 +649,12 @@ mutable class Context private {
     this.!lazyGets = SortedMap[]
   }
 
-  mutable fun addLazyGet(dir: LazyDir, key: Key): void {
+  mutable fun addLazyGet(dir: TLazyDir, key: Key): void {
     dirName = dir.dirName;
-    this.!lazyGets[dirName] = this.lazyGets.maybeGet(dirName)
-      .default(SortedSet[])
-      .set(key)
+    this.!lazyGets[dirName] = dir.addKeyToSetOpt(
+      key,
+      this.lazyGets.maybeGet(dirName),
+    )
   }
 
   mutable fun addDirty(dir: EagerDir, key: Key): void {

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -344,7 +344,7 @@ mutable class Context private {
   private mutable dirty: SortedMap<DirName, KeySet> = SortedMap[],
   private mutable dirtyReaders: /* parentName => childName => keys */ SortedMap<
     DirName,
-    SortedMap<DirName, SortedSet<Key>>,
+    SortedMap<DirName, KeySet>,
   > = SortedMap[],
   mutable canReuse: CanReuse = CRIfMatch(),
   private mutable arrowStack: List<(ArrowKey, TimeStack)> = List[],
@@ -593,7 +593,10 @@ mutable class Context private {
         );
         map.set(
           reader.childName,
-          map.maybeGet(reader.childName).default(SortedSet[]).set(reader.key),
+          parent.addReaderKeyToKeySetOpt(
+            reader,
+            map.maybeGet(reader.childName),
+          ),
         )
       };
       time = if (reader.parentName == reader.childName) {

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -657,12 +657,9 @@ mutable class Context private {
     )
   }
 
-  mutable fun addDirty(dir: EagerDir, key: Key): void {
+  mutable fun addDirty(dir: TEagerDir, key: Key): void {
     dirName = dir.dirName;
-    this.!dirty[dirName] = this.dirty.maybeGet(dirName) match {
-    | None() -> SortedSet[key]
-    | Some(set) -> set.set(key)
-    }
+    this.!dirty[dirName] = dir.addKeyToSetOpt(key, this.dirty.maybeGet(dirName))
   }
 
   mutable fun update(): void {

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -348,13 +348,11 @@ mutable class Context private {
   > = SortedMap[],
   mutable canReuse: CanReuse = CRIfMatch(),
   private mutable arrowStack: List<(ArrowKey, TimeStack)> = List[],
-  private mutable lazyGets: SortedMap<DirName, SortedSet<Key>> = SortedMap[],
-  private mutable lazyGetsQueue: Queue<
-    SortedMap<DirName, SortedSet<Key>>,
-  > = Queue[],
+  private mutable lazyGets: SortedMap<DirName, KeySet> = SortedMap[],
+  private mutable lazyGetsQueue: Queue<SortedMap<DirName, KeySet>> = Queue[],
   private mutable lazyGetsRefCount: SortedMap<
     DirName,
-    SortedMap<Key, Int>,
+    KeyMap<Int>,
   > = SortedMap[],
   private mutable sessions: SortedMap<Int, Sub> = SortedMap[],
   private mutable postponables: List<Postponable> = List[],
@@ -654,7 +652,7 @@ mutable class Context private {
 
   mutable fun addLazyGet(dir: TLazyDir, key: Key): void {
     dirName = dir.dirName;
-    this.!lazyGets[dirName] = dir.addKeyToSetOpt(
+    this.!lazyGets[dirName] = dir.addKeyToKeySetOpt(
       key,
       this.lazyGets.maybeGet(dirName),
     )

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -341,7 +341,7 @@ mutable class Context private {
   mutable newDirs: SortedSet<DirName> = SortedSet[],
   mutable globals: SortedMap<String, File> = SortedMap[],
   private mutable persistents: SortedMap<String, File> = SortedMap[],
-  private mutable dirty: SortedMap<DirName, SortedSet<Key>> = SortedMap[],
+  private mutable dirty: SortedMap<DirName, KeySet> = SortedMap[],
   private mutable dirtyReaders: /* parentName => childName => keys */ SortedMap<
     DirName,
     SortedMap<DirName, SortedSet<Key>>,
@@ -659,7 +659,10 @@ mutable class Context private {
 
   mutable fun addDirty(dir: TEagerDir, key: Key): void {
     dirName = dir.dirName;
-    this.!dirty[dirName] = dir.addKeyToSetOpt(key, this.dirty.maybeGet(dirName))
+    this.!dirty[dirName] = dir.addKeyToKeySetOpt(
+      key,
+      this.dirty.maybeGet(dirName),
+    )
   }
 
   mutable fun update(): void {

--- a/skiplang/prelude/src/skstore/Dir.sk
+++ b/skiplang/prelude/src/skstore/Dir.sk
@@ -54,6 +54,10 @@ base class TDir extends Dir {
    * Returns the list of files in a directory. Should only be used for testing.
    */
   fun keys(): SortedSet<Key>;
+
+  fun addKeyToSetOpt(key: Key, keySetOpt: ?SortedSet<Key>): SortedSet<Key> {
+    keySetOpt.default(SortedSet[]).set(key)
+  }
 }
 
 /*****************************************************************************/

--- a/skiplang/prelude/src/skstore/Dir.sk
+++ b/skiplang/prelude/src/skstore/Dir.sk
@@ -55,12 +55,18 @@ base class TDir extends Dir {
    */
   fun keys(): SortedSet<Key>;
 
+  fun castKeySet(keySet: KeySet): TKeySet {
+    keySet match {
+    | ks @ TKeySet _ -> ks
+    }
+  }
+
   fun addKeyToSetOpt(key: Key, keySetOpt: ?SortedSet<Key>): SortedSet<Key> {
     keySetOpt.default(SortedSet[]).set(key)
   }
 
   fun addKeyToKeySetOpt(key: Key, keySetOpt: ?KeySet): KeySet {
-    keySetOpt.default(KeySet::empty()).set(key)
+    keySetOpt.map(this.castKeySet).default(TKeySet::empty()).set(key)
   }
 }
 

--- a/skiplang/prelude/src/skstore/Dir.sk
+++ b/skiplang/prelude/src/skstore/Dir.sk
@@ -58,6 +58,10 @@ base class TDir extends Dir {
   fun addKeyToSetOpt(key: Key, keySetOpt: ?SortedSet<Key>): SortedSet<Key> {
     keySetOpt.default(SortedSet[]).set(key)
   }
+
+  fun addKeyToKeySetOpt(key: Key, keySetOpt: ?KeySet): KeySet {
+    keySetOpt.default(KeySet::empty()).set(key)
+  }
 }
 
 /*****************************************************************************/

--- a/skiplang/prelude/src/skstore/Dir.sk
+++ b/skiplang/prelude/src/skstore/Dir.sk
@@ -27,6 +27,8 @@ base class Dir protected {timeStack: TimeStack, dirName: DirName} {
   }
 
   fun typed(): TDir;
+
+  fun addReaderKeyToKeySetOpt(arrowKey: ArrowKey, keySetOpt: ?KeySet): KeySet;
 }
 
 base class TDir extends Dir {
@@ -65,6 +67,10 @@ base class TDir extends Dir {
 
   fun addKeyToKeySetOpt(key: Key, keySetOpt: ?KeySet): KeySet {
     keySetOpt.map(this.castKeySet).default(TKeySet::empty()).set(key)
+  }
+
+  fun addReaderKeyToKeySetOpt(arrowKey: ArrowKey, keySetOpt: ?KeySet): KeySet {
+    this.addKeyToKeySetOpt(arrowKey.key, keySetOpt)
   }
 }
 

--- a/skiplang/prelude/src/skstore/Dir.sk
+++ b/skiplang/prelude/src/skstore/Dir.sk
@@ -55,10 +55,8 @@ base class TDir extends Dir {
    */
   fun keys(): SortedSet<Key>;
 
-  fun castKeySet(keySet: KeySet): TKeySet {
-    keySet match {
-    | ks @ TKeySet _ -> ks
-    }
+  fun castKeySet(keySet: KeySet): TKeySet<Key> {
+    Unsafe.cast(keySet, TKeySet<Key>)
   }
 
   fun addKeyToSetOpt(key: Key, keySetOpt: ?SortedSet<Key>): SortedSet<Key> {

--- a/skiplang/prelude/src/skstore/Dir.sk
+++ b/skiplang/prelude/src/skstore/Dir.sk
@@ -65,16 +65,20 @@ base class TDir extends Dir {
     keySetOpt.map(this.castKeySet).default(TKeySet::empty())
   }
 
-  fun addKeyToSetOpt(key: Key, keySetOpt: ?SortedSet<Key>): SortedSet<Key> {
-    keySetOpt.default(SortedSet[]).set(key)
-  }
-
   fun addKeyToKeySetOpt(key: Key, keySetOpt: ?KeySet): KeySet {
     this.castOrEmptyKeySet(keySetOpt).set(key)
   }
 
   fun addReaderKeyToKeySetOpt(arrowKey: ArrowKey, keySetOpt: ?KeySet): KeySet {
     this.addKeyToKeySetOpt(arrowKey.key, keySetOpt)
+  }
+
+  fun castKeyMap<V: frozen>(keyMap: KeyMap<V>): TKeyMap<Key, V> {
+    Unsafe.cast(keyMap, TKeyMap<Key, V>)
+  }
+
+  fun castOrEmptyKeyMap<V: frozen>(keyMapOpt: ?KeyMap<V>): TKeyMap<Key, V> {
+    keyMapOpt.map(this.castKeyMap).default(TKeyMap::empty())
   }
 }
 

--- a/skiplang/prelude/src/skstore/Dir.sk
+++ b/skiplang/prelude/src/skstore/Dir.sk
@@ -61,12 +61,16 @@ base class TDir extends Dir {
     Unsafe.cast(keySet, TKeySet<Key>)
   }
 
+  fun castOrEmptyKeySet(keySetOpt: ?KeySet): TKeySet<Key> {
+    keySetOpt.map(this.castKeySet).default(TKeySet::empty())
+  }
+
   fun addKeyToSetOpt(key: Key, keySetOpt: ?SortedSet<Key>): SortedSet<Key> {
     keySetOpt.default(SortedSet[]).set(key)
   }
 
   fun addKeyToKeySetOpt(key: Key, keySetOpt: ?KeySet): KeySet {
-    keySetOpt.map(this.castKeySet).default(TKeySet::empty()).set(key)
+    this.castOrEmptyKeySet(keySetOpt).set(key)
   }
 
   fun addReaderKeyToKeySetOpt(arrowKey: ArrowKey, keySetOpt: ?KeySet): KeySet {

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -1464,7 +1464,7 @@ base class EagerDir protected {
     parentDirtyOpt match {
     | None() -> void
     | Some(dirtyKeys) ->
-      keys = dirtyKeys.values();
+      keys = parent.typed().castKeySet(dirtyKeys).values();
       !dirty = withRegionFold(None(), keys, dirty, (_, key, dirtyInRegion) ~> {
         for (p in parentMaps) {
           (_, rangeOpt, _) = p;

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -1655,7 +1655,7 @@ base class EagerDir protected {
       Some(cdata)
     };
 
-    context.addDirty(this, k);
+    context.addDirty(this.typed(), k);
     path = Path::create(this.dirName, k);
 
     if (this.totalSize != totalSize) {

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -1421,7 +1421,7 @@ base class EagerDir protected {
     /* this is the parent */
     context: mutable Context,
     parentDirtyOpt: ?KeySet,
-    contextDirtyReadersOpt: ?SortedMap<DirName, SortedSet<Key>>,
+    contextDirtyReadersOpt: ?SortedMap<DirName, KeySet>,
     parentMaps: Array<
       (
         MapFun<Key, File>,
@@ -1443,7 +1443,7 @@ base class EagerDir protected {
       contextDirtyReaders.maybeGet(childName) match {
       | None() -> void
       | Some(dirtyKeys) ->
-        keys = dirtyKeys.values();
+        keys = parent.typed().castKeySet(dirtyKeys).values();
         !dirty = withRegionFold(None(), keys, dirty, (_, key, dirtyInRegion) ~> {
           for (p in parentMaps) {
             (_, rangeOpt, _) = p;

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -1420,7 +1420,7 @@ base class EagerDir protected {
   fun update(
     /* this is the parent */
     context: mutable Context,
-    parentDirtyOpt: ?SortedSet<Key>,
+    parentDirtyOpt: ?KeySet,
     contextDirtyReadersOpt: ?SortedMap<DirName, SortedSet<Key>>,
     parentMaps: Array<
       (

--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -28,7 +28,7 @@ base class LazyDir protected {protected collect: Bool} extends Dir {
 
   fun update(
     context: mutable Context,
-    dirtyReadersOpt: ?SortedMap<DirName, SortedSet<Key>>,
+    dirtyReadersOpt: ?SortedMap<DirName, KeySet>,
   ): void;
 
   fun typed(): TLazyDir;
@@ -108,13 +108,13 @@ class TLazyDir{
 
   fun update(
     context: mutable Context,
-    dirtyReadersOpt: ?SortedMap<DirName, SortedSet<Key>>,
+    dirtyReadersOpt: ?SortedMap<DirName, KeySet>,
   ): void {
     dirtyReadersOpt match {
     | None() -> void
     | Some(dirtyReaders) ->
       for (dirtyReaderDirName => dirtyReaderKeys in dirtyReaders) {
-        for (key in dirtyReaderKeys) {
+        for (key in this.castKeySet(dirtyReaderKeys)) {
           oldValue = this.data.maybeGet(key);
           !this.data = this.data.remove(key);
           context.updateDirtyReaders(Path::create(dirtyReaderDirName, key));

--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -21,10 +21,10 @@ base class LazyDir protected {protected collect: Bool} extends Dir {
   /* Updates the lazyGets ref counts and return as well a potentially updated
     LazyDir in which dead keys have been removed. */
   fun updateLazyGets(
-    refCountsOpt: ?SortedMap<Key, Int>,
-    newKeysOpt: ?SortedSet<Key>,
-    deadKeysOpt: ?SortedSet<Key>,
-  ): (?SortedMap<Key, Int>, ?this);
+    refCountsOpt: ?KeyMap<Int>,
+    newKeysOpt: ?KeySet,
+    deadKeysOpt: ?KeySet,
+  ): (?KeyMap<Int>, ?this);
 
   fun update(
     context: mutable Context,
@@ -39,18 +39,18 @@ class TLazyDir{
   protected lazyFun: (mutable Context, DirName, Key) ~> ?Array<File>,
 } extends LazyDir, TDir {
   fun updateLazyGets(
-    refCountsOpt: ?SortedMap<Key, Int>,
-    newKeysOpt: ?SortedSet<Key>,
-    deadKeysOpt: ?SortedSet<Key>,
-  ): (?SortedMap<Key, Int>, ?this) {
-    refCounts = refCountsOpt.default(SortedMap[]);
-    newKeys = newKeysOpt.default(SortedSet[]);
-    deadKeys = deadKeysOpt.default(SortedSet[]);
+    refCountsOpt: ?KeyMap<Int>,
+    newKeysOpt: ?KeySet,
+    deadKeysOpt: ?KeySet,
+  ): (?KeyMap<Int>, ?this) {
+    refCounts = this.castOrEmptyKeyMap(refCountsOpt);
+    newKeys = this.castOrEmptyKeySet(newKeysOpt);
+    deadKeys = this.castOrEmptyKeySet(deadKeysOpt);
 
     toRemove = mutable Vector[];
     !refCounts = refCounts.mergeWith2(
-      newKeys.inner,
-      deadKeys.inner,
+      newKeys.getInner(),
+      deadKeys.getInner(),
       (key, refCountOpt, newOpt, deadOpt) -> {
         (refCountOpt, newOpt, deadOpt) match {
         | (_, None(), None())

--- a/skiplang/prelude/src/skstore/Path.sk
+++ b/skiplang/prelude/src/skstore/Path.sk
@@ -247,7 +247,9 @@ class SID(value: String) extends Key {
   }
 }
 
-class KeySet private (inner: SortedSet<Key>) {
+base class KeySet
+
+class TKeySet private (inner: SortedSet<Key>) extends KeySet {
   static fun empty(): this {
     static(SortedSet[])
   }

--- a/skiplang/prelude/src/skstore/Path.sk
+++ b/skiplang/prelude/src/skstore/Path.sk
@@ -247,18 +247,18 @@ class SID(value: String) extends Key {
   }
 }
 
-base class KeySet
+base class KeySet uses Unsafe.Downcastable
 
-class TKeySet private (inner: SortedSet<Key>) extends KeySet {
+class TKeySet<+K: Orderable> private (inner: SortedSet<K>) extends KeySet {
   static fun empty(): this {
     static(SortedSet[])
   }
 
-  fun set(key: Key): this {
-    static(this.inner.set(key))
+  fun set<K2: Orderable>[K: K2](key: K2): TKeySet<K2> {
+    TKeySet(this.inner.set(key))
   }
 
-  fun values(): mutable Iterator<Key> {
+  fun values(): mutable Iterator<K> {
     this.inner.values()
   }
 }

--- a/skiplang/prelude/src/skstore/Path.sk
+++ b/skiplang/prelude/src/skstore/Path.sk
@@ -263,6 +263,23 @@ class TKeySet<+K: Orderable> private (inner: SortedSet<K>) extends KeySet {
   }
 }
 
+base class KeyMap<+V> uses Unsafe.Downcastable
+
+class TKeyMap<+K: Orderable, +V: frozen> private (
+  inner: SortedMap<K, V>,
+) extends KeyMap<V> {
+  static fun empty(): this {
+    static(SortedMap[])
+  }
+
+  fun set<K2: Orderable, V2: frozen>[K: K2, V: V2](
+    key: K2,
+    value: V2,
+  ): TKeyMap<K2, V2> {
+    TKeyMap(this.inner.set(key, value))
+  }
+}
+
 base class Exception extends .Exception uses Show
 
 fun error<T>(msg: String): T {

--- a/skiplang/prelude/src/skstore/Path.sk
+++ b/skiplang/prelude/src/skstore/Path.sk
@@ -247,6 +247,8 @@ class SID(value: String) extends Key {
   }
 }
 
+class KeySet private (inner: SortedSet<Key>) {}
+
 base class Exception extends .Exception uses Show
 
 fun error<T>(msg: String): T {

--- a/skiplang/prelude/src/skstore/Path.sk
+++ b/skiplang/prelude/src/skstore/Path.sk
@@ -261,6 +261,10 @@ class TKeySet<+K: Orderable> private (inner: SortedSet<K>) extends KeySet {
   fun values(): mutable Iterator<K> {
     this.inner.values()
   }
+
+  fun getInner(): TKeyMap<K, void> {
+    TKeyMap<K, void>::ofKeySet(this)
+  }
 }
 
 base class KeyMap<+V> uses Unsafe.Downcastable
@@ -272,11 +276,27 @@ class TKeyMap<+K: Orderable, +V: frozen> private (
     static(SortedMap[])
   }
 
+  static fun ofKeySet[V: void](set: TKeySet<K>): TKeyMap<K, void> {
+    TKeyMap<K, void>(set.inner.inner)
+  }
+
+  fun isEmpty(): Bool {
+    this.inner.isEmpty()
+  }
+
   fun set<K2: Orderable, V2: frozen>[K: K2, V: V2](
     key: K2,
     value: V2,
   ): TKeyMap<K2, V2> {
     TKeyMap(this.inner.set(key, value))
+  }
+
+  fun mergeWith2<K2: Orderable, U: frozen, W: frozen, R: frozen>[K: K2](
+    other1: TKeyMap<K2, U>,
+    other2: TKeyMap<K2, W>,
+    f: (K2, ?V, ?U, ?W) -> ?R,
+  ): TKeyMap<K2, R> {
+    TKeyMap(this.inner.mergeWith2(other1.inner, other2.inner, f))
   }
 }
 

--- a/skiplang/prelude/src/skstore/Path.sk
+++ b/skiplang/prelude/src/skstore/Path.sk
@@ -247,7 +247,19 @@ class SID(value: String) extends Key {
   }
 }
 
-class KeySet private (inner: SortedSet<Key>) {}
+class KeySet private (inner: SortedSet<Key>) {
+  static fun empty(): this {
+    static(SortedSet[])
+  }
+
+  fun set(key: Key): this {
+    static(this.inner.set(key))
+  }
+
+  fun values(): mutable Iterator<Key> {
+    this.inner.values()
+  }
+}
 
 base class Exception extends .Exception uses Show
 


### PR DESCRIPTION
A `KeySet` is a `SortedSet<K>` for an existing `K`.

We need them because we have heterogeneous collections of sets of keys.

Based on #937