### PR TITLE
[skargo] Poor man's solution to building build dependencies in another state

### DIFF
--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -388,26 +388,32 @@ mutable class BuildRunner(
 
     skc.args(unit.target.srcs);
 
-    if (!unit.target.is_build_script()) {
-      // TODO: Once we have namespaced packages, we can share the state.db
-      // across architectures.
-      state_db_path = Path.join(
-        this.layout_for(unit).build,
-        // FIXME: This is a dirty hack that splits out the state.db between pic
-        // and static, which is required until `skc` namespaces packages.
-        `${unit.build_opts.relocation_model}_state.db`,
-      );
-      skc.args(
-        Array[
-          if (FileSystem.exists(state_db_path)) {
-            "--data"
-          } else {
-            "--init"
-          },
-          state_db_path,
-        ],
-      )
+    // TODO: Once we have namespaced packages, we can share the state.db
+    // across architectures.
+
+    // Separate state databases for build dependencies and regular dependencies
+    state_suffix = if (
+      unit.target.is_build_script() ||
+      this.is_build_dependency(unit)
+    ) "_build" else {
+      ""
     };
+    state_db_path = Path.join(
+      this.layout_for(unit).build,
+      // FIXME: This is a dirty hack that splits out the state.db between pic
+      // and static, which is required until `skc` namespaces packages.
+      `${unit.build_opts.relocation_model}${state_suffix}_state.db`,
+    );
+    skc.args(
+      Array[
+        if (FileSystem.exists(state_db_path)) {
+          "--data"
+        } else {
+          "--init"
+        },
+        state_db_path,
+      ],
+    );
 
     unit.target.kind match {
     | LibTarget(LibraryTypeSklib()) ->
@@ -580,6 +586,21 @@ mutable class BuildRunner(
     hash = this.hashes[unit].toStringHex();
 
     Path.join(this.fingerprint_dir, `${name}-${hash}`)
+  }
+
+  private readonly fun is_build_dependency(unit: Unit): Bool {
+    // Check if this unit is used as a build dependency by looking at its reverse dependencies
+    for (u in this.bctx.unit_graph.keys()) {
+      for (dep in this.bctx.unit_graph[u]) {
+        if (dep == unit) {
+          // If the parent unit is a CustomBuildTarget, then this unit is a build dependency
+          if (u.target.kind is CustomBuildTarget _) {
+            return true
+          }
+        }
+      }
+    };
+    false
   }
 }
 

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -343,7 +343,7 @@ mutable class BuildRunner(
 
     // TODO: Support this in a more generic way.
     if (
-      unit.pkg.name() == "std" &&
+      (unit.pkg.name() == "std" || unit.pkg.name() == "core") &&
       unit.target.kind is LibTarget(LibraryTypeSklib _)
     ) {
       skc.arg("--no-std")

--- a/skiplang/skargo/src/manifest.sk
+++ b/skiplang/skargo/src/manifest.sk
@@ -189,7 +189,6 @@ class Manifest(
   package_id: PackageId,
   dependencies: Array<Dependency>,
   targets: Array<Target>,
-  original: TomlManifest,
 ) {
   static fun read(path: String): Manifest {
     static::fromTomlManifest(TomlManifest::read(path), path)
@@ -230,7 +229,6 @@ class Manifest(
       package_id,
       dependencies.concat(dev_dependencies).concat(build_dependencies),
       targets,
-      manifest,
     )
   }
 

--- a/skiplang/skargo/src/manifest.sk
+++ b/skiplang/skargo/src/manifest.sk
@@ -205,31 +205,21 @@ class Manifest(
       Semver.Version::fromString(manifest.version),
       source_id,
     );
-    dependencies = manifest.dependencies
-      .map((toml_name, toml_dep) ->
-        Dependency::fromTomlDependency(toml_name, toml_dep, NormalDep())
-      )
-      .values()
-      .collect(Array);
-    dev_dependencies = manifest.dev_dependencies
-      .map((toml_name, toml_dep) ->
-        Dependency::fromTomlDependency(toml_name, toml_dep, DevelopmentDep())
-      )
-      .values()
-      .collect(Array);
-    build_dependencies = manifest.build_dependencies
-      .map((toml_name, toml_dep) ->
-        Dependency::fromTomlDependency(toml_name, toml_dep, BuildDep())
-      )
-      .values()
-      .collect(Array);
+    dependencies = Array[
+      (manifest.dependencies, NormalDep()),
+      (manifest.dev_dependencies, DevelopmentDep()),
+      (manifest.build_dependencies, BuildDep()),
+    ].flatMap((deps) ->
+      deps.i0
+        .map((toml_name, toml_dep) ->
+          Dependency::fromTomlDependency(toml_name, toml_dep, deps.i1)
+        )
+        .values()
+        .collect(Array)
+    );
     targets = manifest_targets(manifest, package_root);
 
-    Manifest(
-      package_id,
-      dependencies.concat(dev_dependencies).concat(build_dependencies),
-      targets,
-    )
+    Manifest(package_id, dependencies, targets)
   }
 
   fun lib_target(): ?Target {


### PR DESCRIPTION
+ other minor things.

Working on #965, I created `core` and added a dependency from `std` to `core`.
Though on `skargo check/build` in `std`, `skc` failed building `core` because of a duplicate stdlib definition.
Indeed, in its state was already the embedded std that was used to build `cc` and `pkg-config`, both dependencies of the build-script of `std`.

My solution: build build dependencies (and the build script, which previously used no state) in another state.

It's not perfect:
- I think other build scripts should probably be built in other states
- if a build dependency has dependencies that are shared with something else during the same skargo invocation, I guess it'll be it once, in the build state...