### PR TITLE
[SKStore] Generic data structures (part 2)

### DIFF
--- a/skiplang/prelude/src/core/Downcastable.sk
+++ b/skiplang/prelude/src/core/Downcastable.sk
@@ -2,6 +2,10 @@ module Unsafe;
 
 @debug
 @cpp_extern("SKIP_unsafe_cast")
+native fun unsafeGenericCast<T, U>(t: T): U;
+
+@debug
+@cpp_extern("SKIP_unsafe_cast")
 native fun unsafeCast<T: Downcastable, F: T>(t: T): F;
 
 trait Downcastable {

--- a/skiplang/prelude/src/core/Downcastable.sk
+++ b/skiplang/prelude/src/core/Downcastable.sk
@@ -32,4 +32,23 @@ fun instanceOf<T: Downcastable, F: T>(v: T, c: Concrete<F>): Bool {
   v.type_id() == c::const_type_id()
 }
 
+fun unsafeSpecializeFactory<
+  Static: Downcastable,
+  Special: Downcastable,
+  Factory,
+  SpecialFactory,
+  DefaultFactory: Factory,
+>(
+  static_: Concrete<Static>,
+  special: Concrete<Special>,
+  specialFactory: Concrete<SpecialFactory>,
+  defaultFactory: Concrete<DefaultFactory>,
+): Concrete<Factory> {
+  if (static_::const_type_id() == special::const_type_id()) {
+    unsafeGenericCast(specialFactory)
+  } else {
+    defaultFactory
+  }
+}
+
 module end;

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -873,7 +873,7 @@ mutable class Context private {
       }
     });
 
