### PR TITLE
[skiplang/skc] Transition to opaque pointers in LLVM IR.

### DIFF
--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -252,7 +252,7 @@ value class AsmDefID() uses TypeSafeID<Int>, AsmFormattable {
       asm.print("getelementptr (i8, ptr ");
     };
 
-    asm.print("bitcast (%N to ptr)" % this);
+    asm.print("%n" % this);
 
     if (byteOffset != 0) {
       asm.print(", i64 %d)" % byteOffset)
@@ -1998,7 +1998,7 @@ mutable class .AsmOutput{
       }
     });
 
-    asm.print("ptr bitcast (%N to ptr)" % id)
+    asm.print("%N" % id)
   }
 
   // Static strings always take a multiple of 8 bytes and have a trailing '\0'
@@ -2273,19 +2273,6 @@ private fun llvmWriteCall(
 
   code = optinfo.getInstr(call.code);
 
-  codeTemp = if (code.isConstant()) {
-    ""
-  } else {
-    // We are calling a raw function pointer, which is not expressible as a
-    // Skip type. We need to cast this to the right LLVM function pointer
-    // type, which we infer from the parameters.
-    tmp = asm.llvmIdentifier("methodCode");
-
-    asm.print("  %%%s = bitcast ptr %n to ptr, %D\n" % tmp % code % call);
-
-    tmp
-  };
-
   asm.print("  ");
   if (call.typ != tVoid) {
     asm.print("%n = " % call)
@@ -2311,11 +2298,7 @@ private fun llvmWriteCall(
 
     // Write function.
     asm.print(" %t " % call);
-    if (codeTemp == "") {
-      asm.print("%n" % code);
-    } else {
-      asm.print("%%%s" % codeTemp);
-    };
+    asm.print("%n" % code);
     llvmWriteArgs(asm, call.args);
 
     if (!call.returns) {
@@ -2617,7 +2600,7 @@ private fun llvmWriteTypeAndName(
     }
   | ConstantFun{value} ->
     subf = asm.env().getFunction(value, asm.pos());
-    asm.print("ptr bitcast (%N to ptr)" % subf)
+    asm.print("%N" % subf)
   | ConstantVoid _ -> asm.print("void")
   | _ -> asm.print("%t %n" % instr % instr)
   }
@@ -2751,8 +2734,8 @@ private fun llvmGetAddr(
   };
 
   // Compute the raw address to be loaded.
-  rawAddr = asm.llvmIdentifier();
-  asm.print("  %%%s = getelementptr inbounds " % rawAddr);
+  addr = asm.llvmIdentifier();
+  asm.print("  %%%s = getelementptr inbounds " % addr);
 
   optinfo.getInstr(instr.addr) match {
   | g @ ConstantGlobalSingleton _ ->
@@ -2762,10 +2745,6 @@ private fun llvmGetAddr(
   };
 
   asm.print(", i64 %s, %D\n" % firstByteOffset % instr);
-
-  // Bitcast it to the right type.
-  addr = asm.llvmIdentifier();
-  asm.print("  %%%s = bitcast ptr %%%s to ptr, %D\n" % addr % rawAddr % instr);
 
   // Compute what we know about the alignment, by taking the lowest bit that
   // could possibly be set in the address.
@@ -2860,10 +2839,8 @@ private fun llvmWriteStore(
 
   if (!isBitfield) {
     if (asm.common.config.asan) {
-      tmp = asm.llvmIdentifier();
-      asm.print("  %%%s = bitcast ptr %%%s to ptr, %D\n" % tmp % addr % pos);
       asm.print(
-        "  call void @SKIP_Obstack_verifyStore(ptr %%%s), %D\n" % tmp % pos,
+        "  call void @SKIP_Obstack_verifyStore(ptr %%%s), %D\n" % addr % pos,
       );
     };
 
@@ -3083,8 +3060,7 @@ private fun llvmWriteSkipLandingPad(
 ): void {
   excPair = asm.llvmIdentifier("excpair");
   asm.print(
-    ("  %%%s = landingpad { ptr, i32 }\n" +
-      "          catch ptr bitcast (ptr @%s to ptr), %D\n") %
+    "  %%%s = landingpad { ptr, i32 }\n          catch ptr @%s, %D\n" %
       excPair %
       skipExceptionTypeInfo %
       pos,
@@ -3097,9 +3073,7 @@ private fun llvmWriteSkipLandingPad(
 
   expectedID = asm.llvmIdentifier("expected_type_id");
   asm.print(
-    ("  %%%s = tail call i32 @llvm.eh.typeid.for(ptr nonnull " +
-      "bitcast (ptr @%s to ptr)) " +
-      "nounwind, %D\n") %
+    "  %%%s = tail call i32 @llvm.eh.typeid.for(ptr nonnull @%s) nounwind, %D\n" %
       expectedID %
       skipExceptionTypeInfo %
       pos,
@@ -3148,12 +3122,10 @@ private fun llvmWriteSkipLandingPad(
       cppExc %
       pos,
   );
-  addr2 = asm.llvmIdentifier("exc_field_addr2");
-  asm.print("  %%%s = bitcast ptr %%%s to ptr, %D\n" % addr2 % addr1 % pos);
 
   asm.print("  ");
   writeExcPtr();
-  asm.print(" = load ptr, ptr %%%s, align 8, %D\n" % addr2 % pos);
+  asm.print(" = load ptr, ptr %%%s, align 8, %D\n" % addr1 % pos);
 
   asm.print("  tail call void @__cxa_end_catch(), %D\n" % pos);
 }
@@ -3410,15 +3382,11 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
       );
 
       // Tell LLVM its lifetime starts here.
-      lifetimeVar = asm.llvmIdentifier("%strcat.lifetime_arg");
-      asm.print(
-        "  %s = bitcast ptr %s to ptr, %D\n" % lifetimeVar % bufVar % instr,
-      );
       lifetimeArgs = (
         "(i64 " +
         (common.config.ptrByteSize * args.size()) +
         ", ptr " +
-        lifetimeVar +
+        bufVar +
         ")"
       );
       asm.print(
@@ -3496,16 +3464,12 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
       );
 
       // Load the string header.
-      rawHdrPtr = asm.llvmIdentifier("%stringswitch.rawhdrptr");
-      asm.print(
-        "  %s = getelementptr inbounds i8, %N, i64 -8, %D\n" %
-          rawHdrPtr %
-          valueInstr %
-          instr,
-      );
       hdrPtr = asm.llvmIdentifier("%stringswitch.hdrptr");
       asm.print(
-        "  %s = bitcast ptr %s to ptr, %D\n" % hdrPtr % rawHdrPtr % instr,
+        "  %s = getelementptr inbounds i8, %N, i64 -8, %D\n" %
+          hdrPtr %
+          valueInstr %
+          instr,
       );
       hdr = asm.llvmIdentifier("%stringswitch.hdr");
       asm.print(
@@ -3948,10 +3912,7 @@ fun llvmWriteFunctionDefinition(
   );
   asm.declarationText.writeChar('\n');
 
-  asm.print(
-    (" uwtable personality ptr bitcast " +
-      "(ptr @__gxx_personality_v0 to ptr) %D {\n") % f,
-  );
+  asm.print((" uwtable personality ptr @__gxx_personality_v0 %D {\n") % f);
 
   for (b in f.blocks) llvmWriteBlock(b, asm);
   asm.print("}\n");

--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -15,7 +15,7 @@ module AsmOutput;
 // %n: Instr, Block: LLVM name (no leading % for blocks)
 // %N: Instr: LLVM type followed by LLVM name
 // %s: Bool, Char, Int, String: simple toString() text
-// %t: LLVM type for a use (e.g. %foo* for a global %foo struct)
+// %t: LLVM type for a use (e.g. ptr for a global %foo struct)
 // %T: LLVM type for the definition (e.g. %foo for a global %foo struct)
 // %x: Int: 16 hexadecimal digits
 
@@ -235,17 +235,7 @@ extension class .Function uses AsmFormattable {
       // AsmDefID uses the same numbers for all existing SFunctionID
       asm.print('@');
       asm.writeRef(this.getAsmDefID())
-    | 't' ->
-      t = this.funType;
-
-      // NOTE: LLVM function types cannot have parameter/return attributes.
-      llvmWriteReturnTypeName(asm, t.returnType, false);
-      asm.print(" (");
-      t.params.eachWithIndex((i, p) -> {
-        if (i > 0) asm.print(", ");
-        llvmWriteTypeName(asm, p)
-      });
-      asm.print(") *")
+    | 't' -> asm.print("ptr")
     | 'N' -> asm.print("%t %n" % this % this)
     | _ -> asm.die(`Bad format for Function: "${spec}"`)
     }
@@ -259,10 +249,10 @@ value class AsmDefID() uses TypeSafeID<Int>, AsmFormattable {
 
   fun writeGetPointer(asm: mutable AsmDefBuilder, byteOffset: Int): void {
     if (byteOffset != 0) {
-      asm.print("getelementptr (i8, i8* ");
+      asm.print("getelementptr (i8, ptr ");
     };
 
-    asm.print("bitcast (%N to i8*)" % this);
+    asm.print("bitcast (%N to ptr)" % this);
 
     if (byteOffset != 0) {
       asm.print(", i64 %d)" % byteOffset)
@@ -315,7 +305,7 @@ mutable private base class AsmDefBase{
     | _ -> asm.die(`Bad format for AsmDef: "${spec}"`)
     };
 
-    if (spec == 't' || spec == 'T' || spec == 'N') {
+    if (spec == 'T') {
       (this.typeString, this.typeRef) match {
       | (Some(str), None()) -> asm.print(str)
       | (None(), Some(ref)) ->
@@ -323,11 +313,9 @@ mutable private base class AsmDefBase{
         asm.writeRef(ref)
       | _ -> asm.die("AsmBuilder has no type to emit")
       };
-
-      if (spec != 'T') {
-        // The type of a global is always a pointer.
-        asm.print("*")
-      }
+    } else if (spec == 't' || spec == 'N') {
+      // The type of a global is always a pointer.
+      asm.print("ptr")
     };
 
     if (spec == 'N') {
@@ -1636,12 +1624,12 @@ private type InlinedAt = DILocation;
 //
 //   !dbg attachment points at wrong subprogram for function
 //   !105 = distinct !DISubprogram(name: "<generic_function:Vector::push>", scope: !3, file: !3, line: 78, type: !55, isLocal: false, isDefinition: true, isOptimized: false, unit: !2)
-//   void (i8*, i8*)* @"sk.Vector::push.q2"
-//     %r45 = getelementptr inbounds i8, i8* %this.0, i64 8, !dbg !84
+//   void ptr @"sk.Vector::push.q2"
+//     %r45 = getelementptr inbounds i8, ptr %this.0, i64 8, !dbg !84
 //
 // may have actually originally been written as (note the different !dbg label):
 //
-//     %r45 = getelementptr inbounds i8, i8* %this.0, i64 8, !dbg !56
+//     %r45 = getelementptr inbounds i8, ptr %this.0, i64 8, !dbg !56
 mutable class Metadata{
   // List of LLVM metadata
   metadata: mutable Vector<String> = mutable Vector[],
@@ -2010,7 +1998,7 @@ mutable class .AsmOutput{
       }
     });
 
-    asm.print("i8* bitcast (%N to i8*)" % id)
+    asm.print("ptr bitcast (%N to ptr)" % id)
   }
 
   // Static strings always take a multiple of 8 bytes and have a trailing '\0'
@@ -2212,7 +2200,7 @@ mutable class .AsmOutput{
       canShare => false,
       symbol => "skip.globals",
       common => this,
-      typeString => Some(`${this.llvmGlobalsType()}*`),
+      typeString => Some("ptr"),
       typeRef => None(),
     };
 
@@ -2293,17 +2281,7 @@ private fun llvmWriteCall(
     // type, which we infer from the parameters.
     tmp = asm.llvmIdentifier("methodCode");
 
-    asm.print("  %%%s = bitcast %N to %t(" % tmp % code % call);
-    call.args.eachWithIndex((i, t) -> {
-      if (i > 0) asm.print(", ");
-      typ = optinfo.getInstr(t).typ;
-      llvmWriteTypeName(asm, typ)
-      // LLVM disallows attributes in the function type, which is weird --
-      // the calling convention is not part of the function type.
-      //   llvmWriteTypeCallAttribute(asm, typ, true, false);
-    });
-
-    asm.print(") *, %D\n" % call);
+    asm.print("  %%%s = bitcast ptr %n to ptr, %D\n" % tmp % code % call);
 
     tmp
   };
@@ -2479,7 +2457,7 @@ private fun llvmWriteName(instr: Instr, asm: mutable AsmDefBuilder): void {
       asm.print("null")
     } else {
       asm.print(
-        "inttoptr (i%s %s to i8*)" % asm.common.config.ptrBitSize % value,
+        "inttoptr (i%s %s to ptr)" % asm.common.config.ptrBitSize % value,
       )
     }
   | obj @ ConstantObject _ -> asm.common.llvmWriteConstantObject(asm, obj)
@@ -2610,7 +2588,7 @@ private fun llvmWriteTypeAndName(
       !f.blocks.any(b -> {
         b.terminator() match {
         | ijump @ IndirectJump{successors} if (tag == ijump.tag) ->
-          asm.print("i8* blockaddress(%n, " % f);
+          asm.print("ptr blockaddress(%n, " % f);
           target = successors[case].target;
           if (
             !f.blocks.any(b2 -> {
@@ -2635,13 +2613,11 @@ private fun llvmWriteTypeAndName(
     ) {
       // Weird -- it seems that the indirect jump that wanted this
       // entry has been optimized away after the vtables were set up?
-      asm.print("i8* null")
+      asm.print("ptr null")
     }
   | ConstantFun{value} ->
-    // Currently, anyone calling this function expects an i8* rather
-    // than a function type so we must introduce a cast.
     subf = asm.env().getFunction(value, asm.pos());
-    asm.print("i8* bitcast (%N to i8*)" % subf)
+    asm.print("ptr bitcast (%N to ptr)" % subf)
   | ConstantVoid _ -> asm.print("void")
   | _ -> asm.print("%t %n" % instr % instr)
   }
@@ -2781,7 +2757,7 @@ private fun llvmGetAddr(
   optinfo.getInstr(instr.addr) match {
   | g @ ConstantGlobalSingleton _ ->
     globalsType = asm.common.llvmGlobalsType();
-    asm.print("%s, %s* @%n, i64 0" % globalsType % globalsType % g)
+    asm.print("%s, ptr @%n, i64 0" % globalsType % g)
   | base -> asm.print("i8, %N" % base)
   };
 
@@ -2789,13 +2765,7 @@ private fun llvmGetAddr(
 
   // Bitcast it to the right type.
   addr = asm.llvmIdentifier();
-  asm.print(
-    "  %%%s = bitcast i8* %%%s to %s*, %D\n" %
-      addr %
-      rawAddr %
-      loadTypeName %
-      instr,
-  );
+  asm.print("  %%%s = bitcast ptr %%%s to ptr, %D\n" % addr % rawAddr % instr);
 
   // Compute what we know about the alignment, by taking the lowest bit that
   // could possibly be set in the address.
@@ -2818,9 +2788,8 @@ private fun llvmWriteLoad(load: Load, asm: mutable FunAsmDefBuilder): void {
   if (!isBitfield) {
     // Normal aligned load.
     asm.print(
-      "  %n = load %s, %s* %%%s, align %s, %D\n" %
+      "  %n = load %s, ptr %%%s, align %s, %D\n" %
         load %
-        t.llvmTypeName %
         t.llvmTypeName %
         addr %
         memByteAlignment %
@@ -2830,9 +2799,8 @@ private fun llvmWriteLoad(load: Load, asm: mutable FunAsmDefBuilder): void {
     // Load the bits.
     memValueTmp = asm.llvmIdentifier();
     asm.print(
-      "  %%%s = load %s, %s* %%%s, align %s" %
+      "  %%%s = load %s, ptr %%%s, align %s" %
         memValueTmp %
-        loadTypeName %
         loadTypeName %
         addr %
         memByteAlignment,
@@ -2893,15 +2861,9 @@ private fun llvmWriteStore(
   if (!isBitfield) {
     if (asm.common.config.asan) {
       tmp = asm.llvmIdentifier();
+      asm.print("  %%%s = bitcast ptr %%%s to ptr, %D\n" % tmp % addr % pos);
       asm.print(
-        "  %%%s = bitcast %s* %%%s to i8*, %D\n" %
-          tmp %
-          memTypeName %
-          addr %
-          pos,
-      );
-      asm.print(
-        "  call void @SKIP_Obstack_verifyStore(i8* %%%s), %D\n" % tmp % pos,
+        "  call void @SKIP_Obstack_verifyStore(ptr %%%s), %D\n" % tmp % pos,
       );
     };
 
@@ -2916,22 +2878,20 @@ private fun llvmWriteStore(
     | (ObstackStore _, GCPointerScalarKind _, false)
     | (ArrayUnsafeSet _, GCPointerScalarKind _, false) ->
       asm.print(
-        "  call void @%s(%s* %%%s, %N), %D\n" %
+        "  call void @%s(ptr %%%s, %N), %D\n" %
           orig match {
           | ObstackStore _ -> "SKIP_Obstack_store"
           | ArrayUnsafeSet _ -> "SKIP_Obstack_vectorUnsafeSet"
           | _ -> ""
           } %
-          memTypeName %
           addr %
           storeValue %
           pos,
       )
     | (_, _, _) ->
       asm.print(
-        "  store %N, %s* %%%s, align %s, %D\n" %
+        "  store %N, ptr %%%s, align %s, %D\n" %
           storeValue %
-          t.llvmTypeName %
           addr %
           memByteAlignment %
           pos,
@@ -2941,9 +2901,8 @@ private fun llvmWriteStore(
     // Load the bits.
     memValueTmp = asm.llvmIdentifier();
     asm.print(
-      "  %%%s = load %s, %s* %%%s, align %s, %D\n" %
+      "  %%%s = load %s, ptr %%%s, align %s, %D\n" %
         memValueTmp %
-        memTypeName %
         memTypeName %
         addr %
         memByteAlignment %
@@ -3039,10 +2998,9 @@ private fun llvmWriteStore(
 
     // Store back the final bits.
     asm.print(
-      "  store %s %%%s, %s* %%%s, align %s, %D\n" %
+      "  store %s %%%s, ptr %%%s, align %s, %D\n" %
         memTypeName %
         setBitsTmp %
-        memTypeName %
         addr %
         memByteAlignment %
         pos,
@@ -3125,9 +3083,8 @@ private fun llvmWriteSkipLandingPad(
 ): void {
   excPair = asm.llvmIdentifier("excpair");
   asm.print(
-    ("  %%%s = landingpad { i8*, i32 }\n" +
-      "          catch i8* bitcast ({ i8*, i8*, i8* }* " +
-      "@%s to i8*), %D\n") %
+    ("  %%%s = landingpad { ptr, i32 }\n" +
+      "          catch ptr bitcast (ptr @%s to ptr), %D\n") %
       excPair %
       skipExceptionTypeInfo %
       pos,
@@ -3135,13 +3092,13 @@ private fun llvmWriteSkipLandingPad(
 
   typeID = asm.llvmIdentifier("caught_type_id");
   asm.print(
-    "  %%%s = extractvalue { i8*, i32 } %%%s, 1, %D\n" % typeID % excPair % pos,
+    "  %%%s = extractvalue { ptr, i32 } %%%s, 1, %D\n" % typeID % excPair % pos,
   );
 
   expectedID = asm.llvmIdentifier("expected_type_id");
   asm.print(
-    ("  %%%s = tail call i32 @llvm.eh.typeid.for(i8* nonnull " +
-      "bitcast ({ i8*, i8*, i8* }* @%s to i8*)) " +
+    ("  %%%s = tail call i32 @llvm.eh.typeid.for(ptr nonnull " +
+      "bitcast (ptr @%s to ptr)) " +
       "nounwind, %D\n") %
       expectedID %
       skipExceptionTypeInfo %
@@ -3162,7 +3119,7 @@ private fun llvmWriteSkipLandingPad(
   // If not, just "resume".
   asm.print("%s:\n" % no);
   writeResume();
-  asm.print("  resume { i8*, i32 } %%%s, %D\n" % excPair % pos);
+  asm.print("  resume { ptr, i32 } %%%s, %D\n" % excPair % pos);
 
   // This is the exception we wanted.
   asm.print("%s:\n" % yes);
@@ -3170,12 +3127,12 @@ private fun llvmWriteSkipLandingPad(
   // Grab the C++ exception.
   cpp1 = asm.llvmIdentifier("");
   asm.print(
-    "  %%%s = extractvalue { i8*, i32 } %%%s, 0, %D\n" % cpp1 % excPair % pos,
+    "  %%%s = extractvalue { ptr, i32 } %%%s, 0, %D\n" % cpp1 % excPair % pos,
   );
 
   cppExc = asm.llvmIdentifier("cpp_exc");
   asm.print(
-    ("  %%%s = tail call i8* @__cxa_begin_catch(i8* %%%s) " +
+    ("  %%%s = tail call ptr @__cxa_begin_catch(ptr %%%s) " +
       "nounwind, %D\n") %
       cppExc %
       cpp1 %
@@ -3186,17 +3143,17 @@ private fun llvmWriteSkipLandingPad(
   // (no easy way to check this here...)
   addr1 = asm.llvmIdentifier("exc_field_addr1");
   asm.print(
-    "  %%%s = getelementptr inbounds i8, i8* %%%s, i64 8, %D\n" %
+    "  %%%s = getelementptr inbounds i8, ptr %%%s, i64 8, %D\n" %
       addr1 %
       cppExc %
       pos,
   );
   addr2 = asm.llvmIdentifier("exc_field_addr2");
-  asm.print("  %%%s = bitcast i8* %%%s to i8**, %D\n" % addr2 % addr1 % pos);
+  asm.print("  %%%s = bitcast ptr %%%s to ptr, %D\n" % addr2 % addr1 % pos);
 
   asm.print("  ");
   writeExcPtr();
-  asm.print(" = load i8*, i8** %%%s, align 8, %D\n" % addr2 % pos);
+  asm.print(" = load ptr, ptr %%%s, align 8, %D\n" % addr2 % pos);
 
   asm.print("  tail call void @__cxa_end_catch(), %D\n" % pos);
 }
@@ -3280,9 +3237,8 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
       "  %s = alloca %s, align %s, %D\n" % tmp % t % byteAlignment % instr,
     );
     asm.print(
-      "  %n = getelementptr inbounds %s, %s* %s, i64 0, i64 0, %D\n" %
+      "  %n = getelementptr inbounds %s, ptr %s, i64 0, i64 0, %D\n" %
         instr %
-        t %
         t %
         tmp %
         instr,
@@ -3298,7 +3254,7 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
     }
   | BytePointerAdd{addr, offset} ->
     asm.print(
-      "  %n = getelementptr inbounds i8, i8* %n, %N, %D\n" %
+      "  %n = getelementptr inbounds i8, ptr %n, %N, %D\n" %
         instr %
         addr %
         offset %
@@ -3443,7 +3399,7 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
       llvmWriteIntrinsicCall(asm, v, runtimeFunName, args)
     } else {
       // Allocate a stack array to hold the arguments.
-      bufType = "[" + args.size() + " x i8*]";
+      bufType = "[" + args.size() + " x ptr]";
       bufVar = asm.llvmIdentifier("%strcat.args");
       asm.print(
         "  %s = alloca %s, align %s, %D\n" %
@@ -3456,16 +3412,12 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
       // Tell LLVM its lifetime starts here.
       lifetimeVar = asm.llvmIdentifier("%strcat.lifetime_arg");
       asm.print(
-        "  %s = bitcast %s* %s to i8*, %D\n" %
-          lifetimeVar %
-          bufType %
-          bufVar %
-          instr,
+        "  %s = bitcast ptr %s to ptr, %D\n" % lifetimeVar % bufVar % instr,
       );
       lifetimeArgs = (
         "(i64 " +
         (common.config.ptrByteSize * args.size()) +
-        ", i8* " +
+        ", ptr " +
         lifetimeVar +
         ")"
       );
@@ -3483,9 +3435,8 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
         };
 
         asm.print(
-          "  %s = getelementptr inbounds %s, %s* %s, i64 0, i64 %s, %D\n" %
+          "  %s = getelementptr inbounds %s, ptr %s, i64 0, i64 %s, %D\n" %
             refVar %
-            bufType %
             bufType %
             bufVar %
             i %
@@ -3493,12 +3444,12 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
         );
         // Could use StackStore wb for completeness, but it's unlikely to
         // ever be worth the cost, assuming stack access is hottest kind.
-        asm.print("  store %N, i8** %s, align 8, %D\n" % arg % refVar % instr)
+        asm.print("  store %N, ptr %s, align 8, %D\n" % arg % refVar % instr)
       });
 
       // Call the runtime.
       asm.print(
-        "  %n = call i8* @%s(i8** %s, i64 %s), %D\n" %
+        "  %n = call ptr @%s(ptr %s, i64 %s), %D\n" %
           instr %
           runtimeFunName %
           bufferStartAddress %
@@ -3554,11 +3505,11 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
       );
       hdrPtr = asm.llvmIdentifier("%stringswitch.hdrptr");
       asm.print(
-        "  %s = bitcast i8* %s to i64*, %D\n" % hdrPtr % rawHdrPtr % instr,
+        "  %s = bitcast ptr %s to ptr, %D\n" % hdrPtr % rawHdrPtr % instr,
       );
       hdr = asm.llvmIdentifier("%stringswitch.hdr");
       asm.print(
-        "  %s = load i64, i64* %s, align 8, %D\n" % hdr % hdrPtr % instr,
+        "  %s = load i64, ptr %s, align 8, %D\n" % hdr % hdrPtr % instr,
       );
 
       // Write out the string switch statement.
@@ -3998,8 +3949,8 @@ fun llvmWriteFunctionDefinition(
   asm.declarationText.writeChar('\n');
 
   asm.print(
-    (" uwtable personality i8* bitcast " +
-      "(i32 (...)* @__gxx_personality_v0 to i8*) %D {\n") % f,
+    (" uwtable personality ptr bitcast " +
+      "(ptr @__gxx_personality_v0 to ptr) %D {\n") % f,
   );
 
   for (b in f.blocks) llvmWriteBlock(b, asm);

--- a/skiplang/compiler/src/PrettyIR.sk
+++ b/skiplang/compiler/src/PrettyIR.sk
@@ -257,10 +257,10 @@ value class PrettyDefID() uses TypeSafeID<Int>, PrettyFormattable {
 
   fun writeGetPointer(out: mutable PrettyDefBuilder, byteOffset: Int): void {
     if (byteOffset != 0) {
-      out.print("getelementptr (i8, i8* ");
+      out.print("getelementptr (i8, ptr ");
     };
 
-    out.print("bitcast (%N to i8*)" / this);
+    out.print("bitcast (%N to ptr)" / this);
 
     if (byteOffset != 0) {
       out.print(", i64 %d)" / byteOffset)
@@ -1088,12 +1088,12 @@ private type InlinedAt = DILocation;
 //
 //   !dbg attachment points at wrong subprogram for function
 //   !105 = distinct !DISubprogram(name: "<generic_function:Vector::push>", scope: !3, file: !3, line: 78, type: !55, isLocal: false, isDefinition: true, isOptimized: false, unit: !2)
-//   void (i8*, i8*)* @"sk.Vector::push.q2"
-//     %r45 = getelementptr inbounds i8, i8* %this.0, i64 8, !dbg !84
+//   void ptr @"sk.Vector::push.q2"
+//     %r45 = getelementptr inbounds i8, ptr %this.0, i64 8, !dbg !84
 //
 // may have actually originally been written as (note the different !dbg label):
 //
-//     %r45 = getelementptr inbounds i8, i8* %this.0, i64 8, !dbg !56
+//     %r45 = getelementptr inbounds i8, ptr %this.0, i64 8, !dbg !56
 mutable class Metadata{
   // List of LLVM metadata
   metadata: mutable Vector<String> = mutable Vector[],
@@ -1625,7 +1625,7 @@ private fun prettyWriteName(instr: Instr, out: mutable PrettyDefBuilder): void {
       out.print("null")
     } else {
       out.print(
-        "inttoptr (i%s %s to i8*)" / out.common.config.ptrBitSize / value,
+        "inttoptr (i%s %s to ptr)" / out.common.config.ptrBitSize / value,
       )
     }
   | obj @ ConstantObject _ -> out.common.prettyWriteConstantObject(out, obj)
@@ -1757,7 +1757,7 @@ private fun prettyWriteTypeAndName(
       !f.blocks.any(b -> {
         b.terminator() match {
         | ijump @ IndirectJump{successors} if (tag == ijump.tag) ->
-          out.print("i8* blockaddress(%n, " / f);
+          out.print("ptr blockaddress(%n, " / f);
           target = successors[case].target;
           if (
             !f.blocks.any(b2 -> {
@@ -1782,13 +1782,11 @@ private fun prettyWriteTypeAndName(
     ) {
       // Weird -- it seems that the indirect jump that wanted this
       // entry has been optimized away after the vtables were set up?
-      out.print("i8* null")
+      out.print("ptr null")
     }
   | ConstantFun{value} ->
-    // Currently, anyone calling this function expects an i8* rather
-    // than a function type so we must introduce a cast.
     subf = out.env().getFunction(value, out.pos());
-    out.print("i8* bitcast (%N to i8*)" / subf)
+    out.print("ptr bitcast (%N to ptr)" / subf)
   | ConstantVoid _ -> out.print("void")
   | _ -> out.print("%t %n" / instr / instr)
   }

--- a/skiplang/compiler/src/PrettyIR.sk
+++ b/skiplang/compiler/src/PrettyIR.sk
@@ -260,7 +260,7 @@ value class PrettyDefID() uses TypeSafeID<Int>, PrettyFormattable {
       out.print("getelementptr (i8, ptr ");
     };
 
-    out.print("bitcast (%N to ptr)" / this);
+    out.print("%n" / this);
 
     if (byteOffset != 0) {
       out.print(", i64 %d)" / byteOffset)
@@ -1786,7 +1786,7 @@ private fun prettyWriteTypeAndName(
     }
   | ConstantFun{value} ->
     subf = out.env().getFunction(value, out.pos());
-    out.print("ptr bitcast (%N to ptr)" / subf)
+    out.print("%N" / subf)
   | ConstantVoid _ -> out.print("void")
   | _ -> out.print("%t %n" / instr / instr)
   }

--- a/skiplang/compiler/src/types.sk
+++ b/skiplang/compiler/src/types.sk
@@ -119,11 +119,11 @@ class ScalarType(
   }
 
   static fun gcPointer(ptrBitSize: Int): ScalarType {
-    ScalarType(ptrBitSize, ptrBitSize, "i8*", GCPointerScalarKind());
+    ScalarType(ptrBitSize, ptrBitSize, "ptr", GCPointerScalarKind());
   }
 
   static fun nonGCPointer(ptrBitSize: Int): ScalarType {
-    ScalarType(ptrBitSize, ptrBitSize, "i8*", NonGCPointerScalarKind());
+    ScalarType(ptrBitSize, ptrBitSize, "ptr", NonGCPointerScalarKind());
   }
 }
 

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -91,19 +91,18 @@ define i1 @SKIP_String_eq(ptr %0, ptr %1) {
 
 declare void @SKIP_saveExn(ptr)
 
-define void @SKIP_etry(ptr %f.0, ptr %onError.1) unnamed_addr uwtable personality ptr bitcast (ptr @__gxx_personality_v0 to ptr) {
+define void @SKIP_etry(ptr %f.0, ptr %onError.1) unnamed_addr uwtable personality ptr @__gxx_personality_v0 {
 b0.entry:
   %r20 = getelementptr inbounds i8, ptr %f.0, i64 -8
   %r2 = load ptr, ptr %r20, align 8
   %r22 = getelementptr inbounds i8, ptr %r2, i64 0
   %r3 = load ptr, ptr %r22, align 8
-  %methodCode.24 = bitcast ptr %r3 to ptr
-  invoke void %methodCode.24(ptr %f.0) to label %b6.exit unwind label %b1.rawcatch_5
+  invoke void %r3(ptr %f.0) to label %b6.exit unwind label %b1.rawcatch_5
 b1.rawcatch_5:
   %excpair.25 = landingpad { ptr, i32 }
-          catch ptr bitcast (ptr @_ZTIN4skip13SkipExceptionE to ptr)
+          catch ptr @_ZTIN4skip13SkipExceptionE
   %caught_type_id.26 = extractvalue { ptr, i32 } %excpair.25, 1
-  %expected_type_id.27 = tail call i32 @llvm.eh.typeid.for(ptr nonnull bitcast (ptr @_ZTIN4skip13SkipExceptionE to ptr)) nounwind
+  %expected_type_id.27 = tail call i32 @llvm.eh.typeid.for(ptr nonnull @_ZTIN4skip13SkipExceptionE) nounwind
   %eq_type_id.28 = icmp eq i32 %caught_type_id.26, %expected_type_id.27
   br i1 %eq_type_id.28, label %catch.29, label %no_catch.30
 no_catch.30:
@@ -121,8 +120,7 @@ b2.record_exc_5:
   %r6 = load ptr, ptr %r35, align 8
   %r37 = getelementptr inbounds i8, ptr %r6, i64 0
   %r9 = load ptr, ptr %r37, align 8
-  %methodCode.39 = bitcast ptr %r9 to ptr
-  tail call void %methodCode.39(ptr %onError.1)
+  tail call void %r9(ptr %onError.1)
   ret void
 b6.exit:
   ret void

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -91,19 +91,19 @@ define i1 @SKIP_String_eq(ptr %0, ptr %1) {
 
 declare void @SKIP_saveExn(ptr)
 
-define void @SKIP_etry(ptr %f.0, ptr %onError.1) unnamed_addr uwtable personality ptr bitcast (i32 (...)* @__gxx_personality_v0 to ptr) {
+define void @SKIP_etry(ptr %f.0, ptr %onError.1) unnamed_addr uwtable personality ptr bitcast (ptr @__gxx_personality_v0 to ptr) {
 b0.entry:
   %r20 = getelementptr inbounds i8, ptr %f.0, i64 -8
   %r2 = load ptr, ptr %r20, align 8
   %r22 = getelementptr inbounds i8, ptr %r2, i64 0
   %r3 = load ptr, ptr %r22, align 8
-  %methodCode.24 = bitcast ptr %r3 to void(ptr) *
+  %methodCode.24 = bitcast ptr %r3 to ptr
   invoke void %methodCode.24(ptr %f.0) to label %b6.exit unwind label %b1.rawcatch_5
 b1.rawcatch_5:
   %excpair.25 = landingpad { ptr, i32 }
-          catch ptr bitcast ({ ptr, ptr, ptr }* @_ZTIN4skip13SkipExceptionE to ptr)
+          catch ptr bitcast (ptr @_ZTIN4skip13SkipExceptionE to ptr)
   %caught_type_id.26 = extractvalue { ptr, i32 } %excpair.25, 1
-  %expected_type_id.27 = tail call i32 @llvm.eh.typeid.for(ptr nonnull bitcast ({ ptr, ptr, ptr }* @_ZTIN4skip13SkipExceptionE to ptr)) nounwind
+  %expected_type_id.27 = tail call i32 @llvm.eh.typeid.for(ptr nonnull bitcast (ptr @_ZTIN4skip13SkipExceptionE to ptr)) nounwind
   %eq_type_id.28 = icmp eq i32 %caught_type_id.26, %expected_type_id.27
   br i1 %eq_type_id.28, label %catch.29, label %no_catch.30
 no_catch.30:
@@ -121,7 +121,7 @@ b2.record_exc_5:
   %r6 = load ptr, ptr %r35, align 8
   %r37 = getelementptr inbounds i8, ptr %r6, i64 0
   %r9 = load ptr, ptr %r37, align 8
-  %methodCode.39 = bitcast ptr %r9 to void(ptr) *
+  %methodCode.39 = bitcast ptr %r9 to ptr
   tail call void %methodCode.39(ptr %onError.1)
   ret void
 b6.exit:


### PR DESCRIPTION
Support for pointee types was officially dropped from LLVM in version
17.

Beyond simplifying the generated LLVM IR and ensuring compatibility
with recent versions of LLVM, these changes lead to:
- 17% reduction in LLVM IR size for `skc`:
  - 71.3MB (1.1M lines) on this branch,
  - 85.8MB (1.3M lines) on main,
- and 10% speedup on my machine when building `skc`:
  - 151s on this branch,
  - 167s on main.

Some `bitcast`s are left, and they all seem to be no-ops except for the ones casting `double`s to bits:
```
$ rg -g '*.ll' ' bitcast ' stage2/target/ | grep -E -v '%r[0-9]+ = bitcast ptr .+ to ptr, !dbg ![0-9]+' | grep -E -v '%r[0-9]+ = bitcast double %[^ ]+ to i64'
stage2/target/host/release/deps/skargo-fda915c3e40d1da7.ll:  %r1 = bitcast i64 %this.0 to i64, !dbg !127
stage2/target/host/release/deps/skargo-fda915c3e40d1da7.ll:  %r1 = bitcast i32 %this.0 to i32, !dbg !5762
stage2/target/host/release/deps/skargo-fda915c3e40d1da7.ll:  %r1 = bitcast i1 %this.0 to i1, !dbg !16960
stage2/target/host/release/deps/skfmt-df7238cdcd85ee6f.ll:  %r1 = bitcast i64 %this.0 to i64, !dbg !3563
stage2/target/host/release/deps/skfmt-df7238cdcd85ee6f.ll:  %r1 = bitcast i32 %this.0 to i32, !dbg !12905
stage2/target/host/release/deps/skfmt-df7238cdcd85ee6f.ll:  %r1 = bitcast i1 %this.0 to i1, !dbg !20011
stage2/target/host/release/deps/skc-df7238c8f5f3efae.ll:  %r1 = bitcast i64 %this.0 to i64, !dbg !13847
stage2/target/host/release/deps/skc-df7238c8f5f3efae.ll:  %r1 = bitcast i1 %this.0 to i1, !dbg !17475
stage2/target/host/release/deps/skc-df7238c8f5f3efae.ll:  %r1 = bitcast i32 %this.0 to i32, !dbg !22510
stage2/target/host/release/deps/skc-df7238c8f5f3efae.ll:  %r1 = bitcast double %this.0 to double, !dbg !30002
```

They stem from some explicit `Cast{}` and `Reinterpret` instructions, which might be worth investigating later.