-    vector: mutable Vector<FixedRow<Key, Array<V>>> = mutable Vector[];
+    vector: mutable Vector<FixedRow<Key, Array<File>>> = mutable Vector[];
 
     n = content.size();
     if (n > 0) {
@@ -892,7 +892,7 @@ mutable class Context private {
           !values = valueAcc.toArray();
         };
         source = Path::create(dirName, key);
-        vector.push(FixedRow<Key, Array<V>>(key, values, source, tickRange));
+        vector.push(FixedRow<Key, Array<File>>(key, values, source, tickRange));
       };
     };
     fixedData = FixedDataMap::create(vector);

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -520,7 +520,7 @@ class DataMap<K: Orderable> private {
 class FixedDataMap{
   data: FixedData<Key, Array<File>>,
   tombs: FixedDir<Key, Path>,
-} {
+} uses Unsafe.Downcastable {
   private static fun fixedDataFactory(): Concrete<
     FixedDataFactory<Key, Array<File>>,
   > {

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -521,11 +521,17 @@ class FixedDataMap{
   data: FixedData<Key, Array<File>>,
   tombs: FixedDir<Key, Path>,
 } {
+  private static fun fixedDataFactory(): Concrete<
+    FixedDataFactory<Key, Array<File>>,
+  > {
+    CompactFixedDir
+  }
+
   static fun create<V: File>(
     vec: mutable Vector<FixedRow<Key, Array<V>>> = mutable Vector[],
     tombs: mutable Vector<FixedRow<Key, Path>> = mutable Vector[],
   ): this {
-    data = CompactFixedDir::create(vec);
+    data = static::fixedDataFactory()::create(vec);
     static{data, tombs => FixedDir::create(tombs)}
   }
 

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -517,26 +517,26 @@ class DataMap<K: Orderable> private {
   }
 }
 
-class FixedDataMap{
-  data: FixedData<Key, Array<File>>,
-  tombs: FixedDir<Key, Path>,
+class FixedDataMap<K: Orderable>{
+  data: FixedData<K, Array<File>>,
+  tombs: FixedDir<K, Path>,
 } uses Unsafe.Downcastable {
   private static fun fixedDataFactory(): Concrete<
-    FixedDataFactory<Key, Array<File>>,
+    FixedDataFactory<K, Array<File>>,
   > {
     // Does not work as expected if types are not explicitly given
     Unsafe.unsafeSpecializeFactory<
-      FixedDataMap,
-      FixedDataMap,
-      FixedDataFactory<Key, Array<File>>,
+      FixedDataMap<K>,
+      FixedDataMap<Key>,
+      FixedDataFactory<K, Array<File>>,
       CompactFixedDir,
-      FixedDir<Key, Array<File>>,
-    >(static, FixedDataMap, CompactFixedDir, FixedDir<Key, Array<File>>)
+      FixedDir<K, Array<File>>,
+    >(static, FixedDataMap, CompactFixedDir, FixedDir<K, Array<File>>)
   }
 
   static fun create<V: File>(
-    vec: mutable Vector<FixedRow<Key, Array<V>>> = mutable Vector[],
-    tombs: mutable Vector<FixedRow<Key, Path>> = mutable Vector[],
+    vec: mutable Vector<FixedRow<K, Array<V>>> = mutable Vector[],
+    tombs: mutable Vector<FixedRow<K, Path>> = mutable Vector[],
   ): this {
     data = static::fixedDataFactory()::create(vec);
     static{data, tombs => FixedDir::create(tombs)}
@@ -546,11 +546,11 @@ class FixedDataMap{
     this.data.size() + this.tombs.size()
   }
 
-  fun getChangesAfter(tick: Tick): SortedSet<Key> {
+  fun getChangesAfter(tick: Tick): SortedSet<K> {
     this.data.getChangesAfter(tick).union(this.tombs.getChangesAfter(tick))
   }
 
-  fun getIterAll(): mutable Iterator<(Tick, Path, Path, Key, Array<File>)> {
+  fun getIterAll(): mutable Iterator<(Tick, Path, Path, K, Array<File>)> {
     iter1 = this.data.iterator();
     iter2 = this.tombs.data.iterator();
     left = iter1.next();
@@ -578,7 +578,7 @@ class FixedDataMap{
     }
   }
 
-  fun getIter(key: Key): mutable Iterator<(Tick, Path, Path, Array<File>)> {
+  fun getIter(key: K): mutable Iterator<(Tick, Path, Path, Array<File>)> {
     iter1 = this.data.getIter(key);
     iter2 = this.tombs.getIter(key);
     left = iter1.next();
@@ -608,7 +608,7 @@ class FixedDataMap{
 
   fun getIterAfter(
     tick: Tick,
-    key: Key,
+    key: K,
   ): mutable Iterator<(Tick, Path, Path, Array<File>)> {
     iter1 = this.data.getIterAfter(tick, key);
     iter2 = this.tombs.getIterAfter(tick, key);
@@ -668,7 +668,7 @@ mutable class FixedDataMapIterator<T> private {
 
 class EagerDir protected {
   input: Bool,
-  private fixedData: FixedDataMap,
+  private fixedData: FixedDataMap<Key>,
   private totalSize: Int,
   creator: ?ArrowKey,
   private fixedOld: FixedSourceMap = FixedSourceMap::empty(),
@@ -695,7 +695,7 @@ class EagerDir protected {
     timeStack: TimeStack,
     dirName: DirName,
     input: Bool,
-    fixedData: FixedDataMap = FixedDataMap::create(),
+    fixedData: FixedDataMap<Key> = FixedDataMap::create(),
     creator: ?ArrowKey,
     data: DataMap<Key> = DataMap::empty(),
     optOnDelete: ?Postponable = None(),
@@ -844,7 +844,7 @@ class EagerDir protected {
     FixedSourceMap::create(acc)
   }
 
-  private fun flattenData(limit: Tick): FixedDataMap {
+  private fun flattenData(limit: Tick): FixedDataMap<Key> {
     withRegionValue(() ~> {
       fixedIter = FixedDataMapIterator::create(this.fixedData.getIterAll());
       data = Vector::mcreate(

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -525,10 +525,7 @@ class FixedDataMap{
     vec: mutable Vector<FixedRow<Key, Array<V>>> = mutable Vector[],
     tombs: mutable Vector<FixedRow<Key, Path>> = mutable Vector[],
   ): this {
-    data = IFixedDir::getMetadata(vec) match {
-    | None() -> FixedDir<Key, Array<File>>::create(vec)
-    | Some(metadata) -> CompactFixedDir::createWithMetadata(vec, metadata)
-    };
+    data = CompactFixedDir::create(vec);
     static{data, tombs => FixedDir::create(tombs)}
   }
 

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -527,7 +527,7 @@ class FixedDataMap{
   ): this {
     data = IFixedDir::getMetadata(vec) match {
     | None() -> FixedDir<Key, Array<File>>::create(vec)
-    | Some(metadata) -> CompactFixedDir::create(vec, metadata)
+    | Some(metadata) -> CompactFixedDir::createWithMetadata(vec, metadata)
     };
     static{data, tombs => FixedDir::create(tombs)}
   }

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -517,25 +517,25 @@ class DataMap<K: Orderable> private {
   }
 }
 
-class FixedDataMap<K: Orderable>{
-  data: FixedData<K, Array<File>>,
+class FixedDataMap<K: Orderable, F: frozen>{
+  data: FixedData<K, Array<F>>,
   tombs: FixedDir<K, Path>,
 } uses Unsafe.Downcastable {
   private static fun fixedDataFactory(): Concrete<
-    FixedDataFactory<K, Array<File>>,
+    FixedDataFactory<K, Array<F>>,
   > {
     // Does not work as expected if types are not explicitly given
     Unsafe.unsafeSpecializeFactory<
-      FixedDataMap<K>,
-      FixedDataMap<Key>,
-      FixedDataFactory<K, Array<File>>,
+      FixedDataMap<K, F>,
+      FixedDataMap<Key, File>,
+      FixedDataFactory<K, Array<F>>,
       CompactFixedDir,
-      FixedDir<K, Array<File>>,
-    >(static, FixedDataMap, CompactFixedDir, FixedDir<K, Array<File>>)
+      FixedDir<K, Array<F>>,
+    >(static, FixedDataMap, CompactFixedDir, FixedDir<K, Array<F>>)
   }
 
-  static fun create<V: File>(
-    vec: mutable Vector<FixedRow<K, Array<V>>> = mutable Vector[],
+  static fun create(
+    vec: mutable Vector<FixedRow<K, Array<F>>> = mutable Vector[],
     tombs: mutable Vector<FixedRow<K, Path>> = mutable Vector[],
   ): this {
     data = static::fixedDataFactory()::create(vec);
@@ -550,7 +550,7 @@ class FixedDataMap<K: Orderable>{
     this.data.getChangesAfter(tick).union(this.tombs.getChangesAfter(tick))
   }
 
-  fun getIterAll(): mutable Iterator<(Tick, Path, Path, K, Array<File>)> {
+  fun getIterAll(): mutable Iterator<(Tick, Path, Path, K, Array<F>)> {
     iter1 = this.data.iterator();
     iter2 = this.tombs.data.iterator();
     left = iter1.next();
@@ -578,7 +578,7 @@ class FixedDataMap<K: Orderable>{
     }
   }
 
-  fun getIter(key: K): mutable Iterator<(Tick, Path, Path, Array<File>)> {
+  fun getIter(key: K): mutable Iterator<(Tick, Path, Path, Array<F>)> {
     iter1 = this.data.getIter(key);
     iter2 = this.tombs.getIter(key);
     left = iter1.next();
@@ -609,7 +609,7 @@ class FixedDataMap<K: Orderable>{
   fun getIterAfter(
     tick: Tick,
     key: K,
-  ): mutable Iterator<(Tick, Path, Path, Array<File>)> {
+  ): mutable Iterator<(Tick, Path, Path, Array<F>)> {
     iter1 = this.data.getIterAfter(tick, key);
     iter2 = this.tombs.getIterAfter(tick, key);
     left = iter1.next();
@@ -668,7 +668,7 @@ mutable class FixedDataMapIterator<T> private {
 
 class EagerDir protected {
   input: Bool,
-  private fixedData: FixedDataMap<Key>,
+  private fixedData: FixedDataMap<Key, File>,
   private totalSize: Int,
   creator: ?ArrowKey,
   private fixedOld: FixedSourceMap = FixedSourceMap::empty(),
@@ -695,7 +695,7 @@ class EagerDir protected {
     timeStack: TimeStack,
     dirName: DirName,
     input: Bool,
-    fixedData: FixedDataMap<Key> = FixedDataMap::create(),
+    fixedData: FixedDataMap<Key, File> = FixedDataMap::create(),
     creator: ?ArrowKey,
     data: DataMap<Key> = DataMap::empty(),
     optOnDelete: ?Postponable = None(),
@@ -844,7 +844,7 @@ class EagerDir protected {
     FixedSourceMap::create(acc)
   }
 
-  private fun flattenData(limit: Tick): FixedDataMap<Key> {
+  private fun flattenData(limit: Tick): FixedDataMap<Key, File> {
     withRegionValue(() ~> {
       fixedIter = FixedDataMapIterator::create(this.fixedData.getIterAll());
       data = Vector::mcreate(

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -524,7 +524,14 @@ class FixedDataMap{
   private static fun fixedDataFactory(): Concrete<
     FixedDataFactory<Key, Array<File>>,
   > {
-    CompactFixedDir
+    // Does not work as expected if types are not explicitly given
+    Unsafe.unsafeSpecializeFactory<
+      FixedDataMap,
+      FixedDataMap,
+      FixedDataFactory<Key, Array<File>>,
+      CompactFixedDir,
+      FixedDir<Key, Array<File>>,
+    >(static, FixedDataMap, CompactFixedDir, FixedDir<Key, Array<File>>)
   }
 
   static fun create<V: File>(

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -150,8 +150,8 @@ fun assertUnique<T, U: Orderable>(
 class FixedDir<+K: Orderable, +T: frozen> extends
   IFixedDir<K, T, FixedRow<K, T>>,
 {
-  static fun create<U: T>(
-    data: mutable Vector<FixedRow<K, U>> = mutable Vector[],
+  static fun create<L: K, U: T>(
+    data: mutable Vector<FixedRow<L, U>> = mutable Vector[],
   ): this {
     if (!data.isSorted()) {
       data.sort();

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -183,6 +183,15 @@ class FixedDirMetadata{
 class CompactFixedDir protected {
   metadata: FixedDirMetadata,
 } extends IFixedDir<Key, Array<File>, CompactRow> {
+  static fun create<V: File>(
+    vec: mutable Vector<FixedRow<Key, Array<V>>> = mutable Vector[],
+  ): FixedData<Key, Array<File>> {
+    IFixedDir::getMetadata(vec) match {
+    | None() -> FixedDir<Key, Array<File>>::create(vec)
+    | Some(metadata) -> static::createWithMetadata(vec, metadata)
+    }
+  }
+
   static fun createWithMetadata<K: Key, V: File>(
     data: mutable Vector<FixedRow<K, Array<V>>>,
     metadata: FixedDirMetadata,

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -80,8 +80,8 @@ base class FixedData<+K: Orderable, +T> {
 }
 
 base class FixedDataFactory<+K: Orderable, +F> {
-  static fun create<L: K, V: F>(
-    vec: mutable Vector<FixedRow<L, V>> = mutable Vector[],
+  static fun create(
+    vec: mutable Vector<FixedRow<K, F>> = mutable Vector[],
   ): FixedData<K, F>;
 }
 
@@ -157,8 +157,8 @@ class FixedDir<+K: Orderable, +T: frozen> extends
   IFixedDir<K, T, FixedRow<K, T>>,
   FixedDataFactory<K, T>,
 {
-  static fun create<L: K, U: T>(
-    data: mutable Vector<FixedRow<L, U>> = mutable Vector[],
+  static fun create(
+    data: mutable Vector<FixedRow<K, T>> = mutable Vector[],
   ): this {
     if (!data.isSorted()) {
       data.sort();
@@ -193,8 +193,8 @@ class CompactFixedDir protected {
   IFixedDir<Key, Array<File>, CompactRow>,
   FixedDataFactory<Key, Array<File>>,
 {
-  static fun create<L: Key, V: Array<File>>(
-    vec: mutable Vector<FixedRow<L, V>> = mutable Vector[],
+  static fun create(
+    vec: mutable Vector<FixedRow<Key, Array<File>>> = mutable Vector[],
   ): FixedData<Key, Array<File>> {
     static::getMetadata(vec) match {
     | None() -> FixedDir<Key, Array<File>>::create(vec)

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -183,7 +183,7 @@ class FixedDirMetadata{
 class CompactFixedDir protected {
   metadata: FixedDirMetadata,
 } extends IFixedDir<Key, Array<File>, CompactRow> {
-  static fun create<K: Key, V: File>(
+  static fun createWithMetadata<K: Key, V: File>(
     data: mutable Vector<FixedRow<K, Array<V>>>,
     metadata: FixedDirMetadata,
   ): this {

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -183,8 +183,8 @@ class FixedDirMetadata{
 class CompactFixedDir protected {
   metadata: FixedDirMetadata,
 } extends IFixedDir<Key, Array<File>, CompactRow> {
-  static fun create<L: Key, V: File>(
-    vec: mutable Vector<FixedRow<L, Array<V>>> = mutable Vector[],
+  static fun create<L: Key, V: Array<File>>(
+    vec: mutable Vector<FixedRow<L, V>> = mutable Vector[],
   ): FixedData<Key, Array<File>> {
     static::getMetadata(vec) match {
     | None() -> FixedDir<Key, Array<File>>::create(vec)
@@ -218,8 +218,8 @@ class CompactFixedDir protected {
     possibleResult
   }
 
-  static fun createWithMetadata<K: Key, V: File>(
-    data: mutable Vector<FixedRow<K, Array<V>>>,
+  static fun createWithMetadata<K: Key, V: Array<File>>(
+    data: mutable Vector<FixedRow<K, V>>,
     metadata: FixedDirMetadata,
   ): this {
     if (!data.isSorted()) {

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -186,10 +186,36 @@ class CompactFixedDir protected {
   static fun create<V: File>(
     vec: mutable Vector<FixedRow<Key, Array<V>>> = mutable Vector[],
   ): FixedData<Key, Array<File>> {
-    IFixedDir::getMetadata(vec) match {
+    static::getMetadata(vec) match {
     | None() -> FixedDir<Key, Array<File>>::create(vec)
     | Some(metadata) -> static::createWithMetadata(vec, metadata)
     }
+  }
+
+  private static fun getMetadata(
+    data: readonly Vector<FixedRow<Key, Array<File>>>,
+  ): ?FixedDirMetadata {
+    possibleResult: ?FixedDirMetadata = None();
+
+    for (elt in data) {
+      if (elt.value.size() != 1) return None();
+      (elt.key, elt.value[0]) match {
+      | (SKDB.RowKey(row1, k), row2 @ SKDB.RowValues _) ->
+        possibleResult match {
+        | None() ->
+          !possibleResult = Some(
+            FixedDirMetadata{sourceDir => elt.source.dirName, kinds => k},
+          )
+        | Some(FixedDirMetadata{sourceDir, kinds}) ->
+          if (k != kinds || elt.source.dirName != sourceDir) {
+            return None()
+          }
+        };
+        if (row1 != row2) return None()
+      | _ -> return None()
+      }
+    };
+    possibleResult
   }
 
   static fun createWithMetadata<K: Key, V: File>(
@@ -252,32 +278,6 @@ base class IFixedDir<
 
   fun iterator(): mutable Iterator<FixedRow<K, T>> {
     this.data.keys().map(i -> this[i])
-  }
-
-  static fun getMetadata(
-    data: readonly Vector<FixedRow<Key, Array<File>>>,
-  ): ?FixedDirMetadata {
-    possibleResult: ?FixedDirMetadata = None();
-
-    for (elt in data) {
-      if (elt.value.size() != 1) return None();
-      (elt.key, elt.value[0]) match {
-      | (SKDB.RowKey(row1, k), row2 @ SKDB.RowValues _) ->
-        possibleResult match {
-        | None() ->
-          !possibleResult = Some(
-            FixedDirMetadata{sourceDir => elt.source.dirName, kinds => k},
-          )
-        | Some(FixedDirMetadata{sourceDir, kinds}) ->
-          if (k != kinds || elt.source.dirName != sourceDir) {
-            return None()
-          }
-        };
-        if (row1 != row2) return None()
-      | _ -> return None()
-      }
-    };
-    possibleResult
   }
 
   fun size(): Int {

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -183,8 +183,8 @@ class FixedDirMetadata{
 class CompactFixedDir protected {
   metadata: FixedDirMetadata,
 } extends IFixedDir<Key, Array<File>, CompactRow> {
-  static fun create<V: File>(
-    vec: mutable Vector<FixedRow<Key, Array<V>>> = mutable Vector[],
+  static fun create<L: Key, V: File>(
+    vec: mutable Vector<FixedRow<L, Array<V>>> = mutable Vector[],
   ): FixedData<Key, Array<File>> {
     static::getMetadata(vec) match {
     | None() -> FixedDir<Key, Array<File>>::create(vec)

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -79,6 +79,12 @@ base class FixedData<+K: Orderable, +T> {
   fun iterator(): mutable Iterator<FixedRow<K, T>>;
 }
 
+base class FixedDataFactory<+K: Orderable, +F> {
+  static fun create<L: K, V: F>(
+    vec: mutable Vector<FixedRow<L, V>> = mutable Vector[],
+  ): FixedData<K, F>;
+}
+
 // Assuming delta is monotone, that is, i <= j implies delta(i) <= delta(j),
 // findFirstBy(delta, l, u) is the least m where l <= m <= u such that
 // delta(m) == EQ(). If there is no such m, then l <= m <= u+1 but otherwise
@@ -149,6 +155,7 @@ fun assertUnique<T, U: Orderable>(
 
 class FixedDir<+K: Orderable, +T: frozen> extends
   IFixedDir<K, T, FixedRow<K, T>>,
+  FixedDataFactory<K, T>,
 {
   static fun create<L: K, U: T>(
     data: mutable Vector<FixedRow<L, U>> = mutable Vector[],
@@ -182,7 +189,10 @@ class FixedDirMetadata{
 // out of the rows themselves.
 class CompactFixedDir protected {
   metadata: FixedDirMetadata,
-} extends IFixedDir<Key, Array<File>, CompactRow> {
+} extends
+  IFixedDir<Key, Array<File>, CompactRow>,
+  FixedDataFactory<Key, Array<File>>,
+{
   static fun create<L: Key, V: Array<File>>(
     vec: mutable Vector<FixedRow<L, V>> = mutable Vector[],
   ): FixedData<Key, Array<File>> {

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -183,14 +183,14 @@ class FixedDirMetadata{
 class CompactFixedDir protected {
   metadata: FixedDirMetadata,
 } extends IFixedDir<Key, Array<File>, CompactRow> {
-  static fun create<V: File>(
-    data: mutable Vector<FixedRow<Key, Array<V>>>,
+  static fun create<K: Key, V: File>(
+    data: mutable Vector<FixedRow<K, Array<V>>>,
     metadata: FixedDirMetadata,
   ): this {
     if (!data.isSorted()) {
       data.sort();
     };
-    static::computeTags(data);
+    IFixedDir::computeTags(data);
     static{
       data => data.map(static::stripMetadata).toArray(),
       metadata => metadata,

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -327,14 +327,14 @@ base class IFixedDir<
     this.getIterSourceKey(source, key).collect(Array)
   }
 
-  protected static fun computeTags<U: T>(
-    array: mutable Vector<FixedRow<K, U>>,
+  protected static fun computeTags<L: K, U: T>(
+    array: mutable Vector<FixedRow<L, U>>,
   ): void {
     _: TickRange = static::computeTags_(array, 0, array.size() - 1);
   }
 
-  private static fun computeTags_<U: T>(
-    array: mutable Vector<FixedRow<K, U>>,
+  private static fun computeTags_<L: K, U: T>(
+    array: mutable Vector<FixedRow<L, U>>,
     i: Int,
     j: Int,
   ): TickRange {

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -337,14 +337,14 @@ base class IFixedDir<
     this.getIterSourceKey(source, key).collect(Array)
   }
 
-  protected static fun computeTags<L: K, U: T>(
-    array: mutable Vector<FixedRow<L, U>>,
+  protected static fun computeTags(
+    array: mutable Vector<FixedRow<K, T>>,
   ): void {
     _: TickRange = static::computeTags_(array, 0, array.size() - 1);
   }
 
-  private static fun computeTags_<L: K, U: T>(
-    array: mutable Vector<FixedRow<L, U>>,
+  private static fun computeTags_(
+    array: mutable Vector<FixedRow<K, T>>,
     i: Int,
     j: Int,
   ): TickRange {


### PR DESCRIPTION
Follow-up of #931: make `FixedDataMap` generic.

`CompactFixedDir` can still be used but only if a `FixedDataMap` is instanciated with the SKDB types, which will happen only once we have typed `EagerDir`s and with use the most precise types (i.e. not `Key` and `File`).