### PR TITLE
Add functions to allow artifacts reload in skip services

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -597,34 +597,33 @@ mutable class Context private {
   /*****************************************************************************/
   mutable fun updateDirtyReaders(path: Path): void {
     for (reader in this.getDeps(path)) {
-      child = this.unsafeMaybeGetDir(reader.childName) match {
-      | None() -> continue
-      | Some(x) -> x
-      };
-      parent = this.unsafeMaybeGetDir(reader.parentName) match {
-      | None() -> continue
-      | Some(x) -> x
-      };
-      this.!dirtyReaders[reader.parentName] = {
-        map = this.dirtyReaders.maybeGet(reader.parentName).default(
-          SortedMap[],
-        );
-        map.set(
-          reader.childName,
-          parent.addReaderKeyToKeySetOpt(
-            reader,
-            map.maybeGet(reader.childName),
-          ),
-        )
-      };
-      time = if (reader.parentName == reader.childName) {
-        -child.getTimeStack()
-      } else {
-        child.getTimeStack()
-      };
-      arrow = Arrow(reader.parentName, reader.childName);
-      this.addToUpdate(time, parent.getTime(), arrow);
+      this.updateDirtyReader(reader)
     };
+  }
+
+  mutable fun updateDirtyReader(reader: ArrowKey): void {
+    child = this.unsafeMaybeGetDir(reader.childName) match {
+    | None() -> return void
+    | Some(x) -> x
+    };
+    parent = this.unsafeMaybeGetDir(reader.parentName) match {
+    | None() -> return void
+    | Some(x) -> x
+    };
+    this.!dirtyReaders[reader.parentName] = {
+      map = this.dirtyReaders.maybeGet(reader.parentName).default(SortedMap[]);
+      map.set(
+        reader.childName,
+        parent.addReaderKeyToKeySetOpt(reader, map.maybeGet(reader.childName)),
+      )
+    };
+    time = if (reader.parentName == reader.childName) {
+      -child.getTimeStack()
+    } else {
+      child.getTimeStack()
+    };
+    arrow = Arrow(reader.parentName, reader.childName);
+    this.addToUpdate(time, parent.getTime(), arrow);
   }
 
   private mutable fun checkPostponables(): Bool {

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -38,7 +38,7 @@ base class NWatch{
 } extends CmdKind uses Unsafe.Downcastable
 
 class TNWatch<K: Key, F: File>{
-  fn: (Array<(K, Array<F>)>, Tick, Bool) ~> void,
+  fn: (readonly Context, Array<(K, Array<F>)>, Tick, Bool) ~> void,
 } extends NWatch
 
 value class Sub(
@@ -799,7 +799,8 @@ mutable class Context private {
       _ = condBroadcast(cond)
     | nWatch @ NWatch{dirNameGetter} ->
       this.unsafeMaybeGetDir(dirNameGetter(this)) match {
-      | Some(dir @ EagerDir _) -> dir.notifySubWatch(start, this.tick, nWatch)
+      | Some(dir @ EagerDir _) ->
+        dir.notifySubWatch(this, start, this.tick, nWatch)
       | _ -> void
       }
     };

--- a/skiplang/prelude/src/skstore/DMap.sk
+++ b/skiplang/prelude/src/skstore/DMap.sk
@@ -55,6 +55,10 @@ base class DMap<K: Orderable, +V> {
     this.items().map(x -> x.i1)
   }
 
+  fun keys(): mutable Iterator<K> {
+    this.items().map(x -> x.i0)
+  }
+
   fun map<Value2>(tick: Tick, f: (K, V) -> Value2): DMap<K, Value2> {
     this match {
     | Nil() -> Nil()

--- a/skiplang/prelude/src/skstore/DeletedDir.sk
+++ b/skiplang/prelude/src/skstore/DeletedDir.sk
@@ -29,6 +29,10 @@ class DeletedDir protected {} extends TDir {
   fun typed(): this {
     this
   }
+
+  fun invalidate(_: mutable Context): void {
+    void
+  }
 }
 
 module end;

--- a/skiplang/prelude/src/skstore/Dir.sk
+++ b/skiplang/prelude/src/skstore/Dir.sk
@@ -29,6 +29,8 @@ base class Dir protected {timeStack: TimeStack, dirName: DirName} {
   fun typed(): TDir;
 
   fun addReaderKeyToKeySetOpt(arrowKey: ArrowKey, keySetOpt: ?KeySet): KeySet;
+
+  fun invalidate(context: mutable Context): void;
 }
 
 base class TDir extends Dir {

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -397,6 +397,10 @@ class DataMapValue{
     | Some(x) -> Some(x.i1)
     }
   }
+
+  fun sources(): Array<Path> {
+    this.map.keys().collect(Array)
+  }
 }
 
 class DataMap<K: Orderable> private {
@@ -2291,6 +2295,29 @@ class TEagerDir extends EagerDir, TDir {
         static::addChildToParent(context, parentName, childName, rangeOpt);
       }
     };
+  }
+
+  fun invalidate(context: mutable Context): void {
+    parents = SortedSet::createFromIterator(
+      this.parents.items().map(v -> v.i0),
+    );
+    this.keys().each(key -> {
+      sources = this.data.maybeGet(key) match {
+      | None() -> this.fixedData.data.getIter(key).map(v -> v.i1).collect(Array)
+      | Some(modified) -> modified.sources()
+      };
+      for (source in sources) {
+        if (parents.contains(source.dirName)) {
+          context.updateDirtyReader(
+            TArrowKey::create{
+              parentName => source.dirName,
+              childName => this.dirName,
+              key => source.baseName,
+            },
+          )
+        }
+      }
+    });
   }
 }
 

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -725,6 +725,12 @@ base class EagerDir protected {
     this
   }
 
+  // renew creation time to force notification
+  fun renew(context: mutable Context): void {
+    !this.created = context.getTick();
+    context.setDir(this);
+  }
+
   protected fun writeDiff(
     isReset: Bool,
     changes: mutable Iterator<Key>,

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -2309,16 +2309,13 @@ class TEagerDir extends EagerDir, TDir {
   }
 
   fun invalidate(context: mutable Context): void {
-    parents = SortedSet::createFromIterator(
-      this.parents.items().map(v -> v.i0),
-    );
     this.keys().each(key -> {
       sources = this.data.maybeGet(key) match {
       | None() -> this.fixedData.data.getIter(key).map(v -> v.i1).collect(Array)
       | Some(modified) -> modified.sources()
       };
       for (source in sources) {
-        if (parents.contains(source.dirName)) {
+        if (this.parents.containsKey(source.dirName)) {
           context.updateDirtyReader(
             TArrowKey::create{
               parentName => source.dirName,

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -2013,7 +2013,12 @@ base class EagerDir protected {
     this.writeArray(context, baseName, Array[]);
   }
 
-  fun notifySubWatch(start: Tick, tick: Tick, nWatch: NWatch): void {
+  fun notifySubWatch(
+    context: readonly Context,
+    start: Tick,
+    tick: Tick,
+    nWatch: NWatch,
+  ): void {
     (init, changedKeys) = if (this.created >= start || start <= nWatch.from) {
       (true, SortedSet[])
     } else {
@@ -2034,7 +2039,7 @@ base class EagerDir protected {
         result.push((key, values))
       };
       fn = Unsafe.cast(nWatch, TNWatch<Key, File>).fn;
-      fn(result.toArray(), tick, !init)
+      fn(context, result.toArray(), tick, !init)
     }
   }
 

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -486,6 +486,10 @@ class FixedSingle<K: Orderable, +V: frozen> private (
     if (elt.i0 != key) return None();
     Some(elt.i1);
   }
+
+  fun containsKey(key: K): Bool {
+    this.maybeGet(key).isSome()
+  }
 }
 
 // Mapping from source paths to MInfo

--- a/skiplang/prelude/src/skstore/Handle.sk
+++ b/skiplang/prelude/src/skstore/Handle.sk
@@ -562,6 +562,10 @@ class EHandle<K: Key, V: File> extends Handle<K, V> {
   fun containsKey(context: mutable Context, key: K): Bool {
     this.getArray(context, key).size() > 0
   }
+
+  fun renew(context: mutable Context): void {
+    context.unsafeGetEagerDir(this.dirName).renew(context);
+  }
 }
 
 module end;

--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -136,6 +136,16 @@ class TLazyDir{
     context.setDir(this);
   }
 
+  fun invalidate(context: mutable Context): void {
+    data = this.data;
+    this.keys().each(key -> {
+      !data[key] = LAbsent();
+      path = Path::create(this.dirName, key);
+      context.updateDirtyReaders(path);
+    });
+    context.setDir(this with {data});
+  }
+
   protected fun doGet(context: mutable Context, key: Key): LazyResult<File> {
     dirName = this.dirName;
 

--- a/skipruntime-ts/addon/src/cjson.cc
+++ b/skipruntime-ts/addon/src/cjson.cc
@@ -272,7 +272,7 @@ void CreateCJBool(const FunctionCallbackInfo<Value>& args) {
   };
   NatTryCatch(isolate, [&args](Isolate* isolate) {
     bool skvalue = args[0].As<Boolean>()->Value();
-    CJSON skbool = SKIP_SKJSON_createCJFloat(skvalue);
+    CJSON skbool = SKIP_SKJSON_createCJBool(skvalue);
     args.GetReturnValue().Set(External::New(isolate, skbool));
   });
 }

--- a/skipruntime-ts/addon/src/common.cc
+++ b/skipruntime-ts/addon/src/common.cc
@@ -314,6 +314,29 @@ char* CallJSStringFunction(Isolate* isolate, Local<Object> binding,
       [](Isolate* _i) {});
 }
 
+char* CallNullableStringFunction(Isolate* isolate, Local<Object> binding,
+                                 const char* name, int argc,
+                                 Local<Value> argv[]) {
+  Local<Function> function = CheckFunction(isolate, binding, name);
+  return (char*)SKTryCatch(
+      isolate, function, binding, argc, argv,
+      [](Isolate* isolate, Local<Value> result) {
+        if (!result->IsString() && !result->IsNull()) {
+          const char* message = "Invalid function return type";
+          char* skempty = sk_string_create("", 0);
+          char* skmessage = sk_string_create(message, strlen(message));
+          SkipRuntime_throwExternalException(skempty, skmessage, skempty);
+        }
+        if (result->IsNull()) {
+          return (char*)nullptr;
+        }
+        String::Utf8Value v8Str(isolate, result.As<String>());
+        std::string cppStr(*v8Str);
+        return sk_string_create(cppStr.c_str(), cppStr.size());
+      },
+      [](Isolate* _i) {});
+}
+
 void NatTryCatch(Isolate* isolate, std::function<void(Isolate*)> run) {
   try {
     run(isolate);

--- a/skipruntime-ts/addon/src/common.h
+++ b/skipruntime-ts/addon/src/common.h
@@ -31,6 +31,8 @@ double CallJSNumberFunction(v8::Isolate*, v8::Local<v8::Object>, const char*,
                             int, v8::Local<v8::Value>[]);
 char* CallJSStringFunction(v8::Isolate*, v8::Local<v8::Object>, const char*,
                            int, v8::Local<v8::Value>[]);
+char* CallNullableStringFunction(v8::Isolate*, v8::Local<v8::Object>,
+                                 const char*, int, v8::Local<v8::Value>[]);
 void NatTryCatch(v8::Isolate*, std::function<void(v8::Isolate*)>);
 void RunWithGC(const v8::FunctionCallbackInfo<v8::Value>&);
 void GetErrorObject(const v8::FunctionCallbackInfo<v8::Value>&);

--- a/skipruntime-ts/addon/src/common.h
+++ b/skipruntime-ts/addon/src/common.h
@@ -62,10 +62,6 @@ struct SkipException : std::exception {
 #define SKContext void*
 #define SKNonEmptyIterator void*
 #define SKResource void*
-#define SKResourceBuilderMap void*
-#define SKResourceBuilder void*
-#define SKExternalServiceMap void*
-#define SKExternalService void*
 #define SKLazyCompute void*
 #define SKChecker void*
 #define SKExecutor void*

--- a/skipruntime-ts/addon/src/fromjs.cc
+++ b/skipruntime-ts/addon/src/fromjs.cc
@@ -312,6 +312,16 @@ CJSON SkipRuntime_Reducer__remove(uint32_t reducerId, CJSON acc, CJSON value) {
                                 "SkipRuntime_Reducer__remove", 3, argv);
 }
 
+CJSON SkipRuntime_Reducer__init(uint32_t reducerId) {
+  Isolate* isolate = Isolate::GetCurrent();
+  Local<Object> externFunctions = kExternFunctions.Get(isolate);
+  Local<Value> argv[1] = {
+      Number::New(isolate, reducerId),
+  };
+  return CallJSFunction(isolate, externFunctions, "SkipRuntime_Reducer__init",
+                        1, argv);
+}
+
 void SkipRuntime_deleteReducer(uint32_t reducerId) {
   Isolate* isolate = Isolate::GetCurrent();
   Local<Object> externFunctions = kExternFunctions.Get(isolate);

--- a/skipruntime-ts/addon/src/fromjs.cc
+++ b/skipruntime-ts/addon/src/fromjs.cc
@@ -12,6 +12,7 @@ using skbinding::CallJSStringFunction;
 using skbinding::CallJSVoidFunction;
 using skbinding::FromUtf8;
 
+using v8::BigInt;
 using v8::External;
 using v8::Isolate;
 using v8::Local;
@@ -128,6 +129,15 @@ void SkipRuntime_Executor__resolve(uint32_t checkerId) {
   Local<Value> argv[1] = {Number::New(isolate, checkerId)};
   CallJSVoidFunction(isolate, externFunctions, "SkipRuntime_Executor__resolve",
                      1, argv);
+}
+
+void SkipRuntime_IntExecutor__resolve(uint32_t checkerId, int64_t instance) {
+  Isolate* isolate = Isolate::GetCurrent();
+  Local<Object> externFunctions = kExternFunctions.Get(isolate);
+  Local<Value> argv[2] = {Number::New(isolate, checkerId),
+                          BigInt::New(isolate, instance)};
+  CallJSVoidFunction(isolate, externFunctions,
+                     "SkipRuntime_IntExecutor__resolve", 2, argv);
 }
 
 void SkipRuntime_Executor__reject(uint32_t checkerId, double handle) {

--- a/skipruntime-ts/addon/src/fromjs.cc
+++ b/skipruntime-ts/addon/src/fromjs.cc
@@ -102,50 +102,6 @@ void SkipRuntime_deleteLazyCompute(uint32_t lazyComputeId) {
                      1, argv);
 }
 
-void SkipRuntime_ExternalService__subscribe(uint32_t externalSupplierId,
-                                            char* collection, char* sessionId,
-                                            char* resource, CJObject params) {
-  Isolate* isolate = Isolate::GetCurrent();
-  Local<Object> externFunctions = kExternFunctions.Get(isolate);
-  Local<Value> argv[5] = {
-      Number::New(isolate, externalSupplierId),
-      FromUtf8(isolate, collection),
-      FromUtf8(isolate, sessionId),
-      FromUtf8(isolate, resource),
-      External::New(isolate, params),
-  };
-  return CallJSVoidFunction(isolate, externFunctions,
-                            "SkipRuntime_ExternalService__subscribe", 5, argv);
-}
-
-void SkipRuntime_ExternalService__unsubscribe(uint32_t externalSupplierId,
-                                              char* sessionId) {
-  Isolate* isolate = Isolate::GetCurrent();
-  Local<Object> externFunctions = kExternFunctions.Get(isolate);
-  Local<Value> argv[2] = {
-      Number::New(isolate, externalSupplierId),
-      FromUtf8(isolate, sessionId),
-  };
-  CallJSVoidFunction(isolate, externFunctions,
-                     "SkipRuntime_ExternalService__unsubscribe", 2, argv);
-}
-
-double SkipRuntime_ExternalService__shutdown(uint32_t externalSupplierId) {
-  Isolate* isolate = Isolate::GetCurrent();
-  Local<Object> externFunctions = kExternFunctions.Get(isolate);
-  Local<Value> argv[1] = {Number::New(isolate, externalSupplierId)};
-  return CallJSNumberFunction(isolate, externFunctions,
-                              "SkipRuntime_ExternalService__shutdown", 1, argv);
-}
-
-void SkipRuntime_deleteExternalService(uint32_t externalSupplierId) {
-  Isolate* isolate = Isolate::GetCurrent();
-  Local<Object> externFunctions = kExternFunctions.Get(isolate);
-  Local<Value> argv[1] = {Number::New(isolate, externalSupplierId)};
-  CallJSVoidFunction(isolate, externFunctions,
-                     "SkipRuntime_deleteExternalService", 1, argv);
-}
-
 char* SkipRuntime_Resource__instantiate(uint32_t resourceId,
                                         CJObject collections) {
   Isolate* isolate = Isolate::GetCurrent();
@@ -163,45 +119,6 @@ void SkipRuntime_deleteResource(uint32_t resourceId) {
   Local<Object> externFunctions = kExternFunctions.Get(isolate);
   Local<Value> argv[1] = {Number::New(isolate, resourceId)};
   CallJSVoidFunction(isolate, externFunctions, "SkipRuntime_deleteResource", 1,
-                     argv);
-}
-
-SKResource SkipRuntime_ResourceBuilder__build(uint32_t builderId,
-                                              CJObject params) {
-  Isolate* isolate = Isolate::GetCurrent();
-  Local<Object> externFunctions = kExternFunctions.Get(isolate);
-  Local<Value> argv[2] = {
-      Number::New(isolate, builderId),
-      External::New(isolate, params),
-  };
-  return CallJSFunction(isolate, externFunctions,
-                        "SkipRuntime_ResourceBuilder__build", 2, argv);
-}
-
-void SkipRuntime_deleteResourceBuilder(uint32_t resourceBuilderId) {
-  Isolate* isolate = Isolate::GetCurrent();
-  Local<Object> externFunctions = kExternFunctions.Get(isolate);
-  Local<Value> argv[1] = {Number::New(isolate, resourceBuilderId)};
-  CallJSVoidFunction(isolate, externFunctions,
-                     "SkipRuntime_deleteResourceBuilder", 1, argv);
-}
-
-void SkipRuntime_Checker__check(uint32_t executorId, char* request) {
-  Isolate* isolate = Isolate::GetCurrent();
-  Local<Object> externFunctions = kExternFunctions.Get(isolate);
-  Local<Value> argv[2] = {
-      Number::New(isolate, executorId),
-      FromUtf8(isolate, request),
-  };
-  CallJSVoidFunction(isolate, externFunctions, "SkipRuntime_Checker__check", 2,
-                     argv);
-}
-
-void SkipRuntime_deleteChecker(uint32_t checkerId) {
-  Isolate* isolate = Isolate::GetCurrent();
-  Local<Object> externFunctions = kExternFunctions.Get(isolate);
-  Local<Value> argv[1] = {Number::New(isolate, checkerId)};
-  CallJSVoidFunction(isolate, externFunctions, "SkipRuntime_deleteChecker", 1,
                      argv);
 }
 
@@ -238,8 +155,94 @@ void SkipRuntime_deleteService(uint32_t serviceId) {
                      argv);
 }
 
-CJObject SkipRuntime_Service__createGraph(uint32_t serviceId,
-                                          CJObject collections) {
+void SkipRuntime_ServiceDefinition__subscribe(uint32_t serviceId,
+                                              char* collection, char* supplier,
+                                              char* sessionId, char* resource,
+                                              CJObject params) {
+  Isolate* isolate = Isolate::GetCurrent();
+  Local<Object> externFunctions = kExternFunctions.Get(isolate);
+  Local<Value> argv[6] = {
+      Number::New(isolate, serviceId), FromUtf8(isolate, collection),
+      FromUtf8(isolate, supplier),     FromUtf8(isolate, sessionId),
+      FromUtf8(isolate, resource),     External::New(isolate, params),
+  };
+  return CallJSVoidFunction(isolate, externFunctions,
+                            "SkipRuntime_ServiceDefinition__subscribe", 6,
+                            argv);
+}
+
+void SkipRuntime_ServiceDefinition__unsubscribe(uint32_t serviceId,
+                                                char* supplier,
+                                                char* sessionId) {
+  Isolate* isolate = Isolate::GetCurrent();
+  Local<Object> externFunctions = kExternFunctions.Get(isolate);
+  Local<Value> argv[3] = {
+      Number::New(isolate, serviceId),
+      FromUtf8(isolate, supplier),
+      FromUtf8(isolate, sessionId),
+  };
+  CallJSVoidFunction(isolate, externFunctions,
+                     "SkipRuntime_ServiceDefinition__unsubscribe", 3, argv);
+}
+
+double SkipRuntime_ServiceDefinition__shutdown(uint32_t serviceId) {
+  Isolate* isolate = Isolate::GetCurrent();
+  Local<Object> externFunctions = kExternFunctions.Get(isolate);
+  Local<Value> argv[1] = {Number::New(isolate, serviceId)};
+  return CallJSNumberFunction(isolate, externFunctions,
+                              "SkipRuntime_ServiceDefinition__shutdown", 1,
+                              argv);
+}
+
+CJArray SkipRuntime_ServiceDefinition__inputs(uint32_t serviceId) {
+  Isolate* isolate = Isolate::GetCurrent();
+  Local<Object> externFunctions = kExternFunctions.Get(isolate);
+  Local<Value> argv[1] = {
+      Number::New(isolate, serviceId),
+  };
+  return CallJSFunction(isolate, externFunctions,
+                        "SkipRuntime_ServiceDefinition__inputs", 1, argv);
+}
+
+CJArray SkipRuntime_ServiceDefinition__initialData(uint32_t serviceId,
+                                                   char* input) {
+  Isolate* isolate = Isolate::GetCurrent();
+  Local<Object> externFunctions = kExternFunctions.Get(isolate);
+  Local<Value> argv[2] = {
+      Number::New(isolate, serviceId),
+      FromUtf8(isolate, input),
+  };
+  return CallJSFunction(isolate, externFunctions,
+                        "SkipRuntime_ServiceDefinition__initialData", 2, argv);
+}
+
+CJArray SkipRuntime_ServiceDefinition__resources(uint32_t serviceId) {
+  Isolate* isolate = Isolate::GetCurrent();
+  Local<Object> externFunctions = kExternFunctions.Get(isolate);
+  Local<Value> argv[1] = {
+      Number::New(isolate, serviceId),
+  };
+  return CallJSFunction(isolate, externFunctions,
+                        "SkipRuntime_ServiceDefinition__resources", 1, argv);
+}
+
+SKResource SkipRuntime_ServiceDefinition__buildResource(uint32_t serviceId,
+                                                        char* resource,
+                                                        CJObject params) {
+  Isolate* isolate = Isolate::GetCurrent();
+  Local<Object> externFunctions = kExternFunctions.Get(isolate);
+  Local<Value> argv[3] = {
+      Number::New(isolate, serviceId),
+      FromUtf8(isolate, resource),
+      External::New(isolate, params),
+  };
+  return CallJSFunction(isolate, externFunctions,
+                        "SkipRuntime_ServiceDefinition__buildResource", 3,
+                        argv);
+}
+
+CJObject SkipRuntime_ServiceDefinition__createGraph(uint32_t serviceId,
+                                                    CJObject collections) {
   Isolate* isolate = Isolate::GetCurrent();
   Local<Object> externFunctions = kExternFunctions.Get(isolate);
   Local<Value> argv[2] = {
@@ -247,7 +250,7 @@ CJObject SkipRuntime_Service__createGraph(uint32_t serviceId,
       External::New(isolate, collections),
   };
   return CallJSFunction(isolate, externFunctions,
-                        "SkipRuntime_Service__createGraph", 2, argv);
+                        "SkipRuntime_ServiceDefinition__createGraph", 2, argv);
 }
 
 void SkipRuntime_Notifier__subscribed(uint32_t notifierId) {

--- a/skipruntime-ts/addon/src/fromjs.cc
+++ b/skipruntime-ts/addon/src/fromjs.cc
@@ -10,6 +10,7 @@ using skbinding::CallJSNullableFunction;
 using skbinding::CallJSNumberFunction;
 using skbinding::CallJSStringFunction;
 using skbinding::CallJSVoidFunction;
+using skbinding::CallNullableStringFunction;
 using skbinding::FromUtf8;
 
 using v8::BigInt;
@@ -212,6 +213,16 @@ CJArray SkipRuntime_ServiceDefinition__inputs(uint32_t serviceId) {
   };
   return CallJSFunction(isolate, externFunctions,
                         "SkipRuntime_ServiceDefinition__inputs", 1, argv);
+}
+
+char* SkipRuntime_ServiceDefinition__from(uint32_t serviceId) {
+  Isolate* isolate = Isolate::GetCurrent();
+  Local<Object> externFunctions = kExternFunctions.Get(isolate);
+  Local<Value> argv[1] = {
+      Number::New(isolate, serviceId),
+  };
+  return CallNullableStringFunction(
+      isolate, externFunctions, "SkipRuntime_ServiceDefinition__from", 1, argv);
 }
 
 CJArray SkipRuntime_ServiceDefinition__initialData(uint32_t serviceId,

--- a/skipruntime-ts/addon/src/tojs.cc
+++ b/skipruntime-ts/addon/src/tojs.cc
@@ -15,14 +15,6 @@ double SkipRuntime_CollectionWriter__update(char* collection, CJArray values,
 double SkipRuntime_CollectionWriter__initialized(char* collection, CJSON error);
 double SkipRuntime_CollectionWriter__error(char* collection, CJSON error);
 
-SKResourceBuilderMap SkipRuntime_ResourceBuilderMap__create();
-void SkipRuntime_ResourceBuilderMap__add(SKResourceBuilderMap builders,
-                                         char* name, SKResourceBuilder builder);
-
-SKExternalServiceMap SkipRuntime_ExternalServiceMap__create();
-void SkipRuntime_ExternalServiceMap__add(SKExternalServiceMap services,
-                                         char* name, SKExternalService service);
-
 char* SkipRuntime_Context__createLazyCollection(SKLazyCompute lazyCompute);
 CJArray SkipRuntime_Context__jsonExtract(CJObject json, char* pattern);
 char* SkipRuntime_Context__useExternalResource(char* service, char* identifier,
@@ -30,18 +22,14 @@ char* SkipRuntime_Context__useExternalResource(char* service, char* identifier,
 
 SKMapper SkipRuntime_createMapper(int32_t ref);
 SKLazyCompute SkipRuntime_createLazyCompute(int32_t ref);
-SKExternalService SkipRuntime_createExternalService(int32_t ref);
 SKResource SkipRuntime_createResource(int32_t ref);
-SKResourceBuilder SkipRuntime_createResourceBuilder(int32_t ref);
 SKExecutor SkipRuntime_createExecutor(int32_t ref);
-SKService SkipRuntime_createService(int32_t ref, CJObject inputs,
-                                    SKResourceBuilderMap resources,
-                                    SKExternalServiceMap exservices);
+SKService SkipRuntime_createService(int32_t ref);
 SKNotifier SkipRuntime_createNotifier(int32_t ref);
 SKReducer SkipRuntime_createReducer(int32_t ref, CJSON json);
 
 double SkipRuntime_initService(SKService service, SKExecutor executor);
-CJSON SkipRuntime_closeService();
+double SkipRuntime_closeService();
 double SkipRuntime_invalidateCollections(CJArray collections);
 
 CJArray SkipRuntime_Collection__getArray(char* collection, CJSON key);
@@ -194,90 +182,6 @@ void ErrorOfCollectionWriter(const FunctionCallbackInfo<Value>& args) {
   });
 }
 
-void CreateOfResourceBuilderMap(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  NatTryCatch(isolate, [&args](Isolate* isolate) {
-    SKResourceBuilderMap skmap = SkipRuntime_ResourceBuilderMap__create();
-    args.GetReturnValue().Set(External::New(isolate, skmap));
-  });
-}
-
-void AddOfResourceBuilderMap(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  if (args.Length() != 3) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(
-        Exception::TypeError(FromUtf8(isolate, "Must have three parameters.")));
-    return;
-  };
-  if (!args[0]->IsExternal()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The first parameter must be a pointer.")));
-    return;
-  }
-  if (!args[1]->IsString()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The second parameter must be a string.")));
-    return;
-  }
-  if (!args[2]->IsExternal()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The third parameter must be a pointer.")));
-    return;
-  }
-  NatTryCatch(isolate, [&args](Isolate* isolate) {
-    SkipRuntime_ResourceBuilderMap__add(
-        args[0].As<External>()->Value(),
-        ToSKString(isolate, args[1].As<String>()),
-        args[2].As<External>()->Value());
-  });
-}
-
-void CreateOfExternalServiceMap(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  NatTryCatch(isolate, [&args](Isolate* isolate) {
-    SKExternalServiceMap skmap = SkipRuntime_ExternalServiceMap__create();
-    args.GetReturnValue().Set(External::New(isolate, skmap));
-  });
-}
-
-void AddOfExternalServiceMap(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  if (args.Length() != 3) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(
-        Exception::TypeError(FromUtf8(isolate, "Must have three parameters.")));
-    return;
-  };
-  if (!args[0]->IsExternal()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The first parameter must be a pointer.")));
-    return;
-  }
-  if (!args[1]->IsString()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The second parameter must be a string.")));
-    return;
-  }
-  if (!args[2]->IsExternal()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The third parameter must be a pointer.")));
-    return;
-  }
-  NatTryCatch(isolate, [&args](Isolate* isolate) {
-    SkipRuntime_ExternalServiceMap__add(
-        args[0].As<External>()->Value(),
-        ToSKString(isolate, args[1].As<String>()),
-        args[2].As<External>()->Value());
-  });
-}
-
 void CreateLazyCollectionOfContext(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   if (!args[0]->IsExternal()) {
@@ -390,27 +294,6 @@ void CreateLazyCompute(const FunctionCallbackInfo<Value>& args) {
   });
 }
 
-void CreateExternalService(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  if (args.Length() != 1) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(
-        Exception::TypeError(FromUtf8(isolate, "Must have one parameter.")));
-    return;
-  };
-  if (!args[0]->IsNumber()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The parameter must be a number.")));
-    return;
-  }
-  NatTryCatch(isolate, [&args](Isolate* isolate) {
-    SKExternalService skexternalService =
-        SkipRuntime_createExternalService(args[0].As<Int32>()->Value());
-    args.GetReturnValue().Set(External::New(isolate, skexternalService));
-  });
-}
-
 void CreateResource(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   if (args.Length() != 1) {
@@ -429,27 +312,6 @@ void CreateResource(const FunctionCallbackInfo<Value>& args) {
     SKResource skResource =
         SkipRuntime_createResource(args[0].As<Int32>()->Value());
     args.GetReturnValue().Set(External::New(isolate, skResource));
-  });
-}
-
-void CreateResourceBuilder(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  if (args.Length() != 1) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(
-        Exception::TypeError(FromUtf8(isolate, "Must have one parameter.")));
-    return;
-  };
-  if (!args[0]->IsNumber()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(Exception::TypeError(
-        FromUtf8(isolate, "The parameter must be a number.")));
-    return;
-  }
-  NatTryCatch(isolate, [&args](Isolate* isolate) {
-    SKResourceBuilder skResourceBuilder =
-        SkipRuntime_createResourceBuilder(args[0].As<Int32>()->Value());
-    args.GetReturnValue().Set(External::New(isolate, skResourceBuilder));
   });
 }
 
@@ -476,10 +338,10 @@ void CreateExecutor(const FunctionCallbackInfo<Value>& args) {
 
 void CreateService(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  if (args.Length() != 4) {
+  if (args.Length() != 1) {
     // Throw an Error that is passed back to JavaScript
     isolate->ThrowException(
-        Exception::TypeError(FromUtf8(isolate, "Must have four parameters.")));
+        Exception::TypeError(FromUtf8(isolate, "Must have one parameters.")));
     return;
   };
   if (!args[0]->IsNumber()) {
@@ -488,17 +350,9 @@ void CreateService(const FunctionCallbackInfo<Value>& args) {
         FromUtf8(isolate, "The parameter must be a number.")));
     return;
   }
-  if (!args[1]->IsExternal() || !args[2]->IsExternal() ||
-      !args[3]->IsExternal()) {
-    // Throw an Error that is passed back to JavaScript
-    isolate->ThrowException(
-        Exception::TypeError(FromUtf8(isolate, "Invalid parameter types.")));
-    return;
-  }
   NatTryCatch(isolate, [&args](Isolate* isolate) {
-    SKService skService = SkipRuntime_createService(
-        args[0].As<Int32>()->Value(), args[1].As<External>()->Value(),
-        args[2].As<External>()->Value(), args[3].As<External>()->Value());
+    SKService skService =
+        SkipRuntime_createService(args[0].As<Int32>()->Value());
     args.GetReturnValue().Set(External::New(isolate, skService));
   });
 }
@@ -575,8 +429,8 @@ void InitService(const FunctionCallbackInfo<Value>& args) {
 void CloseService(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   NatTryCatch(isolate, [&args](Isolate* isolate) {
-    CJSON skresult = SkipRuntime_closeService();
-    args.GetReturnValue().Set(External::New(isolate, skresult));
+    double skresult = SkipRuntime_closeService();
+    args.GetReturnValue().Set(Number::New(isolate, skresult));
   });
 }
 
@@ -1110,16 +964,6 @@ void GetToJSBinding(const FunctionCallbackInfo<Value>& args) {
   AddFunction(isolate, binding, "SkipRuntime_CollectionWriter__error",
               ErrorOfCollectionWriter);
   //
-  AddFunction(isolate, binding, "SkipRuntime_ResourceBuilderMap__create",
-              CreateOfResourceBuilderMap);
-  AddFunction(isolate, binding, "SkipRuntime_ResourceBuilderMap__add",
-              AddOfResourceBuilderMap);
-  //
-  AddFunction(isolate, binding, "SkipRuntime_ExternalServiceMap__create",
-              CreateOfExternalServiceMap);
-  AddFunction(isolate, binding, "SkipRuntime_ExternalServiceMap__add",
-              AddOfExternalServiceMap);
-  //
   AddFunction(isolate, binding, "SkipRuntime_Context__createLazyCollection",
               CreateLazyCollectionOfContext);
   AddFunction(isolate, binding, "SkipRuntime_Context__jsonExtract",
@@ -1130,11 +974,7 @@ void GetToJSBinding(const FunctionCallbackInfo<Value>& args) {
   AddFunction(isolate, binding, "SkipRuntime_createMapper", CreateMapper);
   AddFunction(isolate, binding, "SkipRuntime_createLazyCompute",
               CreateLazyCompute);
-  AddFunction(isolate, binding, "SkipRuntime_createExternalService",
-              CreateExternalService);
   AddFunction(isolate, binding, "SkipRuntime_createResource", CreateResource);
-  AddFunction(isolate, binding, "SkipRuntime_createResourceBuilder",
-              CreateResourceBuilder);
   AddFunction(isolate, binding, "SkipRuntime_createExecutor", CreateExecutor);
   AddFunction(isolate, binding, "SkipRuntime_createService", CreateService);
   AddFunction(isolate, binding, "SkipRuntime_createNotifier", CreateNotifier);

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -10,6 +10,7 @@ import {
   type Resource,
   type SkipService,
 } from "./api.js";
+import type { HandlerInfo } from "./index.js";
 
 export type Handle<T> = Internal.Opaque<number, { handle_for: T }>;
 
@@ -50,13 +51,13 @@ export interface FromBinding {
     K2 extends Json,
     V2 extends Json,
   >(
-    ref: Handle<Mapper<K1, V1, K2, V2>>,
+    ref: Handle<HandlerInfo<Mapper<K1, V1, K2, V2>>>,
   ): Pointer<Internal.Mapper>;
 
   // LazyCompute
 
   SkipRuntime_createLazyCompute<K extends Json, V extends Json>(
-    ref: Handle<LazyCompute<K, V>>,
+    ref: Handle<HandlerInfo<LazyCompute<K, V>>>,
   ): Pointer<Internal.LazyCompute>;
 
   // ExternalService
@@ -218,7 +219,7 @@ export interface FromBinding {
   // Reducer
 
   SkipRuntime_createReducer<K1 extends Json, V1 extends Json>(
-    ref: Handle<Reducer<K1, V1>>,
+    ref: Handle<HandlerInfo<Reducer<K1, V1>>>,
     defaultValue: Pointer<Internal.CJSON>,
   ): Pointer<Internal.Reducer>;
 

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -235,8 +235,9 @@ export interface FromBinding {
   SkipRuntime_closeService(
     identifier: string,
   ): Handle<Error> | Handle<Promise<unknown>>;
+
   SkipRuntime_invalidateCollections(
-    collections: Pointer<Internal.CJArray<Internal.CJSON>>,
+    collections: Pointer<Internal.CJArray<Internal.CJString>>,
   ): Handle<Error>;
 
   // Context

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -8,9 +8,8 @@ import {
   type Mapper,
   type Reducer,
   type Resource,
-  type SkipService,
 } from "./api.js";
-import type { HandlerInfo } from "./index.js";
+import type { HandlerInfo, ServiceDefinition } from "./index.js";
 
 export type Handle<T> = Internal.Opaque<number, { handle_for: T }>;
 
@@ -84,42 +83,15 @@ export interface FromBinding {
     name: string,
     error: Pointer<Internal.CJSON>,
   ): Handle<Error>;
-
   // Resource
 
   SkipRuntime_createResource(ref: Handle<Resource>): Pointer<Internal.Resource>;
 
-  // ResourceBuilder
-  SkipRuntime_createResourceBuilder(
-    ref: Handle<ResourceBuilder>,
-  ): Pointer<Internal.ResourceBuilder>;
+  // Service
 
-  // ResourceBuilder
   SkipRuntime_createService(
-    ref: Handle<SkipService>,
-    jsInputs: Pointer<Internal.CJObject>,
-    resources: Pointer<Internal.ResourceBuilderMap>,
-    remotes: Pointer<Internal.ExternalServiceMap>,
+    ref: Handle<ServiceDefinition>,
   ): Pointer<Internal.Service>;
-
-  // ResourceBuilderMap
-
-  SkipRuntime_ResourceBuilderMap__create(): Pointer<Internal.ResourceBuilderMap>;
-
-  SkipRuntime_ResourceBuilderMap__add(
-    map: Pointer<Internal.ResourceBuilderMap>,
-    key: string,
-    collection: Pointer<Internal.ResourceBuilder>,
-  ): void;
-
-  // ExternalServiceMap
-
-  SkipRuntime_ExternalServiceMap__create(): Pointer<Internal.ExternalServiceMap>;
-  SkipRuntime_ExternalServiceMap__add(
-    map: Pointer<Internal.ExternalServiceMap>,
-    key: string,
-    collection: Pointer<Internal.ExternalService>,
-  ): void;
 
   // Collection
 
@@ -230,7 +202,7 @@ export interface FromBinding {
   ): Handle<Error>;
 
   // closeClose
-  SkipRuntime_closeService(): Pointer<Internal.CJSON>;
+  SkipRuntime_closeService(): Handle<Error> | Handle<Promise<unknown>>;
   SkipRuntime_invalidateCollections(
     collections: Pointer<Internal.CJArray<Internal.CJSON>>,
   ): Handle<Error>;

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -179,6 +179,7 @@ export interface FromBinding {
   ): Handle<Error>;
 
   SkipRuntime_Runtime__replaceActiveResources(
+    service: string,
     resources: Pointer<Internal.CJArray<Internal.CJObject>>,
   ): Handle<Error>;
 

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -231,6 +231,9 @@ export interface FromBinding {
 
   // closeClose
   SkipRuntime_closeService(): Pointer<Internal.CJSON>;
+  SkipRuntime_invalidateCollections(
+    collections: Pointer<Internal.CJArray<Internal.CJSON>>,
+  ): Handle<Error>;
 
   // Context
 

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -37,6 +37,11 @@ export type Executor = {
   reject: (reason: Error) => void;
 };
 
+export type IntExecutor = {
+  resolve: (value: bigint) => void;
+  reject: (reason: Error) => void;
+};
+
 export interface FromBinding {
   // NonEmptyIterator
   SkipRuntime_NonEmptyIterator__next(
@@ -161,6 +166,24 @@ export interface FromBinding {
     executor: Pointer<Internal.Executor>,
   ): Handle<Error>;
 
+  SkipRuntime_Runtime__resourceInstances(
+    resources: Pointer<Internal.CJArray<Internal.CJString>>,
+  ): Pointer<Internal.CJArray<Internal.CJObject>>;
+
+  SkipRuntime_Runtime__reloadResource(
+    resource: string,
+    jsonParams: Pointer<Internal.CJObject>,
+    executor: Pointer<Internal.Executor>,
+  ): Handle<Error>;
+
+  SkipRuntime_Runtime__replaceActiveResources(
+    resources: Pointer<Internal.CJArray<Internal.CJObject>>,
+  ): Handle<Error>;
+
+  SkipRuntime_Runtime__destroyResources(
+    resources: Pointer<Internal.CJArray<Internal.CJObject>>,
+  ): Handle<Error>;
+
   SkipRuntime_Runtime__getAll(
     resource: string,
     jsonParams: Pointer<Internal.CJObject>,
@@ -227,4 +250,7 @@ export interface FromBinding {
   // Executor
 
   SkipRuntime_createExecutor(ref: Handle<Executor>): Pointer<Internal.Executor>;
+  SkipRuntime_createIntExecutor(
+    ref: Handle<IntExecutor>,
+  ): Pointer<Internal.Executor>;
 }

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -160,6 +160,7 @@ export interface FromBinding {
   // Runtime
 
   SkipRuntime_Runtime__createResource(
+    service: string,
     identifier: string,
     resource: string,
     jsonParams: Pointer<Internal.CJObject>,
@@ -171,6 +172,7 @@ export interface FromBinding {
   ): Pointer<Internal.CJArray<Internal.CJObject>>;
 
   SkipRuntime_Runtime__reloadResource(
+    service: string,
     resource: string,
     jsonParams: Pointer<Internal.CJObject>,
     executor: Pointer<Internal.Executor>,
@@ -185,11 +187,13 @@ export interface FromBinding {
   ): Handle<Error>;
 
   SkipRuntime_Runtime__getAll(
+    service: string,
     resource: string,
     jsonParams: Pointer<Internal.CJObject>,
   ): Pointer<Internal.CJObject | Internal.CJFloat>;
 
   SkipRuntime_Runtime__getForKey(
+    service: string,
     resource: string,
     jsonParams: Pointer<Internal.CJObject>,
     key: Pointer<Internal.CJSON>,
@@ -206,6 +210,7 @@ export interface FromBinding {
   SkipRuntime_Runtime__unsubscribe(id: bigint): Handle<Error>;
 
   SkipRuntime_Runtime__update(
+    service: string,
     input: string,
     values: Pointer<Internal.CJArray<Internal.CJArray<Internal.CJSON>>>,
     executor: Pointer<Internal.Executor>,
@@ -220,12 +225,15 @@ export interface FromBinding {
 
   // initService
   SkipRuntime_initService(
+    identifier: string,
     service: Pointer<Internal.Service>,
     executor: Pointer<Internal.Executor>,
   ): Handle<Error>;
 
   // closeClose
-  SkipRuntime_closeService(): Handle<Error> | Handle<Promise<unknown>>;
+  SkipRuntime_closeService(
+    identifier: string,
+  ): Handle<Error> | Handle<Promise<unknown>>;
   SkipRuntime_invalidateCollections(
     collections: Pointer<Internal.CJArray<Internal.CJSON>>,
   ): Handle<Error>;
@@ -242,7 +250,7 @@ export interface FromBinding {
   ): Pointer<Internal.CJArray>;
 
   SkipRuntime_Context__useExternalResource(
-    service: string,
+    extservice: string,
     identifier: string,
     params: Pointer<Internal.CJObject>,
   ): string;

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -992,6 +992,14 @@ export class ToBinding {
 
   // Reducer
 
+  SkipRuntime_Reducer__init(
+    skreducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
+  ): Pointer<Internal.CJSON> {
+    const skjson = this.getJsonConverter();
+    const reducer = this.handles.get(skreducer);
+    return skjson.exportJSON(reducer.object.initial);
+  }
+
   SkipRuntime_Reducer__add(
     skreducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
     skacc: Nullable<Pointer<Internal.CJSON>>,

--- a/skipruntime-ts/skiplang/core/src/BaseTypes.sk
+++ b/skipruntime-ts/skiplang/core/src/BaseTypes.sk
@@ -1,7 +1,8 @@
 module SkipRuntime;
 
-base class Reducer<V1: frozen, V2: frozen>(initial: V2) {
+base class Reducer<V1: frozen, V2: frozen>() {
   fun getType(): SKStore.File ~> V2;
+  fun init(): V2;
   fun add(acc: V2, value: V1): V2;
   fun remove(acc: V2, value: V1): ?V2;
 }

--- a/skipruntime-ts/skiplang/core/src/BaseTypes.sk
+++ b/skipruntime-ts/skiplang/core/src/BaseTypes.sk
@@ -31,6 +31,8 @@ base class Resource {
 }
 
 base class Service {
+  fun from(): ?String;
+
   fun inputs(): Array<String>;
 
   fun initialData(name: String): Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)>;

--- a/skipruntime-ts/skiplang/core/src/BaseTypes.sk
+++ b/skipruntime-ts/skiplang/core/src/BaseTypes.sk
@@ -26,32 +26,31 @@ base class LazyCompute {
   fun compute(self: LazyCollection, key: SKJSON.CJSON): Array<SKJSON.CJSON>;
 }
 
-base class ExternalService {
+base class Resource {
+  fun instantiate(collections: Map<String, Collection>): Collection;
+}
+
+base class Service {
+  fun inputs(): Array<String>;
+
+  fun initialData(name: String): Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)>;
+
+  fun resources(): Array<String>;
+
+  fun buildResource(name: String, parameters: SKJSON.CJSON): Resource;
+
   fun subscribe(
+    external: String,
     instance: String,
     collection: CollectionWriter,
     resource: String,
     params: SKJSON.CJSON,
   ): void;
 
-  fun unsubscribe(instance: String): void;
+  fun unsubscribe(external: String, instance: String): void;
 
   fun shutdown(): Float;
-}
 
-base class Resource {
-  fun instantiate(collections: Map<String, Collection>): Collection;
-}
-
-base class ResourceBuilder {
-  fun build(parameters: SKJSON.CJSON): Resource;
-}
-
-base class Service(
-  initialData: Array<Input>,
-  resources: Map<String, ResourceBuilder>,
-  remoteCollections: Map<String, ExternalService> = Map[],
-) {
   fun createGraph(
     inputCollections: Map<String, Collection>,
   ): Map<String, Collection>;

--- a/skipruntime-ts/skiplang/core/src/BaseTypes.sk
+++ b/skipruntime-ts/skiplang/core/src/BaseTypes.sk
@@ -66,6 +66,11 @@ base class Executor {
   fun reject(exc: .Exception): void;
 }
 
+base class IntExecutor {
+  fun resolve(value: Int): void;
+  fun reject(exc: .Exception): void;
+}
+
 base class Notifier {
   fun subscribed(): void;
 

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -70,10 +70,15 @@ class ResourceCollection(value: Collection) extends SKStore.File
 class ResourceDef(
   name: String,
   params: SKJSON.CJSON,
+  instance: Int = 0,
 ) extends SKStore.File, SKStore.Key {
   //
   fun toString(): String {
-    `${this.name}:${this.params.prettyPrint()}`
+    `${this.name}:${this.params.prettyPrint()}:${this.instance}`
+  }
+
+  fun toId(): String {
+    `${toResourceId(this.name, this.params)}_${this.instance}`
   }
 }
 
@@ -170,6 +175,11 @@ class RemoteSpecifiers(
   value: Map<String, ExternalService>,
 ) extends SKStore.File
 
+class StatusRef(
+  resourceId: String,
+  statusRef: SKStore.DirName,
+) extends SKStore.File
+
 class ResourceInfo(
   name: String,
   collection: Collection,
@@ -233,11 +243,11 @@ fun buildResourcesGraph(
   );
   statusesHdl = availablesHdl.map(
     ResourceDef::keyType,
-    SKStore.StringFile::type,
+    StatusRef::type,
     context,
     kResourceStatusDir,
     (context, writer, key, _it) ~> {
-      resourceId = toResourceId(key.name, key.params);
+      resourceId = `${key.toId()}`;
       statusRef = dirname.sub(resourceId);
       // Status graph
       sStatusHdl = context
@@ -271,7 +281,7 @@ fun buildResourcesGraph(
           writer.set(key, requestStatuses);
         },
       );
-      writer.set(key, SKStore.StringFile(statusRef.toString()));
+      writer.set(key, StatusRef(resourceId, statusRef));
     },
   );
   _ = statusesHdl.map(
@@ -280,8 +290,8 @@ fun buildResourcesGraph(
     context,
     kResourceCollectionsDir,
     (context, writer, key, it) ~> {
-      resourceId = toResourceId(key.name, key.params);
-      statusRef = SKStore.DirName::create(it.first.value);
+      resourceId = it.first.resourceId;
+      statusRef = it.first.statusRef;
       (runId, resources) = definitionHdl.maybeGet(
         context,
         SKStore.UnitID::singleton,
@@ -1065,7 +1075,7 @@ private fun sessionId(
   context: readonly SKStore.Context,
   dir: SKStore.EagerDir,
 ): ?String {
-  resourceId(context, dir).map(def -> toResourceId(def.name, def.params))
+  resourceId(context, dir).map(def -> def.toId())
 }
 
 private fun isResourceDir(dirName: SKStore.DirName): Bool {
@@ -1129,10 +1139,7 @@ class CollectionWriter(dirName: SKStore.DirName) {
     | Some(dir) ->
       optResource = resourceId(context, dir);
       dirname = optResource match {
-      | Some(def) ->
-        kResourceSessionDir
-          .sub(toResourceId(def.name, def.params))
-          .sub("status")
+      | Some(def) -> kResourceSessionDir.sub(`${def.toId()}`).sub("status")
       | _ -> kSessionDir.sub("status")
       };
       shdl = SKStore.EHandle(

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -448,6 +448,21 @@ fun closeService(): Result<Array<Float>, .Exception> {
   SKStore.runWithResult(ctx ~> closeService_(ctx))
 }
 
+fun invalidateCollections(
+  jsonCollections: SKJSON.CJArray,
+): Result<void, .Exception> {
+  SKStore.runWithResult(context ~> {
+    collections = SKJSON.expectArray(jsonCollections).map(SKJSON.asString);
+    collections.each(collection -> {
+      context.maybeGetDir(SKStore.DirName::create(collection)) match {
+      | Some(dir) -> dir.invalidate(context)
+      | _ -> void
+      }
+    });
+    updateContext(context);
+  })
+}
+
 class LinkToResource(
   supplier: ExternalService,
   instance: String,

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -454,11 +454,14 @@ fun closeService_(
       kf.i1.next().each(f -> if (f.service == identifier) todestroy.push(kf.i0))
     );
     todestroy.each(key -> _ = destroyReactiveResource(context, key));
-    activeHdl.items(context).each(kf ->
-      if (kf.i0.service == identifier) {
-        activeHdl.writeArray(context, kf.i0, Array[])
-      }
-    );
+    activeHdl.items(context).each(kf -> {
+      kf.i1.next().each(_ ->
+        if (kf.i0.service == identifier) {
+          activeHdl.writeArray(context, kf.i0, Array[])
+        }
+      )
+    });
+    sessionHdl.writeArray(context, SKStore.SID(identifier), Array[]);
     def.service.shutdown()
   | _ -> 0.0
   };
@@ -1485,13 +1488,26 @@ fun delete(
   updateContext(context);
 }
 
+class ResourceExecutor(
+  executor: IntExecutor,
+  definition: ResourceDef,
+) extends Executor {
+  fun resolve(): void {
+    this.executor.resolve(this.definition.instance)
+  }
+
+  fun reject(exc: .Exception): void {
+    this.executor.reject(exc)
+  }
+}
+
 fun createReactiveResource(
   context: mutable SKStore.Context,
   service: String,
   identifier: String,
   resource: String,
   params: SKJSON.CJSON,
-  executor: Executor,
+  executor: IntExecutor,
 ): ResourceInfo {
   resourceHdl = SKStore.EHandle(
     SKStore.SID::keyType,
@@ -1524,7 +1540,12 @@ fun createReactiveResource(
     context.update();
     definition
   };
-  checkResourceInstanceSubcriptions(context, definition, identifier, executor);
+  checkResourceInstanceSubcriptions(
+    context,
+    definition,
+    identifier,
+    ResourceExecutor(executor, definition),
+  );
   checkGarbage(context);
   SKStore.EHandle(
     ResourceDef::keyType,
@@ -1533,20 +1554,11 @@ fun createReactiveResource(
   ).get(context, definition);
 }
 
-class ReloadExecutor(executor: IntExecutor, id: Int) extends Executor {
-  fun resolve(): void {
-    this.executor.resolve(this.id)
-  }
-
-  fun reject(exc: .Exception): void {
-    this.executor.reject(exc)
-  }
-}
-
 fun resourceInstances(
   context: mutable SKStore.Context,
   resources: SortedSet<String>,
 ): Array<ResourceDef> {
+  all = resources.isEmpty();
   activeHdl = SKStore.EHandle(
     ResourceDef::keyType,
     SKStore.IntFile::type,
@@ -1554,7 +1566,9 @@ fun resourceInstances(
   );
   instances = mutable Vector[];
   activeHdl.items(context).each(kf ->
-    if (resources.contains(kf.i0.name)) instances.push(kf.i0)
+    kf.i1.next().each(_ ->
+      if (all || resources.contains(kf.i0.name)) instances.push(kf.i0)
+    )
   );
   instances.toArray()
 }
@@ -1579,12 +1593,13 @@ fun reloadResource(
     context,
     definition,
     reloadId,
-    ReloadExecutor(executor, definition.instance),
+    ResourceExecutor(executor, definition),
   );
 }
 
 fun replaceActiveResources(
   context: mutable SKStore.Context,
+  service: String,
   definitions: Array<ResourceDef>,
 ): void {
   resourceHdl = SKStore.EHandle(
@@ -1603,22 +1618,23 @@ fun replaceActiveResources(
     kResourceSessionDir.sub("idbyresource"),
   );
   definitions.each(d -> {
-    activeKey = d.derive();
+    activeKey = ResourceDef(service, d.name, d.params);
     activeInstance = activeHdl.get(context, activeKey).value;
-    activeDef = d.derive(activeInstance);
+    activeDef = activeKey.derive(activeInstance);
     // remove reload id
     idbyresourceHdl.getArray(context, d).each(sidf -> {
       resourceHdl.writeArray(context, SKStore.SID(sidf.value), Array[])
     });
     // replace active def id
-    idbyresourceHdl.getArray(context, activeDef).each(sidf -> {
+    activeDefinitions = idbyresourceHdl.getArray(context, activeDef);
+    activeDefinitions.each(sidf -> {
       resourceHdl.writeArray(context, SKStore.SID(sidf.value), Array[d])
     });
     activeHdl.writeArray(
       context,
       activeKey,
-      Array[SKStore.IntFile(d.instance)],
-    );
+      if (service == d.service) Array[SKStore.IntFile(d.instance)] else Array[],
+    )
   });
   // Force the notification of replaced resources
   graphHdl = SKStore.EHandle(

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -52,6 +52,10 @@ class ConvReducer(
     JSONFile::type
   }
 
+  fun init(): JSONFile {
+    JSONFile(this.reducer.init());
+  }
+
   fun add(acc: JSONFile, value: JSONFile): JSONFile {
     JSONFile(this.reducer.add(acc.json, value.json));
   }
@@ -732,7 +736,7 @@ class Collection(hdl: SKStore.EHandle<JSONID, JSONFile>) {
         context,
         dirName,
         mapper,
-        accReducer(ConvReducer(reducer, JSONFile(reducer.initial))),
+        accReducer(ConvReducer(reducer)),
       );
       Collection(hdl)
     | _ -> invariant_violation("Store context must be specified.")

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -176,10 +176,6 @@ class RequestStatuses(statuses: Array<ResourceStatus>) extends SKStore.File {
   }
 }
 
-class RemoteSpecifiers(
-  value: Map<String, ExternalService>,
-) extends SKStore.File
-
 class StatusRef(
   resourceId: String,
   statusRef: SKStore.DirName,
@@ -302,17 +298,16 @@ fun buildResourcesGraph(
     (context, writer, key, it) ~> {
       resourceId = it.first.resourceId;
       statusRef = it.first.statusRef;
-      (runId, resources) = definitionHdl.maybeGet(
+      (runId, service) = definitionHdl.maybeGet(
         context,
         SKStore.UnitID::singleton,
       ) match {
-      | Some(definition) -> (definition.runId, definition.service.resources)
+      | Some(definition) -> (definition.runId, definition.service)
       | _ -> return void
       };
       pushContext(context);
       try {
-        resourceBuilder = resources.get(key.name);
-        resource = resourceBuilder.build(key.params);
+        resource = service.buildResource(key.name, key.params);
         collections = servicesHdl.get(context, SKStore.SID(runId)).value;
         collection = resource.instantiate(collections);
         writer.set(key, ResourceInfo(resourceId, collection, statusRef, runId));
@@ -356,17 +351,16 @@ fun initService(
           (ctx, writer, _key, it) ~> {
             serviceDef = it.first;
             mInputs = mutable Map<String, Collection>[];
-            serviceDef.service.initialData.each(input -> {
-              iDirName = SKStore.DirName::create(`/${input.name}/`);
+            serviceDef.service.inputs().each(input -> {
+              iDirName = SKStore.DirName::create(`/${input}/`);
+              values = serviceDef.service.initialData(input);
               iHdl = ctx.mkdirMulti(
                 JSONID::keyType,
                 JSONFile::type,
                 iDirName,
-                input.values.map(v ->
-                  (JSONID(v.i0), v.i1.map(x -> JSONFile(x)))
-                ),
+                values.map(v -> (JSONID(v.i0), v.i1.map(x -> JSONFile(x)))),
               );
-              mInputs.add(input.name, Collection(iHdl))
+              mInputs.add(input, Collection(iHdl))
             });
             writer.set(
               SKStore.SID(serviceDef.runId),
@@ -451,7 +445,7 @@ fun initService(
 fun closeService_(
   context: mutable SKStore.Context,
   update: Bool = true,
-): Array<Float> {
+): Float {
   resourceHdl = SKStore.EHandle(
     SKStore.SID::keyType,
     ResourceDef::type,
@@ -476,18 +470,14 @@ fun closeService_(
     kSessionDir,
   );
   handles = sessionHdl.maybeGet(context, SKStore.UnitID::singleton) match {
-  | Some(def) ->
-    def.service.remoteCollections
-      .values()
-      .map(es -> es.shutdown())
-      .collect(Array)
-  | _ -> Array[]
+  | Some(def) -> def.service.shutdown()
+  | _ -> 0.0
   };
   if (update) context.update();
   handles;
 }
 
-fun closeService(): Result<Array<Float>, .Exception> {
+fun closeService(): Result<Float, .Exception> {
   SKStore.runWithResult(ctx ~> closeService_(ctx))
 }
 
@@ -507,7 +497,8 @@ fun invalidateCollections(
 }
 
 class LinkToResource(
-  supplier: ExternalService,
+  service: Service,
+  supplier: String,
   instance: String,
   writer: CollectionWriter,
   name: String,
@@ -517,14 +508,21 @@ class LinkToResource(
   fun perform(context: mutable SKStore.Context): void {
     this.writer.status(context, Status::create());
     pushContext(context);
-    this.supplier.subscribe(this.instance, this.writer, this.name, this.params);
+    this.service.subscribe(
+      this.supplier,
+      this.instance,
+      this.writer,
+      this.name,
+      this.params,
+    );
     popContext();
     addSubscription(context, this.writer.dirName);
   }
 }
 
 class CloseExternalService(
-  supplier: ExternalService,
+  service: Service,
+  supplier: String,
   instance: String,
   dirName: SKStore.DirName,
   definition: ExternalServiceDef,
@@ -549,7 +547,7 @@ class CloseExternalService(
     | _ -> void
     };
     pushContext(context);
-    this.supplier.unsubscribe(this.instance);
+    this.service.unsubscribe(this.supplier, this.instance);
     popContext();
     addClosed(context, this.definition);
   }
@@ -626,11 +624,7 @@ fun useExternalCollection(
       ServiceDefinition::type,
       kSessionDir,
     );
-    remoteCollections = sessionHdl.get(
-      context,
-      SKStore.UnitID::singleton,
-    ).service.remoteCollections;
-    externalSupplier = remoteCollections.get(supplier);
+    service = sessionHdl.get(context, SKStore.UnitID::singleton).service;
     collectionId = toSuppliedResourceId(supplier, resource, params);
     dirName = subDirName(context, collectionId);
     paramsDir = dirName.sub("params");
@@ -659,7 +653,8 @@ fun useExternalCollection(
           (
             Some(
               LinkToResource(
-                externalSupplier,
+                service,
+                supplier,
                 instance,
                 CollectionWriter(storeDir),
                 resource,
@@ -667,7 +662,8 @@ fun useExternalCollection(
               ),
             ),
             CloseExternalService(
-              externalSupplier,
+              service,
+              supplier,
               instance,
               storeDir,
               definition,

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -217,6 +217,11 @@ fun buildResourcesGraph(
     dirname,
   );
   _ = context.mkdir(
+    ResourceDef::keyType,
+    SKStore.IntFile::type,
+    dirname.sub("active"),
+  );
+  _ = context.mkdir(
     SKStore.SID::keyType,
     SKStore.IntFile::type,
     kResourceGarbageDir,
@@ -432,11 +437,19 @@ fun closeService_(
     ResourceDef::type,
     kResourceSessionDir,
   );
+  activeHdl = SKStore.EHandle(
+    ResourceDef::keyType,
+    SKStore.IntFile::type,
+    kResourceSessionDir.sub("active"),
+  );
   todestroy = mutable Vector[];
   resourceHdl.items(context).each(kf -> {
     kf.i1.next().each(_f -> todestroy.push(kf.i0))
   });
-  todestroy.each(key -> destroyReactiveResource(context, key));
+  todestroy.each(key -> _ = destroyReactiveResource(context, key));
+  activeHdl.items(context).each(kf ->
+    activeHdl.writeArray(context, kf.i0, Array[])
+  );
   sessionHdl = SKStore.EHandle(
     SKStore.UnitID::keyType,
     ServiceDefinition::type,
@@ -1177,13 +1190,7 @@ fun getAll(
   resourceName: String,
   params: SKJSON.CJSON,
 ): GetResult<Values> {
-  graphHdl = SKStore.EHandle(
-    ResourceDef::keyType,
-    ResourceInfo::type,
-    kResourceCollectionsDir,
-  );
-  resourceID = ResourceDef(resourceName, params);
-  resource = graphHdl.get(context, resourceID);
+  resource = getResourceInfo(context, resourceName, params);
   resource.getResult(
     context,
     Values(
@@ -1199,13 +1206,7 @@ fun getForKey(
   params: SKJSON.CJSON,
   key: SKJSON.CJSON,
 ): GetResult<Array<SKJSON.CJSON>> {
-  graphHdl = SKStore.EHandle(
-    ResourceDef::keyType,
-    ResourceInfo::type,
-    kResourceCollectionsDir,
-  );
-  resourceID = ResourceDef(resourceName, params);
-  resource = graphHdl.get(context, resourceID);
+  resource = getResourceInfo(context, resourceName, params);
   pushContext(context);
   values = resource.collection.getArray(key);
   popContext();
@@ -1215,7 +1216,7 @@ fun getForKey(
 fun destroyReactiveResource(
   context: mutable SKStore.Context,
   sid: SKStore.SID,
-): void {
+): ResourceDef {
   context
     .getPersistent(`subscription.${sid}`)
     .map(SKStore.IntFile::type) match {
@@ -1232,12 +1233,14 @@ fun destroyReactiveResource(
     })
   | _ -> void
   };
-  resourceHdl = SKStore.EHandle(
+  resourcesHdl = SKStore.EHandle(
     SKStore.SID::keyType,
     ResourceDef::type,
     kResourceSessionDir,
   );
-  resourceHdl.writeArray(context, sid, Array[]);
+  defintion = resourcesHdl.get(context, sid);
+  resourcesHdl.writeArray(context, sid, Array[]);
+  defintion
 }
 
 fun closeReactiveResource(
@@ -1276,23 +1279,12 @@ fun subscribe(
   );
   sid = SKStore.SID(identifier);
   session = SKStore.genSym(0);
-  resourceHdl = SKStore.EHandle(
-    SKStore.SID::keyType,
-    ResourceDef::type,
-    kResourceSessionDir,
-  );
-  resourcesCollectionsHdl = SKStore.EHandle(
-    ResourceDef::keyType,
-    ResourceInfo::type,
-    kResourceCollectionsDir,
-  );
   subId = `subscription.${identifier}`;
   if (context.getPersistent(subId).isSome()) {
     return -2
   };
-  resourceHdl.maybeGet(context, sid) match {
-  | Some(definition) ->
-    info = resourcesCollectionsHdl.get(context, definition);
+  maybeGetReactiveResource(context, identifier) match {
+  | Some(info) ->
     start = `${info.session}/`;
     from = SKStore.Tick(
       optWatermark match {
@@ -1306,8 +1298,7 @@ fun subscribe(
       session,
       SKStore.TNWatch<SKStore.Key, SKStore.File>{
         dirNameGetter => ctx ~> {
-          resourcesCollectionsHdl.unsafeGet(ctx, definition).collection.hdl
-            .dirName
+          unsafeGetReactiveResource(ctx, identifier).collection.hdl.dirName
         },
         identifier,
         from,
@@ -1451,41 +1442,106 @@ fun createReactiveResource(
     ResourceDef::type,
     kResourceSessionDir,
   );
-  graphHdl = SKStore.EHandle(
+  activeKey = ResourceDef(resource, params);
+  activeHdl = SKStore.EHandle(
     ResourceDef::keyType,
-    ResourceInfo::type,
-    kResourceCollectionsDir,
+    SKStore.IntFile::type,
+    kResourceSessionDir.sub("active"),
   );
   key = SKStore.SID(identifier);
   resourceHdl.maybeGet(context, key) match {
   | Some _ -> throw ExistingResourceException()
   | _ -> void
   };
-  definition = ResourceDef(resource, params);
-  resourceHdl.writeArray(context, key, Array[definition]);
-  context.update();
+  definition = activeHdl.maybeGet(context, activeKey) match {
+  | Some(activeFile) ->
+    // Add the instance for corresponding active resource
+    definition = ResourceDef(resource, params, activeFile.value);
+    resourceHdl.writeArray(context, key, Array[definition]);
+    context.update();
+    definition
+  | _ ->
+    active = SKStore.genSym(0);
+    definition = ResourceDef(resource, params, active);
+    activeHdl.writeArray(context, activeKey, Array[SKStore.IntFile(active)]);
+    resourceHdl.writeArray(context, key, Array[definition]);
+    context.update();
+    definition
+  };
   checkResourceInstanceSubcriptions(context, definition, identifier, executor);
   checkGarbage(context);
-  graphHdl.get(context, definition);
+  SKStore.EHandle(
+    ResourceDef::keyType,
+    ResourceInfo::type,
+    kResourceCollectionsDir,
+  ).get(context, definition);
 }
 
 fun getReactiveResource(
   context: mutable SKStore.Context,
   identifier: String,
 ): ResourceInfo {
-  resourceHdl = SKStore.EHandle(
-    SKStore.SID::keyType,
-    ResourceDef::type,
-    kResourceSessionDir,
-  );
+  maybeGetReactiveResource(context, identifier) match {
+  | Some(ri) -> ri
+  | _ ->
+    invariant_violation(`Reactive resource ${identifier} should be defined.`)
+  }
+}
+
+fun maybeGetReactiveResource(
+  context: mutable SKStore.Context,
+  identifier: String,
+): ?ResourceInfo {
   graphHdl = SKStore.EHandle(
     ResourceDef::keyType,
     ResourceInfo::type,
     kResourceCollectionsDir,
   );
-  key = SKStore.SID(identifier);
-  definition = resourceHdl.get(context, key);
-  graphHdl.get(context, definition);
+  SKStore.EHandle(SKStore.SID::keyType, ResourceDef::type, kResourceSessionDir)
+    .maybeGet(context, SKStore.SID(identifier))
+    .map(definition -> graphHdl.get(context, definition))
+}
+
+fun unsafeMaybeGetReactiveResource(
+  context: readonly SKStore.Context,
+  identifier: String,
+): ?ResourceInfo {
+  graphHdl = SKStore.EHandle(
+    ResourceDef::keyType,
+    ResourceInfo::type,
+    kResourceCollectionsDir,
+  );
+  SKStore.EHandle(SKStore.SID::keyType, ResourceDef::type, kResourceSessionDir)
+    .unsafeMaybeGet(context, SKStore.SID(identifier))
+    .map(definition -> graphHdl.unsafeGet(context, definition))
+}
+
+fun unsafeGetReactiveResource(
+  context: readonly SKStore.Context,
+  identifier: String,
+): ResourceInfo {
+  unsafeMaybeGetReactiveResource(context, identifier) match {
+  | Some(ri) -> ri
+  | _ ->
+    invariant_violation(`Reactive resource ${identifier} should be defined.`)
+  }
+}
+
+fun getResourceInfo(
+  context: mutable SKStore.Context,
+  resource: String,
+  params: SKJSON.CJSON,
+): ResourceInfo {
+  activeFile = SKStore.EHandle(
+    ResourceDef::keyType,
+    SKStore.IntFile::type,
+    kResourceSessionDir.sub("active"),
+  ).get(context, ResourceDef(resource, params));
+  SKStore.EHandle(
+    ResourceDef::keyType,
+    ResourceInfo::type,
+    kResourceCollectionsDir,
+  ).get(context, ResourceDef(resource, params, activeFile.value));
 }
 
 fun checkGarbage(context: mutable SKStore.Context): void {
@@ -1501,18 +1557,57 @@ fun checkGarbage(context: mutable SKStore.Context): void {
   );
   time = Time.time_ms();
   destroyed = mutable Vector[];
+  resources = SortedSet[];
   garbageHdl.items(context).each(kf -> {
     kf.i1.next().each(f -> {
       suppressed = f.value;
       if (time - suppressed > kGarbageMillis) {
         key = kf.i0;
+        !resources = resources.set(resourceHdl.get(context, key));
         destroyed.push(key);
         resourceHdl.writeArray(context, key, Array[]);
       }
     })
   });
   destroyed.each(key -> garbageHdl.writeArray(context, key, Array[]));
-  if (!destroyed.isEmpty()) context.update();
+  if (!destroyed.isEmpty()) {
+    context.update();
+    if (checkResources(context, resources)) context.update();
+  }
+}
+
+fun checkResources(
+  context: mutable SKStore.Context,
+  resources: SortedSet<ResourceDef>,
+): Bool {
+  idbyresourceHdl = SKStore.EHandle(
+    ResourceDef::keyType,
+    SKStore.StringFile::type,
+    kResourceSessionDir.sub("idbyresource"),
+  );
+  activeHdl = SKStore.EHandle(
+    ResourceDef::keyType,
+    SKStore.IntFile::type,
+    kResourceSessionDir.sub("active"),
+  );
+  availablesHdl = SKStore.EHandle(
+    ResourceDef::keyType,
+    SKStore.IntFile::type,
+    kResourceAvailablesDir,
+  );
+  hasDestruction = false;
+  for (resource in resources) {
+    values = idbyresourceHdl.getArray(context, resource);
+    if (values.isEmpty()) {
+      !hasDestruction = true;
+      activeKey = resource with {instance => 0};
+      activeHdl.maybeGet(context, activeKey).each(_ -> {
+        activeHdl.writeArray(context, activeKey, Array[]);
+      });
+      availablesHdl.writeArray(context, resource, Array[]);
+    }
+  };
+  hasDestruction
 }
 
 fun updateContext(context: mutable SKStore.Context): void {

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -39,6 +39,11 @@ class ServiceDefinition(
   executor: Executor,
 ) extends SKStore.File
 
+class ServiceInputs(
+  service: Service,
+  inputs: Map<String, Collection>,
+) extends SKStore.File
+
 class Handle(value: SKStore.EHandle<JSONID, JSONFile>) extends SKStore.File
 
 class StatusHandle(
@@ -342,42 +347,57 @@ fun initService(
           ),
         ],
       );
-      servicesHdl = sessionHdl.map(
-        SKStore.SID::keyType,
-        ServiceFile::type,
-        context,
-        kGraphDir,
-        (ctx, writer, _key, it) ~> {
-          serviceDef = it.first;
-          pushContext(ctx);
-          mInputs = mutable Map<String, Collection>[];
-          serviceDef.service.initialData.each(input -> {
-            iDirName = SKStore.DirName::create(`/${input.name}/`);
-            iHdl = ctx.mkdirMulti(
-              JSONID::keyType,
-              JSONFile::type,
-              iDirName,
-              input.values.map(v -> (JSONID(v.i0), v.i1.map(x -> JSONFile(x)))),
-            );
-            mInputs.add(input.name, Collection(iHdl))
-          });
-          inputCollections = mInputs.chill();
-          try {
+      servicesHdl = sessionHdl
+        .map(
+          SKStore.SID::keyType,
+          ServiceInputs::type,
+          context,
+          kSessionDir.sub("inputs"),
+          (ctx, writer, _key, it) ~> {
+            serviceDef = it.first;
+            mInputs = mutable Map<String, Collection>[];
+            serviceDef.service.initialData.each(input -> {
+              iDirName = SKStore.DirName::create(`/${input.name}/`);
+              iHdl = ctx.mkdirMulti(
+                JSONID::keyType,
+                JSONFile::type,
+                iDirName,
+                input.values.map(v ->
+                  (JSONID(v.i0), v.i1.map(x -> JSONFile(x)))
+                ),
+              );
+              mInputs.add(input.name, Collection(iHdl))
+            });
             writer.set(
               SKStore.SID(serviceDef.runId),
-              ServiceFile(
-                serviceDef.service.createGraph(inputCollections),
-                inputCollections,
-              ),
-            );
-            popContext()
-          } catch {
-          | ex ->
-            popContext();
-            throw ex
-          }
-        },
-      );
+              ServiceInputs(serviceDef.service, mInputs.chill()),
+            )
+          },
+        )
+        .map(
+          SKStore.SID::keyType,
+          ServiceFile::type,
+          context,
+          kGraphDir,
+          (ctx, writer, key, it) ~> {
+            definition = it.first;
+            pushContext(ctx);
+            try {
+              writer.set(
+                key,
+                ServiceFile(
+                  definition.service.createGraph(definition.inputs),
+                  definition.inputs,
+                ),
+              );
+              popContext()
+            } catch {
+            | ex ->
+              popContext();
+              throw ex
+            }
+          },
+        );
       // Service status
       statusDefHdl = context.mkdir(
         SKStore.DirName::keyType,

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -85,6 +85,11 @@ class ResourceDef(
   fun toId(): String {
     `${toResourceId(this.name, this.params)}_${this.instance}`
   }
+
+  fun derive(instance: Int = 0): ResourceDef {
+    !this.instance = instance;
+    this;
+  }
 }
 
 class ResourceStatus(
@@ -1491,6 +1496,124 @@ fun createReactiveResource(
     ResourceInfo::type,
     kResourceCollectionsDir,
   ).get(context, definition);
+}
+
+class ReloadExecutor(executor: IntExecutor, id: Int) extends Executor {
+  fun resolve(): void {
+    this.executor.resolve(this.id)
+  }
+
+  fun reject(exc: .Exception): void {
+    this.executor.reject(exc)
+  }
+}
+
+fun resourceInstances(
+  context: mutable SKStore.Context,
+  resources: SortedSet<String>,
+): Array<ResourceDef> {
+  activeHdl = SKStore.EHandle(
+    ResourceDef::keyType,
+    SKStore.IntFile::type,
+    kResourceSessionDir.sub("active"),
+  );
+  instances = mutable Vector[];
+  activeHdl.items(context).each(kf ->
+    if (resources.contains(kf.i0.name)) instances.push(kf.i0)
+  );
+  instances.toArray()
+}
+
+fun reloadResource(
+  context: mutable SKStore.Context,
+  resource: String,
+  params: SKJSON.CJSON,
+  executor: IntExecutor,
+): void {
+  reloadId = Ksuid::create().toString();
+  resourceHdl = SKStore.EHandle(
+    SKStore.SID::keyType,
+    ResourceDef::type,
+    kResourceSessionDir,
+  );
+  definition = ResourceDef(resource, params, SKStore.genSym(0));
+  resourceHdl.writeArray(context, SKStore.SID(reloadId), Array[definition]);
+  context.update();
+  checkResourceInstanceSubcriptions(
+    context,
+    definition,
+    reloadId,
+    ReloadExecutor(executor, definition.instance),
+  );
+}
+
+fun replaceActiveResources(
+  context: mutable SKStore.Context,
+  definitions: Array<ResourceDef>,
+): void {
+  resourceHdl = SKStore.EHandle(
+    SKStore.SID::keyType,
+    ResourceDef::type,
+    kResourceSessionDir,
+  );
+  activeHdl = SKStore.EHandle(
+    ResourceDef::keyType,
+    SKStore.IntFile::type,
+    kResourceSessionDir.sub("active"),
+  );
+  idbyresourceHdl = SKStore.EHandle(
+    ResourceDef::keyType,
+    SKStore.StringFile::type,
+    kResourceSessionDir.sub("idbyresource"),
+  );
+  definitions.each(d -> {
+    activeKey = d.derive();
+    activeInstance = activeHdl.get(context, activeKey).value;
+    activeDef = d.derive(activeInstance);
+    // remove reload id
+    idbyresourceHdl.getArray(context, d).each(sidf -> {
+      resourceHdl.writeArray(context, SKStore.SID(sidf.value), Array[])
+    });
+    // replace active def id
+    idbyresourceHdl.getArray(context, activeDef).each(sidf -> {
+      resourceHdl.writeArray(context, SKStore.SID(sidf.value), Array[d])
+    });
+    activeHdl.writeArray(
+      context,
+      activeKey,
+      Array[SKStore.IntFile(d.instance)],
+    );
+  });
+  // Force the notification of replaced resources
+  graphHdl = SKStore.EHandle(
+    ResourceDef::keyType,
+    ResourceInfo::type,
+    kResourceCollectionsDir,
+  );
+  definitions.each(d -> graphHdl.get(context, d).collection.hdl.renew(context));
+  updateContext(context);
+}
+
+fun destroyResources(
+  context: mutable SKStore.Context,
+  definitions: Array<ResourceDef>,
+): void {
+  resourceHdl = SKStore.EHandle(
+    SKStore.SID::keyType,
+    ResourceDef::type,
+    kResourceSessionDir,
+  );
+  idbyresourceHdl = SKStore.EHandle(
+    ResourceDef::keyType,
+    SKStore.StringFile::type,
+    kResourceSessionDir.sub("idbyresource"),
+  );
+  definitions.each(d -> {
+    idbyresourceHdl.getArray(context, d).each(sidf -> {
+      resourceHdl.writeArray(context, SKStore.SID(sidf.value), Array[])
+    })
+  });
+  updateContext(context);
 }
 
 fun getReactiveResource(

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -34,7 +34,6 @@ class ResourceCollections(
 ) extends SKStore.File
 
 class ServiceDefinition(
-  runId: String,
   service: Service,
   executor: Executor,
 ) extends SKStore.File
@@ -73,17 +72,20 @@ class ConvReducer(
 class ResourceCollection(value: Collection) extends SKStore.File
 
 class ResourceDef(
+  service: String,
   name: String,
   params: SKJSON.CJSON,
   instance: Int = 0,
 ) extends SKStore.File, SKStore.Key {
   //
   fun toString(): String {
-    `${this.name}:${this.params.prettyPrint()}:${this.instance}`
+    `${this.service}:${this.name}:${this.params.prettyPrint()}:${this.instance}`
   }
 
   fun toId(): String {
-    `${toResourceId(this.name, this.params)}_${this.instance}`
+    `${base64(this.service)}_${toResourceId(this.name, this.params)}_${
+      this.instance
+    }`
   }
 
   fun derive(instance: Int = 0): ResourceDef {
@@ -139,7 +141,7 @@ base class Status(
     `Ok{created: ${created}, modified: ${modified}, initialiazed: ${initialiazed.isSome()}}`
 }
 
-class StatusFile(status: Status) extends SKStore.File
+class StatusFile(service: String, status: Status) extends SKStore.File
 
 class RequestStatuses(statuses: Array<ResourceStatus>) extends SKStore.File {
   //
@@ -190,7 +192,6 @@ class ResourceInfo(
   name: String,
   collection: Collection,
   statusRef: SKStore.DirName,
-  session: String,
 ) extends SKStore.File {
   fun getResult<T>(context: mutable SKStore.Context, values: T): GetResult<T> {
     SKStore.EHandle(
@@ -212,8 +213,8 @@ class Input(name: String, values: Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)>)
 
 fun buildResourcesGraph(
   context: mutable SKStore.Context,
-  definitionHdl: SKStore.EHandle<SKStore.UnitID, ServiceDefinition>,
-  statusHdl: SKStore.EHandle<SKStore.UnitID, ResourceStatus>,
+  definitionHdl: SKStore.EHandle<SKStore.SID, ServiceDefinition>,
+  statusHdl: SKStore.EHandle<SKStore.SID, ResourceStatus>,
   servicesHdl: SKStore.EHandle<SKStore.SID, ServiceFile>,
 ): void {
   dirname = kResourceSessionDir;
@@ -286,10 +287,12 @@ fun buildResourcesGraph(
         RequestStatuses::type,
         context,
         statusRef.sub("all"),
-        (ctx, writer, key, it) ~> {
-          statuses = statusHdl.getArray(ctx, key).concat(it.toArray());
+        (ctx, writer, lkey, it) ~> {
+          statuses = statusHdl
+            .getArray(ctx, SKStore.SID(key.service))
+            .concat(it.toArray());
           requestStatuses = RequestStatuses(statuses);
-          writer.set(key, requestStatuses);
+          writer.set(lkey, requestStatuses);
         },
       );
       writer.set(key, StatusRef(resourceId, statusRef));
@@ -301,21 +304,19 @@ fun buildResourcesGraph(
     context,
     kResourceCollectionsDir,
     (context, writer, key, it) ~> {
+      serviceId = SKStore.SID(key.service);
       resourceId = it.first.resourceId;
       statusRef = it.first.statusRef;
-      (runId, service) = definitionHdl.maybeGet(
-        context,
-        SKStore.UnitID::singleton,
-      ) match {
-      | Some(definition) -> (definition.runId, definition.service)
+      service = definitionHdl.maybeGet(context, serviceId) match {
+      | Some(definition) -> definition.service
       | _ -> return void
       };
       pushContext(context);
       try {
         resource = service.buildResource(key.name, key.params);
-        collections = servicesHdl.get(context, SKStore.SID(runId)).value;
+        collections = servicesHdl.get(context, serviceId).value;
         collection = resource.instantiate(collections);
-        writer.set(key, ResourceInfo(resourceId, collection, statusRef, runId));
+        writer.set(key, ResourceInfo(resourceId, collection, statusRef));
         popContext()
       } catch {
       | ex ->
@@ -327,25 +328,20 @@ fun buildResourcesGraph(
 }
 
 fun initService(
+  identifier: String,
   service: Service,
   executor: Executor,
 ): Result<void, .Exception> {
   if (SKStore.gHasContext() == 0) {
     SKStore.gContextInit(initCtx());
   };
-  runId = Ksuid::create().toString();
   SKStore.runWithResult(context ~> {
     if (context.unsafeMaybeGetEagerDir(kSessionDir) is None()) {
       sessionHdl = context.mkdir(
-        SKStore.UnitID::keyType,
+        SKStore.SID::keyType,
         ServiceDefinition::type,
         kSessionDir,
-        Array[
-          (
-            SKStore.UnitID::singleton,
-            ServiceDefinition(runId, service, executor),
-          ),
-        ],
+        Array[(SKStore.SID(identifier), ServiceDefinition(service, executor))],
       );
       servicesHdl = sessionHdl
         .map(
@@ -353,11 +349,11 @@ fun initService(
           ServiceInputs::type,
           context,
           kSessionDir.sub("inputs"),
-          (ctx, writer, _key, it) ~> {
+          (ctx, writer, key, it) ~> {
             serviceDef = it.first;
             mInputs = mutable Map<String, Collection>[];
             serviceDef.service.inputs().each(input -> {
-              iDirName = SKStore.DirName::create(`/${input}/`);
+              iDirName = SKStore.DirName::create(`/${base64(key)}/${input}/`);
               values = serviceDef.service.initialData(input);
               iHdl = ctx.mkdirMulti(
                 JSONID::keyType,
@@ -367,10 +363,7 @@ fun initService(
               );
               mInputs.add(input, Collection(iHdl))
             });
-            writer.set(
-              SKStore.SID(serviceDef.runId),
-              ServiceInputs(serviceDef.service, mInputs.chill()),
-            )
+            writer.set(key, ServiceInputs(serviceDef.service, mInputs.chill()))
           },
         )
         .map(
@@ -404,86 +397,77 @@ fun initService(
         kSessionDir.sub("status"),
       );
       statusHdl = statusDefHdl.map(
-        SKStore.UnitID::keyType,
+        SKStore.SID::keyType,
         ResourceStatus::type,
         context,
         kSessionDir.sub("statuses"),
         (_ctx, writer, key, it) ~> {
           writer.set(
-            SKStore.UnitID::singleton,
+            SKStore.SID(it.first.service),
             ResourceStatus(key, it.first.status),
           );
         },
       );
       buildResourcesGraph(context, sessionHdl, statusHdl, servicesHdl)
     } else {
-      // Can be done because it's only used on test, we can add a environment variable or some way to protect that usage
-      _ = closeService_(context);
       sessionHdl = SKStore.EHandle(
-        SKStore.UnitID::keyType,
+        SKStore.SID::keyType,
         ServiceDefinition::type,
         kSessionDir,
       );
-      statusHdl = SKStore.EHandle(
-        SKStore.DirName::keyType,
-        StatusFile::type,
-        kSessionDir.sub("status"),
-      );
-      toclean = mutable Vector[];
-      statusHdl.items(context).each(kf -> {
-        kf.i1.next().each(_f -> toclean.push(SKStore.DirName::keyType(kf.i0)))
-      });
-      toclean.each(key -> statusHdl.writeArray(context, key, Array[]));
-      sessionHdl.writeArray(context, SKStore.UnitID::singleton, Array[]);
-      context.update();
       sessionHdl.writeArray(
         context,
-        SKStore.UnitID::singleton,
-        Array[ServiceDefinition(runId, service, executor)],
+        SKStore.SID(identifier),
+        Array[ServiceDefinition(service, executor)],
       );
+      context.update();
     };
     updateContext(context);
-    checkSubcriptions(context, executor);
+    checkSubcriptions(context, identifier, executor);
   })
 }
 
 fun closeService_(
   context: mutable SKStore.Context,
+  identifier: String,
   update: Bool = true,
 ): Float {
-  resourceHdl = SKStore.EHandle(
-    SKStore.SID::keyType,
-    ResourceDef::type,
-    kResourceSessionDir,
-  );
-  activeHdl = SKStore.EHandle(
-    ResourceDef::keyType,
-    SKStore.IntFile::type,
-    kResourceSessionDir.sub("active"),
-  );
-  todestroy = mutable Vector[];
-  resourceHdl.items(context).each(kf -> {
-    kf.i1.next().each(_f -> todestroy.push(kf.i0))
-  });
-  todestroy.each(key -> _ = destroyReactiveResource(context, key));
-  activeHdl.items(context).each(kf ->
-    activeHdl.writeArray(context, kf.i0, Array[])
-  );
   sessionHdl = SKStore.EHandle(
-    SKStore.UnitID::keyType,
+    SKStore.SID::keyType,
     ServiceDefinition::type,
     kSessionDir,
   );
-  handles = sessionHdl.maybeGet(context, SKStore.UnitID::singleton) match {
-  | Some(def) -> def.service.shutdown()
+  handles = sessionHdl.maybeGet(context, SKStore.SID(identifier)) match {
+  | Some(def) ->
+    resourceHdl = SKStore.EHandle(
+      SKStore.SID::keyType,
+      ResourceDef::type,
+      kResourceSessionDir,
+    );
+    activeHdl = SKStore.EHandle(
+      ResourceDef::keyType,
+      SKStore.IntFile::type,
+      kResourceSessionDir.sub("active"),
+    );
+    todestroy = mutable Vector[];
+    resourceHdl.items(context).each(kf ->
+      kf.i1.next().each(f -> if (f.service == identifier) todestroy.push(kf.i0))
+    );
+    todestroy.each(key -> _ = destroyReactiveResource(context, key));
+    activeHdl.items(context).each(kf ->
+      if (kf.i0.service == identifier) {
+        activeHdl.writeArray(context, kf.i0, Array[])
+      }
+    );
+    def.service.shutdown()
   | _ -> 0.0
   };
   if (update) context.update();
   handles;
 }
 
-fun closeService(): Result<Float, .Exception> {
-  SKStore.runWithResult(ctx ~> closeService_(ctx))
+fun closeService(identifier: String): Result<Float, .Exception> {
+  SKStore.runWithResult(ctx ~> closeService_(ctx, identifier))
 }
 
 fun invalidateCollections(
@@ -502,6 +486,7 @@ fun invalidateCollections(
 }
 
 class LinkToResource(
+  serviceId: String,
   service: Service,
   supplier: String,
   instance: String,
@@ -511,7 +496,7 @@ class LinkToResource(
 ) extends SKStore.Postponable {
   //
   fun perform(context: mutable SKStore.Context): void {
-    this.writer.status(context, Status::create());
+    this.writer.status(context, Status::create(), this.serviceId);
     pushContext(context);
     this.service.subscribe(
       this.supplier,
@@ -624,12 +609,15 @@ fun useExternalCollection(
       | _ -> void
       }
     });
+    serviceId = serviceId(context, context.currentArrow()).fromSome(
+      "Unable to get service identifier",
+    );
     sessionHdl = SKStore.EHandle(
-      SKStore.UnitID::keyType,
+      SKStore.SID::keyType,
       ServiceDefinition::type,
       kSessionDir,
     );
-    service = sessionHdl.get(context, SKStore.UnitID::singleton).service;
+    service = sessionHdl.get(context, SKStore.SID(serviceId)).service;
     collectionId = toSuppliedResourceId(supplier, resource, params);
     dirName = subDirName(context, collectionId);
     paramsDir = dirName.sub("params");
@@ -658,6 +646,7 @@ fun useExternalCollection(
           (
             Some(
               LinkToResource(
+                serviceId,
                 service,
                 supplier,
                 instance,
@@ -1105,6 +1094,32 @@ private fun resourceId(
   }
 }
 
+private fun serviceId(
+  context: readonly SKStore.Context,
+  keyArrow: ?SKStore.ArrowKey,
+): ?String {
+  keyArrow match {
+  | Some(arrow) ->
+    if (isResourceDir(arrow.parentName)) {
+      Some(
+        ResourceDef::keyType(SKStore.TEagerDir::staticKeyOfArrowKey(arrow))
+          .service,
+      )
+    } else if (arrow.parentName == kSessionDir.sub("inputs")) {
+      Some(
+        SKStore.SID::keyType(SKStore.TEagerDir::staticKeyOfArrowKey(arrow))
+          .value,
+      )
+    } else {
+      context.unsafeMaybeGetEagerDir(arrow.parentName) match {
+      | Some(sdir) -> serviceId(context, sdir.creator)
+      | _ -> None()
+      }
+    }
+  | _ -> None()
+  }
+}
+
 private fun sessionId(
   context: readonly SKStore.Context,
   dir: SKStore.EagerDir,
@@ -1148,7 +1163,11 @@ class CollectionWriter(dirName: SKStore.DirName) {
     )
   }
 
-  fun status(context: mutable SKStore.Context, status: Status): void {
+  fun status(
+    context: mutable SKStore.Context,
+    status: Status,
+    serviceId: String,
+  ): void {
     context.maybeGetEagerDir(this.dirName) match {
     | Some(dir) ->
       dirname = sessionId(context, dir) match {
@@ -1160,7 +1179,11 @@ class CollectionWriter(dirName: SKStore.DirName) {
         StatusFile::type,
         dirname,
       );
-      shdl.writeArray(context, this.dirName, Array[StatusFile(status)])
+      shdl.writeArray(
+        context,
+        this.dirName,
+        Array[StatusFile(serviceId, status)],
+      )
     | _ -> void
     };
   }
@@ -1181,8 +1204,13 @@ class CollectionWriter(dirName: SKStore.DirName) {
         StatusFile::type,
         dirname,
       );
-      status = update(shdl.get(context, this.dirName).status);
-      shdl.writeArray(context, this.dirName, Array[StatusFile(status)]);
+      statusFile = shdl.get(context, this.dirName);
+      status = update(statusFile.status);
+      shdl.writeArray(
+        context,
+        this.dirName,
+        Array[StatusFile(statusFile.service, status)],
+      );
       optResource
     | _ -> None()
     };
@@ -1208,26 +1236,28 @@ value class GetResult<T>(values: T, errors: Array<SKJSON.CJSON>)
 
 fun getAll(
   context: mutable SKStore.Context,
+  service: String,
   resourceName: String,
   params: SKJSON.CJSON,
 ): GetResult<Values> {
-  resource = getResourceInfo(context, resourceName, params);
+  resource = getResourceInfo(context, service, resourceName, params);
   resource.getResult(
     context,
     Values(
       resource.collection.getAll(context),
-      `${resource.session}/${context.getTick()}`,
+      `${service}/${context.getTick()}`,
     ),
   );
 }
 
 fun getForKey(
   context: mutable SKStore.Context,
+  service: String,
   resourceName: String,
   params: SKJSON.CJSON,
   key: SKJSON.CJSON,
 ): GetResult<Array<SKJSON.CJSON>> {
-  resource = getResourceInfo(context, resourceName, params);
+  resource = getResourceInfo(context, service, resourceName, params);
   pushContext(context);
   values = resource.collection.getArray(key);
   popContext();
@@ -1304,9 +1334,9 @@ fun subscribe(
   if (context.getPersistent(subId).isSome()) {
     return -2
   };
-  maybeGetReactiveResource(context, identifier) match {
-  | Some(info) ->
-    start = `${info.session}/`;
+  unsafeMaybeGetResourceDef(context, identifier) match {
+  | Some(def) ->
+    start = `${def.service}/`;
     from = SKStore.Tick(
       optWatermark match {
       | Some(watermark) if (watermark.startsWith(start)) ->
@@ -1323,7 +1353,10 @@ fun subscribe(
         },
         identifier,
         from,
-        fn => (values, tick, update) ~> {
+        fn => (ctx, values, tick, update) ~> {
+          ldef = unsafeMaybeGetResourceDef(ctx, identifier).fromSome(
+            `Resource ${identifier} should exists`,
+          );
           notifier.notify(
             values.map(v ->
               (
@@ -1331,7 +1364,7 @@ fun subscribe(
                 v.i1.map(x -> JSONFile::type(x).json),
               )
             ),
-            `${info.session}/${tick}`,
+            `${ldef.service}/${tick}`,
             update,
           )
         },
@@ -1424,6 +1457,7 @@ private fun writeInCollection(
 
 fun update(
   context: mutable SKStore.Context,
+  service: String,
   collection: String,
   values: Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)>,
   executor: Executor,
@@ -1431,7 +1465,7 @@ fun update(
   writeInCollection(
     context,
     context,
-    SKStore.DirName::create(`/${collection}/`),
+    SKStore.DirName::create(`/${base64(service)}/${collection}/`),
     values,
     executor,
   )
@@ -1453,6 +1487,7 @@ fun delete(
 
 fun createReactiveResource(
   context: mutable SKStore.Context,
+  service: String,
   identifier: String,
   resource: String,
   params: SKJSON.CJSON,
@@ -1463,7 +1498,7 @@ fun createReactiveResource(
     ResourceDef::type,
     kResourceSessionDir,
   );
-  activeKey = ResourceDef(resource, params);
+  activeKey = ResourceDef(service, resource, params);
   activeHdl = SKStore.EHandle(
     ResourceDef::keyType,
     SKStore.IntFile::type,
@@ -1477,13 +1512,13 @@ fun createReactiveResource(
   definition = activeHdl.maybeGet(context, activeKey) match {
   | Some(activeFile) ->
     // Add the instance for corresponding active resource
-    definition = ResourceDef(resource, params, activeFile.value);
+    definition = ResourceDef(service, resource, params, activeFile.value);
     resourceHdl.writeArray(context, key, Array[definition]);
     context.update();
     definition
   | _ ->
     active = SKStore.genSym(0);
-    definition = ResourceDef(resource, params, active);
+    definition = ResourceDef(service, resource, params, active);
     activeHdl.writeArray(context, activeKey, Array[SKStore.IntFile(active)]);
     resourceHdl.writeArray(context, key, Array[definition]);
     context.update();
@@ -1526,6 +1561,7 @@ fun resourceInstances(
 
 fun reloadResource(
   context: mutable SKStore.Context,
+  service: String,
   resource: String,
   params: SKJSON.CJSON,
   executor: IntExecutor,
@@ -1536,7 +1572,7 @@ fun reloadResource(
     ResourceDef::type,
     kResourceSessionDir,
   );
-  definition = ResourceDef(resource, params, SKStore.genSym(0));
+  definition = ResourceDef(service, resource, params, SKStore.genSym(0));
   resourceHdl.writeArray(context, SKStore.SID(reloadId), Array[definition]);
   context.update();
   checkResourceInstanceSubcriptions(
@@ -1641,6 +1677,17 @@ fun maybeGetReactiveResource(
     .map(definition -> graphHdl.get(context, definition))
 }
 
+fun unsafeMaybeGetResourceDef(
+  context: readonly SKStore.Context,
+  identifier: String,
+): ?ResourceDef {
+  SKStore.EHandle(
+    SKStore.SID::keyType,
+    ResourceDef::type,
+    kResourceSessionDir,
+  ).unsafeMaybeGet(context, SKStore.SID(identifier))
+}
+
 fun unsafeMaybeGetReactiveResource(
   context: readonly SKStore.Context,
   identifier: String,
@@ -1650,9 +1697,9 @@ fun unsafeMaybeGetReactiveResource(
     ResourceInfo::type,
     kResourceCollectionsDir,
   );
-  SKStore.EHandle(SKStore.SID::keyType, ResourceDef::type, kResourceSessionDir)
-    .unsafeMaybeGet(context, SKStore.SID(identifier))
-    .map(definition -> graphHdl.unsafeGet(context, definition))
+  unsafeMaybeGetResourceDef(context, identifier).map(definition ->
+    graphHdl.unsafeGet(context, definition)
+  )
 }
 
 fun unsafeGetReactiveResource(
@@ -1668,6 +1715,7 @@ fun unsafeGetReactiveResource(
 
 fun getResourceInfo(
   context: mutable SKStore.Context,
+  service: String,
   resource: String,
   params: SKJSON.CJSON,
 ): ResourceInfo {
@@ -1675,12 +1723,12 @@ fun getResourceInfo(
     ResourceDef::keyType,
     SKStore.IntFile::type,
     kResourceSessionDir.sub("active"),
-  ).get(context, ResourceDef(resource, params));
+  ).get(context, ResourceDef(service, resource, params));
   SKStore.EHandle(
     ResourceDef::keyType,
     ResourceInfo::type,
     kResourceCollectionsDir,
-  ).get(context, ResourceDef(resource, params, activeFile.value));
+  ).get(context, ResourceDef(service, resource, params, activeFile.value));
 }
 
 fun checkGarbage(context: mutable SKStore.Context): void {

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -352,14 +352,34 @@ fun initService(
           (ctx, writer, key, it) ~> {
             serviceDef = it.first;
             mInputs = mutable Map<String, Collection>[];
+            optFrom = serviceDef.service.from();
             serviceDef.service.inputs().each(input -> {
               iDirName = SKStore.DirName::create(`/${base64(key)}/${input}/`);
-              values = serviceDef.service.initialData(input);
+              values = optFrom match {
+              | Some(from) ->
+                fDirName = SKStore.DirName::create(
+                  `/${base64(from)}/${input}/`,
+                );
+                ctx.unsafeMaybeGetEagerDir(fDirName) match {
+                | Some(dir) ->
+                  dir.keys().collect(Array).map(k ->
+                    (JSONID::keyType(k), dir.getArrayRaw(k).map(JSONFile::type))
+                  )
+                | None() ->
+                  serviceDef.service.initialData(input).map(v ->
+                    (JSONID(v.i0), v.i1.map(x -> JSONFile(x)))
+                  )
+                }
+              | _ ->
+                serviceDef.service.initialData(input).map(v ->
+                  (JSONID(v.i0), v.i1.map(x -> JSONFile(x)))
+                )
+              };
               iHdl = ctx.mkdirMulti(
                 JSONID::keyType,
                 JSONFile::type,
                 iDirName,
-                values.map(v -> (JSONID(v.i0), v.i1.map(x -> JSONFile(x)))),
+                values,
               );
               mInputs.add(input, Collection(iHdl))
             });
@@ -420,7 +440,7 @@ fun initService(
         SKStore.SID(identifier),
         Array[ServiceDefinition(service, executor)],
       );
-      context.update();
+      context.update()
     };
     updateContext(context);
     checkSubcriptions(context, identifier, executor);

--- a/skipruntime-ts/skiplang/core/src/Transaction.sk
+++ b/skipruntime-ts/skiplang/core/src/Transaction.sk
@@ -189,7 +189,7 @@ base class InitializationFile(
   services: SortedSet<SKStore.DirName>,
 ) extends SKStore.File {
   children =
-  | ServiceInitialization(executor: Executor)
+  | ServiceInitialization(service: String, executor: Executor)
   | ResourceInitialization(instances: List<(String, Executor)>)
 }
 
@@ -320,6 +320,7 @@ private fun checkResourceInstanceSubcriptions(
 
 private fun checkSubcriptions(
   context: mutable SKStore.Context,
+  identifier: String,
   executor: Executor,
 ): void {
   subcriptions = getSubscriptions(context);
@@ -328,7 +329,7 @@ private fun checkSubcriptions(
   } else {
     context.setPersistent(
       kInitializationsKey,
-      ServiceInitialization(executor, subcriptions),
+      ServiceInitialization(identifier, executor, subcriptions),
     )
   };
 }
@@ -367,18 +368,18 @@ private fun checkInitialization(
     | Some(errors) ->
       if (errors.isEmpty()) {
         init match {
-        | ServiceInitialization(executor, _) -> executor.resolve()
+        | ServiceInitialization(_, executor, _) -> executor.resolve()
         | ResourceInitialization(instances, _) ->
           instances.each(info -> info.i1.resolve())
         }
       } else {
         (init, resource) match {
-        | (ServiceInitialization(executor, _), None()) ->
+        | (ServiceInitialization(service, executor, _), None()) ->
           executor.reject(ServiceInstanceInitFailed(errors));
           context.getPersistent(kTransactionIdKey).map(f ->
             SKStore.StringFile::type(f).value
           ) match {
-          | None() -> _ = closeService_(context, false)
+          | None() -> _ = closeService_(context, service, false)
           | _ -> void
           }
         | (ResourceInitialization(instances, _), Some _) ->

--- a/skipruntime-ts/skiplang/core/src/Transaction.sk
+++ b/skipruntime-ts/skiplang/core/src/Transaction.sk
@@ -382,10 +382,15 @@ private fun checkInitialization(
           | _ -> void
           }
         | (ResourceInitialization(instances, _), Some _) ->
-          instances.each(info -> {
-            info.i1.reject(ResourceInstanceInitFailed(errors));
-            destroyReactiveResource(context, SKStore.SID(info.i0))
-          })
+          resources = SortedSet::createFromItems(
+            instances.map(info -> {
+              info.i1.reject(ResourceInstanceInitFailed(errors));
+              destroyReactiveResource(context, SKStore.SID(info.i0))
+            }),
+          );
+          context.update();
+          if (checkResources(context, resources)) context.update()
+
         | _ -> invariant_violation("Invalid initialisation state.")
         }
       };

--- a/skipruntime-ts/skiplang/core/src/Transaction.sk
+++ b/skipruntime-ts/skiplang/core/src/Transaction.sk
@@ -293,8 +293,7 @@ private fun checkResourceInstanceSubcriptions(
   instance: String,
   executor: Executor,
 ): void {
-  resourceId = toResourceId(resource.name, resource.params);
-  key = `${kInitializationsKey}.${resourceId}`;
+  key = `${kInitializationsKey}.${resource.toId()}`;
   subcriptions = getSubscriptions(context);
   context.getPersistent(key).map(ResourceInitialization::type) match {
   | Some(init) ->
@@ -359,9 +358,7 @@ private fun checkInitialization(
   resource: ?ResourceDef,
 ): void {
   key = resource match {
-  | Some(def) ->
-    resourceId = toResourceId(def.name, def.params);
-    `${kInitializationsKey}.${resourceId}`
+  | Some(def) -> `${kInitializationsKey}.${def.toId()}`
   | _ -> kInitializationsKey
   };
   context.getPersistent(key).map(f ~> f as InitializationFile _) match {
@@ -394,8 +391,7 @@ private fun checkInitialization(
       };
       resource match {
       | Some(def) ->
-        resourceId = toResourceId(def.name, def.params);
-        context.removePersistent(`${kInitializationsKey}.${resourceId}`)
+        context.removePersistent(`${kInitializationsKey}.${def.toId()}`)
       | _ -> context.removePersistent(kInitializationsKey)
       }
     | _ -> void

--- a/skipruntime-ts/skiplang/core/src/Utils.sk
+++ b/skipruntime-ts/skiplang/core/src/Utils.sk
@@ -43,7 +43,7 @@ fun accReducer<V1: SKStore.File, V2: SKStore.File>(
     type => reducer.getType(),
     canReset => true,
     init => iter ~> {
-      acc = reducer.initial;
+      acc = reducer.init();
       for (x in iter) {
         !acc = reducer.add(acc, x)
       };

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -526,13 +526,21 @@ class JSONReducer(
 
 @export("SkipRuntime_Runtime__createResource")
 fun createResourceOfRuntime(
+  service: String,
   identifier: String,
   resource: String,
   params: SKJSON.CJSON,
   executor: Executor,
 ): Float {
   SKStore.runWithResult(context ~> {
-    createReactiveResource(context, identifier, resource, params, executor)
+    createReactiveResource(
+      context,
+      service,
+      identifier,
+      resource,
+      params,
+      executor,
+    )
   }) match {
   | Success _ -> 0.0
   | Failure(err) -> getErrorHdl(err)
@@ -552,6 +560,7 @@ fun resourceInstancesOfRuntime(jsResources: SKJSON.CJSON): SKJSON.CJArray {
         SKJSON.CJObject(
           SKJSON.CJFields::create(
             Array<(String, SKJSON.CJSON)>[
+              ("service", SKJSON.CJString(def.service)),
               ("resource", SKJSON.CJString(def.name)),
               ("params", def.params),
             ],
@@ -568,12 +577,13 @@ fun resourceInstancesOfRuntime(jsResources: SKJSON.CJSON): SKJSON.CJArray {
 
 @export("SkipRuntime_Runtime__reloadResource")
 fun reloadResourceOfRuntime(
+  service: String,
   resource: String,
   params: SKJSON.CJSON,
   executor: IntExecutor,
 ): Float {
   SKStore.runWithResult(context ~> {
-    reloadResource(context, resource, params, executor)
+    reloadResource(context, service, resource, params, executor)
   }) match {
   | Success _ -> 0.0
   | Failure(err) -> getErrorHdl(err)
@@ -586,6 +596,7 @@ fun replaceActiveResourcesOfRuntime(jsResources: SKJSON.CJSON): Float {
     resources = SKJSON.expectArray(jsResources).map(jsvalue -> {
       obj = SKJSON.asObject(jsvalue);
       ResourceDef(
+        SKJSON.getString(obj, "service").fromSome("service must be defined."),
         SKJSON.getString(obj, "resource").fromSome("resource must be defined."),
         SKJSON.getValue(obj, "params").fromSome("params must be defined."),
         SKJSON.getValue(obj, "instance")
@@ -606,6 +617,7 @@ fun destroyResourcesOfRuntime(jsResources: SKJSON.CJSON): Float {
     resources = SKJSON.expectArray(jsResources).map(jsvalue -> {
       obj = SKJSON.asObject(jsvalue);
       ResourceDef(
+        SKJSON.getString(obj, "service").fromSome("service must be defined."),
         SKJSON.getString(obj, "resource").fromSome("resource must be defined."),
         SKJSON.getValue(obj, "params").fromSome("params must be defined."),
         SKJSON.getValue(obj, "instance")
@@ -621,9 +633,13 @@ fun destroyResourcesOfRuntime(jsResources: SKJSON.CJSON): Float {
 }
 
 @export("SkipRuntime_Runtime__getAll")
-fun getAllOfRuntime(resource: String, params: SKJSON.CJSON): SKJSON.CJSON {
+fun getAllOfRuntime(
+  service: String,
+  resource: String,
+  params: SKJSON.CJSON,
+): SKJSON.CJSON {
   SKStore.runWithResult(context ~> {
-    res = getAll(context, resource, params);
+    res = getAll(context, service, resource, params);
     /* Ensure all resources closed at right time */
     updateContext(context);
     res
@@ -649,12 +665,13 @@ fun getAllOfRuntime(resource: String, params: SKJSON.CJSON): SKJSON.CJSON {
 
 @export("SkipRuntime_Runtime__getForKey")
 fun getForKeyOfRuntime(
+  service: String,
   resource: String,
   params: SKJSON.CJSON,
   key: SKJSON.CJSON,
 ): SKJSON.CJSON {
   SKStore.runWithResult(context ~> {
-    res = getForKey(context, resource, params, key);
+    res = getForKey(context, service, resource, params, key);
     /* Ensure all resources closed at right time */
     updateContext(context);
     res
@@ -707,6 +724,7 @@ fun unsubscribeOfRuntime(session: Int): Float {
 
 @export("SkipRuntime_Runtime__update")
 fun updateOfRuntime(
+  service: String,
   input: String,
   values: SKJSON.CJArray,
   executor: Executor,
@@ -714,6 +732,7 @@ fun updateOfRuntime(
   SKStore.runWithResult(context ~> {
     update(
       context,
+      service,
       input,
       values match {
       | SKJSON.CJArray(vs) ->
@@ -757,8 +776,12 @@ fun useExternalResource(
 /************ initService ****************/
 
 @export("SkipRuntime_initService")
-fun initSkipRuntimeService(service: Service, executor: Executor): Float {
-  initService(service, executor) match {
+fun initSkipRuntimeService(
+  identifier: String,
+  service: Service,
+  executor: Executor,
+): Float {
+  initService(identifier, service, executor) match {
   | Success _ -> 0.0
   | Failure(err) -> getErrorHdl(err)
   };
@@ -767,8 +790,8 @@ fun initSkipRuntimeService(service: Service, executor: Executor): Float {
 /************ closeService ****************/
 
 @export("SkipRuntime_closeService")
-fun closeSkipRuntimeService(): Float {
-  closeService() match {
+fun closeSkipRuntimeService(identifier: String): Float {
+  closeService(identifier) match {
   | Success(handle) -> handle
   | Failure(err) -> -getErrorHdl(err)
   };

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -732,6 +732,16 @@ fun closeSkipRuntimeService(): SKJSON.CJSON {
   };
 }
 
+/************ closeService ****************/
+
+@export("SkipRuntime_invalidateCollections")
+fun invalidateCollectionsOfSkipRuntime(collections: SKJSON.CJArray): Float {
+  invalidateCollections(collections) match {
+  | Success(_) -> 0.0
+  | Failure(err) -> getErrorHdl(err)
+  }
+}
+
 class ExternalException(
   type: String,
   message: String,

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -530,7 +530,7 @@ fun createResourceOfRuntime(
   identifier: String,
   resource: String,
   params: SKJSON.CJSON,
-  executor: Executor,
+  executor: IntExecutor,
 ): Float {
   SKStore.runWithResult(context ~> {
     createReactiveResource(
@@ -591,7 +591,10 @@ fun reloadResourceOfRuntime(
 }
 
 @export("SkipRuntime_Runtime__replaceActiveResources")
-fun replaceActiveResourcesOfRuntime(jsResources: SKJSON.CJSON): Float {
+fun replaceActiveResourcesOfRuntime(
+  service: String,
+  jsResources: SKJSON.CJSON,
+): Float {
   SKStore.runWithResult(context ~> {
     resources = SKJSON.expectArray(jsResources).map(jsvalue -> {
       obj = SKJSON.asObject(jsvalue);
@@ -604,7 +607,7 @@ fun replaceActiveResourcesOfRuntime(jsResources: SKJSON.CJSON): Float {
           .fromSome("instance must be defined."),
       )
     });
-    replaceActiveResources(context, resources)
+    replaceActiveResources(context, service, resources)
   }) match {
   | Success _ -> 0.0
   | Failure(err) -> getErrorHdl(err)

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -191,6 +191,25 @@ class ExternExecutor(eptr: SKStore.ExternalPointer) extends Executor {
   }
 }
 
+@cpp_extern("SkipRuntime_IntExecutor__resolve")
+@debug
+native fun resolveOfIntExecutor(executor: UInt32, value: Int): void;
+
+@export("SkipRuntime_createIntExecutor")
+fun createIntExecutor(executor: UInt32): ExternIntExecutor {
+  ExternIntExecutor(SKStore.ExternalPointer::create(executor, deleteExecutor))
+}
+
+class ExternIntExecutor(eptr: SKStore.ExternalPointer) extends IntExecutor {
+  fun resolve(value: Int): void {
+    resolveOfIntExecutor(this.eptr.value, value)
+  }
+
+  fun reject(exc: .Exception): void {
+    rejectOfExecutor(this.eptr.value, getErrorHdl(exc))
+  }
+}
+
 /************  Service ****************/
 
 @export("SkipRuntime_createService")
@@ -514,6 +533,87 @@ fun createResourceOfRuntime(
 ): Float {
   SKStore.runWithResult(context ~> {
     createReactiveResource(context, identifier, resource, params, executor)
+  }) match {
+  | Success _ -> 0.0
+  | Failure(err) -> getErrorHdl(err)
+  };
+}
+
+@export("SkipRuntime_Runtime__resourceInstances")
+fun resourceInstancesOfRuntime(jsResources: SKJSON.CJSON): SKJSON.CJArray {
+  SKStore.runWithResult(context ~> {
+    resources = SKJSON.expectArray(jsResources).map(SKJSON.asString);
+    instances = resourceInstances(
+      context,
+      SortedSet::createFromItems(resources),
+    );
+    SKJSON.CJArray(
+      instances.map(def -> {
+        SKJSON.CJObject(
+          SKJSON.CJFields::create(
+            Array<(String, SKJSON.CJSON)>[
+              ("resource", SKJSON.CJString(def.name)),
+              ("params", def.params),
+            ],
+            x -> x,
+          ),
+        )
+      }),
+    )
+  }) match {
+  | Success(arr) -> arr
+  | Failure(err) -> throw err
+  };
+}
+
+@export("SkipRuntime_Runtime__reloadResource")
+fun reloadResourceOfRuntime(
+  resource: String,
+  params: SKJSON.CJSON,
+  executor: IntExecutor,
+): Float {
+  SKStore.runWithResult(context ~> {
+    reloadResource(context, resource, params, executor)
+  }) match {
+  | Success _ -> 0.0
+  | Failure(err) -> getErrorHdl(err)
+  };
+}
+
+@export("SkipRuntime_Runtime__replaceActiveResources")
+fun replaceActiveResourcesOfRuntime(jsResources: SKJSON.CJSON): Float {
+  SKStore.runWithResult(context ~> {
+    resources = SKJSON.expectArray(jsResources).map(jsvalue -> {
+      obj = SKJSON.asObject(jsvalue);
+      ResourceDef(
+        SKJSON.getString(obj, "resource").fromSome("resource must be defined."),
+        SKJSON.getValue(obj, "params").fromSome("params must be defined."),
+        SKJSON.getValue(obj, "instance")
+          .map(v -> SKJSON.asNumber(v).toInt())
+          .fromSome("instance must be defined."),
+      )
+    });
+    replaceActiveResources(context, resources)
+  }) match {
+  | Success _ -> 0.0
+  | Failure(err) -> getErrorHdl(err)
+  };
+}
+
+@export("SkipRuntime_Runtime__destroyResources")
+fun destroyResourcesOfRuntime(jsResources: SKJSON.CJSON): Float {
+  SKStore.runWithResult(context ~> {
+    resources = SKJSON.expectArray(jsResources).map(jsvalue -> {
+      obj = SKJSON.asObject(jsvalue);
+      ResourceDef(
+        SKJSON.getString(obj, "resource").fromSome("resource must be defined."),
+        SKJSON.getValue(obj, "params").fromSome("params must be defined."),
+        SKJSON.getValue(obj, "instance")
+          .map(v -> SKJSON.asNumber(v).toInt())
+          .fromSome("instance must be defined."),
+      )
+    });
+    destroyResources(context, resources)
   }) match {
   | Success _ -> 0.0
   | Failure(err) -> getErrorHdl(err)

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -232,6 +232,10 @@ native fun createGraphOfService(
 @debug
 native fun inputsOfService(service: UInt32): SKJSON.CJArray;
 
+@cpp_extern("SkipRuntime_ServiceDefinition__from")
+@debug
+native fun fromOfService(service: UInt32): ?String;
+
 @cpp_extern("SkipRuntime_ServiceDefinition__initialData")
 @debug
 native fun initialDataOfService(service: UInt32, input: String): SKJSON.CJArray;
@@ -275,6 +279,10 @@ class ExternService(eptr: SKStore.ExternalPointer) extends Service {
   //
   fun inputs(): Array<String> {
     SKJSON.expectArray(inputsOfService(this.eptr.value)).map(SKJSON.asString)
+  }
+
+  fun from(): ?String {
+    fromOfService(this.eptr.value)
   }
 
   fun initialData(name: String): Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)> {

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -528,13 +528,17 @@ native fun removeOfReducer(
   value: SKJSON.CJSON,
 ): ?SKJSON.CJSON;
 
+@cpp_extern("SkipRuntime_Reducer__init")
+@debug
+native fun initOfReducer(reducer: UInt32): SKJSON.CJSON;
+
 @cpp_extern("SkipRuntime_deleteReducer")
 @debug
 native fun deleteReducer(reducer: UInt32): void;
 
 @export("SkipRuntime_createReducer")
-fun createReducer(reducer: UInt32, initial: SKJSON.CJSON): JSONReducer {
-  JSONReducer(SKStore.ExternalPointer::create(reducer, deleteReducer), initial)
+fun createReducer(reducer: UInt32): JSONReducer {
+  JSONReducer(SKStore.ExternalPointer::create(reducer, deleteReducer))
 }
 
 class JSONReducer(
@@ -542,6 +546,10 @@ class JSONReducer(
 ) extends Reducer<SKJSON.CJSON, SKJSON.CJSON> {
   fun getType(): SKStore.File ~> SKJSON.CJSON {
     f ~> JSONFile::type(f).json
+  }
+
+  fun init(): SKJSON.CJSON {
+    initOfReducer(this.eptr.value)
   }
 
   fun add(acc: SKJSON.CJSON, value: SKJSON.CJSON): SKJSON.CJSON {

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -87,67 +87,6 @@ class ExternLazyCompute(eptr: SKStore.ExternalPointer) extends LazyCompute {
   }
 }
 
-/************  ExternalService ****************/
-
-@cpp_extern("SkipRuntime_ExternalService__subscribe")
-@debug
-native fun subscribeOfExternalService(
-  externalSupplier: UInt32,
-  collection: String,
-  instance: String,
-  resource: String,
-  params: SKJSON.CJSON,
-): void;
-
-@cpp_extern("SkipRuntime_ExternalService__unsubscribe")
-@debug
-native fun unsubscribeOfExternalService(
-  externalSupplier: UInt32,
-  instance: String,
-): void;
-
-@cpp_extern("SkipRuntime_ExternalService__shutdown")
-@debug
-native fun shutdownOfExternalService(externalSupplier: UInt32): Float;
-
-@cpp_extern("SkipRuntime_deleteExternalService")
-@debug
-native fun deleteExternalService(externalSupplier: UInt32): void;
-
-@export("SkipRuntime_createExternalService")
-fun createExternalService(externalSupplier: UInt32): ExternExternalService {
-  ExternExternalService(
-    SKStore.ExternalPointer::create(externalSupplier, deleteExternalService),
-  )
-}
-
-class ExternExternalService(
-  eptr: SKStore.ExternalPointer,
-) extends ExternalService {
-  fun subscribe(
-    instance: String,
-    collection: CollectionWriter,
-    resource: String,
-    params: SKJSON.CJSON,
-  ): void {
-    subscribeOfExternalService(
-      this.eptr.value,
-      collection.dirName.toString(),
-      instance,
-      resource,
-      params,
-    )
-  }
-
-  fun unsubscribe(instance: String): void {
-    unsubscribeOfExternalService(this.eptr.value, instance)
-  }
-
-  fun shutdown(): Float {
-    shutdownOfExternalService(this.eptr.value)
-  }
-}
-
 /************  CollectionWriter ****************/
 
 @export("SkipRuntime_CollectionWriter__update")
@@ -223,34 +162,6 @@ class ExternResource(eptr: SKStore.ExternalPointer) extends Resource {
   }
 }
 
-/************  ResourceBuilder ****************/
-
-@cpp_extern("SkipRuntime_ResourceBuilder__build")
-@debug
-native fun buildOfResourceBuilder(
-  builder: UInt32,
-  params: SKJSON.CJSON,
-): Resource;
-
-@cpp_extern("SkipRuntime_deleteResourceBuilder")
-@debug
-native fun deleteResourceBuilder(resourceBuilder: UInt32): void;
-
-@export("SkipRuntime_createResourceBuilder")
-fun createResourceBuilder(resourceBuilder: UInt32): ExternResourceBuilder {
-  ExternResourceBuilder(
-    SKStore.ExternalPointer::create(resourceBuilder, deleteResourceBuilder),
-  )
-}
-
-class ExternResourceBuilder(
-  eptr: SKStore.ExternalPointer,
-) extends ResourceBuilder {
-  fun build(params: SKJSON.CJSON): Resource {
-    buildOfResourceBuilder(this.eptr.value, params)
-  }
-}
-
 /************  Executor ****************/
 
 @cpp_extern("SkipRuntime_Executor__resolve")
@@ -283,48 +194,86 @@ class ExternExecutor(eptr: SKStore.ExternalPointer) extends Executor {
 /************  Service ****************/
 
 @export("SkipRuntime_createService")
-fun createService(
-  service: UInt32,
-  jsInputs: SKJSON.CJObject,
-  resources: mutable Map<String, ResourceBuilder>,
-  remotes: mutable Map<String, ExternalService>,
-): ExternService {
-  inputs = mutable Vector[];
-  jsInputs match {
-  | SKJSON.CJObject(fields) ->
-    for (fieldName => field in fields) {
-      inputs.push(
-        Input(
-          fieldName,
-          SKJSON.expectArray(field).map(v -> {
-            e = SKJSON.expectArray(v);
-            (e[0], SKJSON.expectArray(e[1]))
-          }),
-        ),
-      )
-    }
-  };
-  ExternService(
-    SKStore.ExternalPointer::create(service, deleteService),
-    inputs.toArray(),
-    resources.chill(),
-    remotes.chill(),
-  )
+fun createService(service: UInt32): ExternService {
+  ExternService(SKStore.ExternalPointer::create(service, deleteService))
 }
 
 @cpp_extern("SkipRuntime_deleteService")
 @debug
 native fun deleteService(service: UInt32): void;
 
-@cpp_extern("SkipRuntime_Service__createGraph")
+@cpp_extern("SkipRuntime_ServiceDefinition__createGraph")
 @debug
 native fun createGraphOfService(
-  resource: UInt32,
+  service: UInt32,
   collections: SKJSON.CJObject,
 ): SKJSON.CJObject;
 
+@cpp_extern("SkipRuntime_ServiceDefinition__inputs")
+@debug
+native fun inputsOfService(service: UInt32): SKJSON.CJArray;
+
+@cpp_extern("SkipRuntime_ServiceDefinition__initialData")
+@debug
+native fun initialDataOfService(service: UInt32, input: String): SKJSON.CJArray;
+
+@cpp_extern("SkipRuntime_ServiceDefinition__resources")
+@debug
+native fun resourcesOfService(service: UInt32): SKJSON.CJArray;
+
+@cpp_extern("SkipRuntime_ServiceDefinition__buildResource")
+@debug
+native fun buildResourceOfService(
+  service: UInt32,
+  resource: String,
+  params: SKJSON.CJSON,
+): Resource;
+
+@cpp_extern("SkipRuntime_ServiceDefinition__subscribe")
+@debug
+native fun subscribeOfService(
+  service: UInt32,
+  supplier: String,
+  collection: String,
+  instance: String,
+  resource: String,
+  params: SKJSON.CJSON,
+): void;
+
+@cpp_extern("SkipRuntime_ServiceDefinition__unsubscribe")
+@debug
+native fun unsubscribeOfService(
+  service: UInt32,
+  supplier: String,
+  instance: String,
+): void;
+
+@cpp_extern("SkipRuntime_ServiceDefinition__shutdown")
+@debug
+native fun shutdownOfService(service: UInt32): Float;
+
 class ExternService(eptr: SKStore.ExternalPointer) extends Service {
   //
+  fun inputs(): Array<String> {
+    SKJSON.expectArray(inputsOfService(this.eptr.value)).map(SKJSON.asString)
+  }
+
+  fun initialData(name: String): Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)> {
+    values = initialDataOfService(this.eptr.value, name);
+    SKJSON.expectArray(values).map(v -> {
+      e = SKJSON.expectArray(v);
+      (e[0], SKJSON.expectArray(e[1]))
+    })
+  }
+
+  fun resources(): Array<String> {
+    SKJSON.expectArray(resourcesOfService(this.eptr.value)).map(SKJSON.asString)
+  }
+
+  fun buildResource(name: String, parameters: SKJSON.CJSON): Resource {
+    buildResourceOfService(this.eptr.value, name, parameters)
+  }
+
   fun createGraph(inputs: Map<String, Collection>): Map<String, Collection> {
     names = createGraphOfService(this.eptr.value, collectionsByName(inputs));
     map = mutable Map[];
@@ -336,38 +285,31 @@ class ExternService(eptr: SKStore.ExternalPointer) extends Service {
     };
     map.chill()
   }
-}
 
-/************  ResourceBuilderMap ****************/
+  fun subscribe(
+    supplier: String,
+    instance: String,
+    collection: CollectionWriter,
+    resource: String,
+    params: SKJSON.CJSON,
+  ): void {
+    subscribeOfService(
+      this.eptr.value,
+      supplier,
+      collection.dirName.toString(),
+      instance,
+      resource,
+      params,
+    )
+  }
 
-@export("SkipRuntime_ResourceBuilderMap__create")
-fun createOfResourceBuilderMap(): mutable Map<String, ResourceBuilder> {
-  mutable Map[]
-}
+  fun unsubscribe(supplier: String, instance: String): void {
+    unsubscribeOfService(this.eptr.value, supplier, instance)
+  }
 
-@export("SkipRuntime_ResourceBuilderMap__add")
-fun addOfResourceBuilderMap(
-  builders: mutable Map<String, ResourceBuilder>,
-  name: String,
-  builder: ResourceBuilder,
-): void {
-  builders.add(name, builder)
-}
-
-/************  ExternalServiceMap ****************/
-
-@export("SkipRuntime_ExternalServiceMap__create")
-fun createOfExternalServiceMap(): mutable Map<String, ExternalService> {
-  mutable Map[]
-}
-
-@export("SkipRuntime_ExternalServiceMap__add")
-fun addOfExternalServiceMap(
-  suppliers: mutable Map<String, ExternalService>,
-  name: String,
-  supplier: ExternalService,
-): void {
-  suppliers.add(name, supplier)
+  fun shutdown(): Float {
+    shutdownOfService(this.eptr.value)
+  }
 }
 
 /************  Collection ****************/
@@ -725,14 +667,14 @@ fun initSkipRuntimeService(service: Service, executor: Executor): Float {
 /************ closeService ****************/
 
 @export("SkipRuntime_closeService")
-fun closeSkipRuntimeService(): SKJSON.CJSON {
+fun closeSkipRuntimeService(): Float {
   closeService() match {
-  | Success(handles) -> SKJSON.CJArray(handles.map(h -> SKJSON.CJFloat(h)))
-  | Failure(err) -> SKJSON.CJFloat(getErrorHdl(err))
+  | Success(handle) -> handle
+  | Failure(err) -> -getErrorHdl(err)
   };
 }
 
-/************ closeService ****************/
+/************ invalidateCollections ****************/
 
 @export("SkipRuntime_invalidateCollections")
 fun invalidateCollectionsOfSkipRuntime(collections: SKJSON.CJArray): Float {

--- a/skipruntime-ts/tests/src/for-reload.ts
+++ b/skipruntime-ts/tests/src/for-reload.ts
@@ -1,0 +1,7 @@
+import type { Mapper, Values } from "@skipruntime/core";
+
+export class ReloadMapper implements Mapper<number, number, number, number> {
+  mapEntry(key: number, values: Values<number>): Iterable<[number, number]> {
+    return Array([0, values.getUnique() + 2 * key]);
+  }
+}

--- a/skipruntime-ts/tests/src/for-reload.ts
+++ b/skipruntime-ts/tests/src/for-reload.ts
@@ -1,7 +1,26 @@
-import type { Mapper, Values } from "@skipruntime/core";
+import type {
+  Mapper,
+  Values,
+  Resource,
+  EagerCollection,
+} from "@skipruntime/core";
 
 export class ReloadMapper implements Mapper<number, number, number, number> {
   mapEntry(key: number, values: Values<number>): Iterable<[number, number]> {
     return Array([0, values.getUnique() + 2 * key]);
+  }
+}
+
+export class AfterMapper implements Mapper<number, number, number, number> {
+  mapEntry(key: number, values: Values<number>): Iterable<[number, number]> {
+    return values.toArray().map((v) => [key + 1, v + 1] as [number, number]);
+  }
+}
+
+type Input_NN = { input: EagerCollection<number, number> };
+
+export class ReloadResource implements Resource<Input_NN> {
+  instantiate(collections: Input_NN): EagerCollection<number, number> {
+    return collections.input.map(ReloadMapper).map(AfterMapper);
   }
 }

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -1978,8 +1978,8 @@ INSERT INTO skip_test (id, x) VALUES (1, 1), (2, 2), (3, 3);`);
       expect((await service.getArray(resource, 1)).sort()).toEqual([6, 9]);
       notifier.checkUpdate([[1, [6, 9]]]);
       await service.reloadService(reloadService());
-      expect(await service.getAll(resource)).toEqual([]);
-      notifier.checkInit([]);
+      expect((await service.getArray(resource, 0)).sort()).toEqual([4, 6]);
+      notifier.checkInit([[0, [4, 6]]]);
       await service.update("input", [
         [1, [2]],
         [2, [3]],

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -1134,6 +1134,7 @@ export function initTests(
     const service = await initService(map1Service);
     await service.update("input", [["1", [10]]]);
     expect(await service.getArray("map1", "1")).toEqual([12]);
+    await service.close();
   });
 
   it("testMap2", async () => {
@@ -1148,6 +1149,7 @@ export function initTests(
       ["1", [30]],
       ["2", [10]],
     ]);
+    await service.close();
   });
 
   it("testMap3", async () => {
@@ -1162,6 +1164,7 @@ export function initTests(
       ["1", [36]],
       ["2", [10]],
     ]);
+    await service.close();
   });
 
   it("valueMapper", async () => {
@@ -1179,6 +1182,7 @@ export function initTests(
       [5, [30]],
       [10, [110]],
     ]);
+    await service.close();
   });
 
   it("testSize", async () => {
@@ -1205,6 +1209,7 @@ export function initTests(
       [1, [1]],
       [2, [3]],
     ]);
+    await service.close();
   });
 
   it("testSlicedMap1", async () => {
@@ -1224,6 +1229,7 @@ export function initTests(
       [9, [81]],
       [20, [400]],
     ]);
+    await service.close();
   });
 
   it("testLazy", async () => {
@@ -1248,6 +1254,7 @@ export function initTests(
       [0, [2]],
       [1, [2]],
     ]);
+    await service.close();
   });
 
   it("testMapReduce", async () => {
@@ -1281,6 +1288,7 @@ export function initTests(
       [0, [3]],
       [1, [2]],
     ]);
+    await service.close();
   });
 
   it("testUserMapReduce", async () => {
@@ -1314,6 +1322,7 @@ export function initTests(
       [0, [3]],
       [1, [2]],
     ]);
+    await service.close();
   });
 
   it("testCount", async () => {
@@ -1345,6 +1354,7 @@ export function initTests(
       [2, [2]],
       [3, [0]],
     ]);
+    await service.close();
   });
 
   it("testMerge1", async () => {
@@ -1364,6 +1374,7 @@ export function initTests(
       [1, [20]],
       [2, [3, 7]],
     ]);
+    await service.close();
   });
 
   it("testMergeReduce", async () => {
@@ -1383,6 +1394,7 @@ export function initTests(
       [1, [20]],
       [2, [10]],
     ]);
+    await service.close();
   });
 
   it("testMergeMapReduce", async () => {
@@ -1402,6 +1414,7 @@ export function initTests(
       [1, [25]],
       [2, [20]],
     ]);
+    await service.close();
   });
 
   it("testJSONParams", async () => {
@@ -1428,6 +1441,7 @@ export function initTests(
       [1, [43]],
       [2, [44]],
     ]);
+    await service.close();
   });
 
   it("testJSONExtract", async () => {
@@ -1486,6 +1500,7 @@ export function initTests(
       ],
       [2, [[[{ var: 1 }, { var: 2 }]]]],
     ]);
+    await service.close();
   });
 
   it("testExternal", async () => {
@@ -1609,6 +1624,7 @@ export function initTests(
     expect(await service.getArray("resource1", "1")).toEqual([30]);
     await service.update("input2", [["1", [40]]]);
     expect(await service.getArray("resource2", "1")).toEqual([40]);
+    await service.close();
   });
 
   it("testPostgres", async function () {
@@ -1775,6 +1791,7 @@ INSERT INTO skip_test (id, x) VALUES (1, 1), (2, 2), (3, 3);`);
         ),
       );
     }
+    await service.close();
   });
 
   it("testMapWithException", async () => {
@@ -1795,6 +1812,8 @@ INSERT INTO skip_test (id, x) VALUES (1, 1), (2, 2), (3, 3);`);
       expect((e as Error).message).toMatchRegex(
         new RegExp(/^(?:Error: )?Something goes wrong.$/),
       );
+    } finally {
+      await service.close();
     }
   });
 
@@ -1831,6 +1850,8 @@ INSERT INTO skip_test (id, x) VALUES (1, 1), (2, 2), (3, 3);`);
           /^(?:SkipRuntime\.ResourceInstanceInitFailed: )?Resource instance cannot be initialized:/,
         ),
       );
+    } finally {
+      await service.close();
     }
   });
 

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -1899,5 +1899,26 @@ INSERT INTO skip_test (id, x) VALUES (1, 1), (2, 2), (3, 3);`);
     const reload = await import("./for-reload.js");
     service.reload([reload.ReloadMapper]);
     expect((await service.getArray(resource, 0)).sort()).toEqual([4, 7]);
+    await service.update("input", [
+      [1, [3]],
+      [2, [4]],
+    ]);
+    expect((await service.getArray(resource, 0)).sort()).toEqual([5, 8]);
+    const werror = await import("./with-error.js");
+    try {
+      service.reload([werror.ReloadMapper]);
+      throw new Error("Error was not thrown");
+    } catch (e: unknown) {
+      expect(e).toBeA(Error);
+      expect((e as Error).message).toMatchRegex(
+        new RegExp(/^(?:Error: )?Something goes wrong.$/),
+      );
+    }
+    // The wrong mapper should not be taken into account
+    await service.update("input", [
+      [1, [2]],
+      [2, [3]],
+    ]);
+    expect((await service.getArray(resource, 0)).sort()).toEqual([4, 7]);
   });
 }

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -1977,6 +1977,31 @@ INSERT INTO skip_test (id, x) VALUES (1, 1), (2, 2), (3, 3);`);
       ]);
       expect((await service.getArray(resource, 1)).sort()).toEqual([6, 9]);
       notifier.checkUpdate([[1, [6, 9]]]);
+      await service.reloadService(reloadService());
+      expect(await service.getAll(resource)).toEqual([]);
+      notifier.checkInit([]);
+      await service.update("input", [
+        [1, [2]],
+        [2, [3]],
+      ]);
+      expect((await service.getArray(resource, 0)).sort()).toEqual([3, 5]);
+      notifier.checkUpdate([[0, [3, 5]]]);
+      try {
+        await service.reloadService(werror.service());
+        throw new Error("Error was not thrown");
+      } catch (e: unknown) {
+        expect(e).toBeA(Error);
+        expect((e as Error).message).toMatchRegex(
+          new RegExp(/^(?:Error: )?Something goes wrong.$/),
+        );
+      }
+      expect((await service.getArray(resource, 0)).sort()).toEqual([3, 5]);
+      notifier.checkEmpty();
+      await service.update("input", [
+        [1, [3]],
+        [2, [4]],
+      ]);
+      expect((await service.getArray(resource, 0)).sort()).toEqual([4, 6]);
     } finally {
       if (notifier) notifier.close();
       await service.close();

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -1982,4 +1982,41 @@ INSERT INTO skip_test (id, x) VALUES (1, 1), (2, 2), (3, 3);`);
       await service.close();
     }
   });
+
+  it("testMultipleService", async () => {
+    let service1: Nullable<ServiceInstance> = null;
+    let service2: Nullable<ServiceInstance> = null;
+    let service3: Nullable<ServiceInstance> = null;
+    let service4: Nullable<ServiceInstance> = null;
+
+    try {
+      service1 = await initService(map1Service);
+      service2 = await initService(map1Service);
+      service3 = await initService(testExternalService());
+      service4 = await initService(testExternalService());
+      await service1.update("input", [["1", [10]]]);
+      await service2.update("input", [["2", [10]]]);
+      expect(await service1.getArray("map1", "1")).toEqual([12]);
+      expect(await service1.getArray("map1", "2")).toEqual([]);
+      expect(await service2.getArray("map1", "1")).toEqual([]);
+      expect(await service2.getArray("map1", "2")).toEqual([12]);
+      await service3.update("input1", [[0, [10]]]);
+      await service3.update("input2", [
+        [0, [5]],
+        [1, [10]],
+      ]);
+      await service4.update("input1", [[1, [20]]]);
+      await service4.update("input2", [
+        [0, [1]],
+        [1, [2]],
+      ]);
+      expect(await service3.getAll("external")).toEqual([[0, [[10, 15]]]]);
+      expect(await service4.getAll("external")).toEqual([[1, [[20, 22]]]]);
+    } finally {
+      if (service1) await service1.close();
+      if (service2) await service2.close();
+      if (service3) await service3.close();
+      if (service4) await service4.close();
+    }
+  });
 }

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -17,6 +17,7 @@ import type {
   NamedCollections,
   SubscriptionID,
   Nullable,
+  Reducer,
 } from "@skipruntime/core";
 
 import { Count, Sum } from "@skipruntime/helpers";
@@ -381,6 +382,34 @@ class MapReduceResource implements Resource<Input_NN> {
 const mapReduceService: SkipService<Input_NN, Input_NN> = {
   initialData: { input: [] },
   resources: { mapReduce: MapReduceResource },
+
+  createGraph(inputCollections: Input_NN) {
+    return inputCollections;
+  },
+};
+
+//// testUserMapReduce
+class UserSum implements Reducer<number, number> {
+  initial = 0;
+
+  add(accum: Nullable<number>, value: number): number {
+    return (accum ?? 0) + value;
+  }
+
+  remove(accum: number, value: number): Nullable<number> {
+    return accum - value;
+  }
+}
+
+class UserMapReduceResource implements Resource<Input_NN> {
+  instantiate(cs: Input_NN): EagerCollection<number, number> {
+    return cs.input.mapReduce(TestOddEven)(UserSum);
+  }
+}
+
+const userMapReduceService: SkipService<Input_NN, Input_NN> = {
+  initialData: { input: [] },
+  resources: { userMapReduce: UserMapReduceResource },
 
   createGraph(inputCollections: Input_NN) {
     return inputCollections;
@@ -1199,6 +1228,39 @@ export function initTests(
   it("testMapReduce", async () => {
     const service = await initService(mapReduceService);
     const resource = "mapReduce";
+    await service.update("input", [
+      [0, [1]],
+      [1, [1]],
+      [2, [1]],
+    ]);
+    expect(await service.getAll(resource)).toEqual([
+      [0, [2]],
+      [1, [1]],
+    ]);
+    await service.update("input", [[3, [2]]]);
+    expect(await service.getAll(resource)).toEqual([
+      [0, [2]],
+      [1, [3]],
+    ]);
+    await service.update("input", [
+      [0, [2]],
+      [1, [2]],
+    ]);
+    expect(await service.getAll(resource)).toEqual([
+      [0, [3]],
+      [1, [4]],
+    ]);
+
+    await service.update("input", [[3, []]]);
+    expect(await service.getAll(resource)).toEqual([
+      [0, [3]],
+      [1, [2]],
+    ]);
+  });
+
+  it("testUserMapReduce", async () => {
+    const service = await initService(userMapReduceService);
+    const resource = "userMapReduce";
     await service.update("input", [
       [0, [1]],
       [1, [1]],

--- a/skipruntime-ts/tests/src/with-error.ts
+++ b/skipruntime-ts/tests/src/with-error.ts
@@ -1,0 +1,7 @@
+import type { Mapper, Values } from "@skipruntime/core";
+
+export class ReloadMapper implements Mapper<number, number, number, number> {
+  mapEntry(_key: number, _values: Values<number>): Iterable<[number, number]> {
+    throw new Error("Something goes wrong.");
+  }
+}

--- a/skipruntime-ts/tests/src/with-error.ts
+++ b/skipruntime-ts/tests/src/with-error.ts
@@ -1,7 +1,20 @@
-import type { Mapper, Values } from "@skipruntime/core";
+import type {
+  EagerCollection,
+  Mapper,
+  Values,
+  Resource,
+} from "@skipruntime/core";
 
 export class ReloadMapper implements Mapper<number, number, number, number> {
   mapEntry(_key: number, _values: Values<number>): Iterable<[number, number]> {
+    throw new Error("Something goes wrong.");
+  }
+}
+
+type Input_NN = { input: EagerCollection<number, number> };
+
+export class ReloadResource implements Resource<Input_NN> {
+  instantiate(_collections: Input_NN): EagerCollection<number, number> {
     throw new Error("Something goes wrong.");
   }
 }

--- a/skipruntime-ts/tests/src/with-error.ts
+++ b/skipruntime-ts/tests/src/with-error.ts
@@ -18,3 +18,14 @@ export class ReloadResource implements Resource<Input_NN> {
     throw new Error("Something goes wrong.");
   }
 }
+
+export function service() {
+  return {
+    initialData: { input: [] },
+    resources: { "reload-map": ReloadResource },
+
+    createGraph(_cs: Input_NN) {
+      throw new Error("Something goes wrong.");
+    },
+  };
+}

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -17,6 +17,7 @@ import type {
   ExternalService,
   Resource,
   Watermark,
+  HandlerInfo,
 } from "@skipruntime/core";
 import {
   ServiceInstance,
@@ -55,13 +56,13 @@ export interface FromWasm {
     K2 extends Json,
     V2 extends Json,
   >(
-    ref: Handle<Mapper<K1, V1, K2, V2>>,
+    ref: Handle<HandlerInfo<Mapper<K1, V1, K2, V2>>>,
   ): ptr<Internal.Mapper>;
 
   // LazyCompute
 
   SkipRuntime_createLazyCompute<K extends Json, V extends Json>(
-    ref: Handle<LazyCompute<K, V>>,
+    ref: Handle<HandlerInfo<LazyCompute<K, V>>>,
   ): ptr<Internal.LazyCompute>;
 
   // ExternalService
@@ -228,7 +229,7 @@ export interface FromWasm {
   // Reducer
 
   SkipRuntime_createReducer<K1 extends Json, V1 extends Json>(
-    ref: Handle<Reducer<K1, V1>>,
+    ref: Handle<HandlerInfo<Reducer<K1, V1>>>,
     defaultValue: ptr<Internal.CJSON>,
   ): ptr<Internal.Reducer>;
 
@@ -273,22 +274,24 @@ interface ToWasm {
   // Mapper
 
   SkipRuntime_Mapper__mapEntry(
-    mapper: Handle<JSONMapper>,
+    mapper: Handle<HandlerInfo<JSONMapper>>,
     key: ptr<Internal.CJSON>,
     values: ptr<Internal.NonEmptyIterator>,
   ): ptr<Internal.CJArray>;
 
-  SkipRuntime_deleteMapper(mapper: Handle<JSONMapper>): void;
+  SkipRuntime_deleteMapper(mapper: Handle<HandlerInfo<JSONMapper>>): void;
 
   // LazyCompute
 
   SkipRuntime_LazyCompute__compute(
-    lazyCompute: Handle<JSONLazyCompute>,
+    lazyCompute: Handle<HandlerInfo<JSONLazyCompute>>,
     self: ptr<Internal.String>,
     key: ptr<Internal.CJSON>,
   ): ptr<Internal.CJArray>;
 
-  SkipRuntime_deleteLazyCompute(mapper: Handle<JSONLazyCompute>): void;
+  SkipRuntime_deleteLazyCompute(
+    mapper: Handle<HandlerInfo<JSONLazyCompute>>,
+  ): void;
 
   // ExternalService
 
@@ -362,18 +365,20 @@ interface ToWasm {
   // Reducer
 
   SkipRuntime_Reducer__add(
-    reducer: Handle<Reducer<Json, Json>>,
+    reducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
     acc: ptr<Internal.CJSON>,
     value: ptr<Internal.CJSON>,
   ): ptr<Internal.CJSON>;
 
   SkipRuntime_Reducer__remove(
-    reducer: Handle<Reducer<Json, Json>>,
+    reducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
     acc: ptr<Internal.CJSON>,
     value: ptr<Internal.CJSON>,
   ): Nullable<ptr<Internal.CJSON>>;
 
-  SkipRuntime_deleteReducer(reducer: Handle<Reducer<Json, Json>>): void;
+  SkipRuntime_deleteReducer(
+    reducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
+  ): void;
 
   // Checker
 
@@ -415,12 +420,14 @@ export class WasmFromBinding implements FromBinding {
     V1 extends Json,
     K2 extends Json,
     V2 extends Json,
-  >(ref: Handle<Mapper<K1, V1, K2, V2>>): Pointer<Internal.Mapper> {
+  >(
+    ref: Handle<HandlerInfo<Mapper<K1, V1, K2, V2>>>,
+  ): Pointer<Internal.Mapper> {
     return this.fromWasm.SkipRuntime_createMapper(ref);
   }
 
   SkipRuntime_createLazyCompute<K extends Json, V extends Json>(
-    ref: Handle<LazyCompute<K, V>>,
+    ref: Handle<HandlerInfo<LazyCompute<K, V>>>,
   ): Pointer<Internal.LazyCompute> {
     return this.fromWasm.SkipRuntime_createLazyCompute(ref);
   }
@@ -723,7 +730,7 @@ export class WasmFromBinding implements FromBinding {
   }
 
   SkipRuntime_createReducer<K1 extends Json, V1 extends Json>(
-    ref: Handle<Reducer<K1, V1>>,
+    ref: Handle<HandlerInfo<Reducer<K1, V1>>>,
     defaultValue: Pointer<Internal.CJSON>,
   ): Pointer<Internal.Reducer> {
     return this.fromWasm.SkipRuntime_createReducer(ref, toPtr(defaultValue));
@@ -827,7 +834,7 @@ class LinksImpl implements Links {
   // Mapper
 
   mapEntryOfMapper(
-    skmapper: Handle<JSONMapper>,
+    skmapper: Handle<HandlerInfo<JSONMapper>>,
     key: ptr<Internal.CJSON>,
     values: ptr<Internal.NonEmptyIterator>,
   ): ptr<Internal.CJArray> {
@@ -836,14 +843,14 @@ class LinksImpl implements Links {
     );
   }
 
-  deleteMapper(mapper: Handle<JSONMapper>) {
+  deleteMapper(mapper: Handle<HandlerInfo<JSONMapper>>) {
     this.tobinding.SkipRuntime_deleteMapper(mapper);
   }
 
   // LazyCompute
 
   computeOfLazyCompute(
-    sklazyCompute: Handle<JSONLazyCompute>,
+    sklazyCompute: Handle<HandlerInfo<JSONLazyCompute>>,
     skself: ptr<Internal.String>,
     skkey: ptr<Internal.CJSON>,
   ) {
@@ -856,7 +863,7 @@ class LinksImpl implements Links {
     );
   }
 
-  deleteLazyCompute(lazyCompute: Handle<JSONLazyCompute>) {
+  deleteLazyCompute(lazyCompute: Handle<HandlerInfo<JSONLazyCompute>>) {
     this.tobinding.SkipRuntime_deleteLazyCompute(lazyCompute);
   }
 
@@ -944,7 +951,7 @@ class LinksImpl implements Links {
   // Reducer
 
   addOfReducer(
-    skreducer: Handle<Reducer<Json, Json>>,
+    skreducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
     skacc: ptr<Internal.CJSON>,
     skvalue: ptr<Internal.CJSON>,
   ) {
@@ -954,7 +961,7 @@ class LinksImpl implements Links {
   }
 
   removeOfReducer(
-    skreducer: Handle<Reducer<Json, Json>>,
+    skreducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
     skacc: ptr<Internal.CJSON>,
     skvalue: ptr<Internal.CJSON>,
   ) {
@@ -963,7 +970,7 @@ class LinksImpl implements Links {
     );
   }
 
-  deleteReducer(reducer: Handle<Reducer<Json, Json>>) {
+  deleteReducer(reducer: Handle<HandlerInfo<Reducer<Json, Json>>>) {
     this.tobinding.SkipRuntime_deleteReducer(reducer);
   }
 

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -32,6 +32,7 @@ import type {
   Handle,
   Notifier,
   Executor,
+  IntExecutor,
 } from "@skipruntime/core/binding.js";
 
 import type { Json } from "@skipruntime/core/json.js";
@@ -170,6 +171,24 @@ export interface FromWasm {
     executor: ptr<Internal.Executor>,
   ): Handle<Error>;
 
+  SkipRuntime_Runtime__resourceInstances(
+    resources: ptr<Internal.CJArray<Internal.CJString>>,
+  ): ptr<Internal.CJArray<Internal.CJObject>>;
+
+  SkipRuntime_Runtime__reloadResource(
+    resource: ptr<Internal.String>,
+    jsonParams: ptr<Internal.CJObject>,
+    executor: ptr<Internal.Executor>,
+  ): Handle<Error>;
+
+  SkipRuntime_Runtime__replaceActiveResources(
+    resources: ptr<Internal.CJArray<Internal.CJObject>>,
+  ): Handle<Error>;
+
+  SkipRuntime_Runtime__destroyResources(
+    resources: ptr<Internal.CJArray<Internal.CJObject>>,
+  ): Handle<Error>;
+
   SkipRuntime_Runtime__getAll(
     resource: ptr<Internal.String>,
     params: ptr<Internal.CJSON>,
@@ -238,6 +257,9 @@ export interface FromWasm {
   // Executor
 
   SkipRuntime_createExecutor(ref: Handle<Executor>): ptr<Internal.Executor>;
+  SkipRuntime_createIntExecutor(
+    ref: Handle<IntExecutor>,
+  ): ptr<Internal.Executor>;
 }
 
 interface ToWasm {
@@ -372,6 +394,10 @@ interface ToWasm {
   // Executor
 
   SkipRuntime_Executor__resolve(skexecutor: Handle<Executor>): void;
+  SkipRuntime_IntExecutor__resolve(
+    skexecutor: Handle<IntExecutor>,
+    value: bigint,
+  ): void;
 
   SkipRuntime_Executor__reject(
     skexecutor: Handle<Executor>,
@@ -607,6 +633,42 @@ export class WasmFromBinding implements FromBinding {
     );
   }
 
+  SkipRuntime_Runtime__resourceInstances(
+    resources: ptr<Internal.CJArray<Internal.CJString>>,
+  ): ptr<Internal.CJArray<Internal.CJObject>> {
+    return this.fromWasm.SkipRuntime_Runtime__resourceInstances(
+      toPtr(resources),
+    );
+  }
+
+  SkipRuntime_Runtime__reloadResource(
+    resource: string,
+    params: ptr<Internal.CJObject>,
+    executor: ptr<Internal.Executor>,
+  ): Handle<Error> {
+    return this.fromWasm.SkipRuntime_Runtime__reloadResource(
+      this.utils.exportString(resource),
+      toPtr(params),
+      toPtr(executor),
+    );
+  }
+
+  SkipRuntime_Runtime__replaceActiveResources(
+    resources: ptr<Internal.CJArray<Internal.CJObject>>,
+  ): Handle<Error> {
+    return this.fromWasm.SkipRuntime_Runtime__replaceActiveResources(
+      toPtr(resources),
+    );
+  }
+
+  SkipRuntime_Runtime__destroyResources(
+    resources: ptr<Internal.CJArray<Internal.CJObject>>,
+  ): Handle<Error> {
+    return this.fromWasm.SkipRuntime_Runtime__destroyResources(
+      toPtr(resources),
+    );
+  }
+
   SkipRuntime_Runtime__getAll(
     resource: string,
     params: Pointer<Internal.CJSON>,
@@ -726,6 +788,12 @@ export class WasmFromBinding implements FromBinding {
     ref: Handle<Executor>,
   ): Pointer<Internal.Executor> {
     return this.fromWasm.SkipRuntime_createExecutor(ref);
+  }
+
+  SkipRuntime_createIntExecutor(
+    ref: Handle<IntExecutor>,
+  ): Pointer<Internal.Executor> {
+    return this.fromWasm.SkipRuntime_createIntExecutor(ref);
   }
 }
 
@@ -989,6 +1057,10 @@ class LinksImpl implements Links {
     this.tobinding.SkipRuntime_Executor__resolve(skexecutor);
   }
 
+  resolveOfIntExecutor(skexecutor: Handle<IntExecutor>, value: bigint) {
+    this.tobinding.SkipRuntime_IntExecutor__resolve(skexecutor, value);
+  }
+
   rejectOfExecutor(skexecutor: Handle<Executor>, error: Handle<Error>) {
     this.tobinding.SkipRuntime_Executor__reject(skexecutor, error);
   }
@@ -1082,6 +1154,8 @@ class Manager implements ToWasmManager {
     // Executor
 
     toWasm.SkipRuntime_Executor__resolve = links.resolveOfExecutor.bind(links);
+    toWasm.SkipRuntime_IntExecutor__resolve =
+      links.resolveOfIntExecutor.bind(links);
     toWasm.SkipRuntime_Executor__reject = links.rejectOfExecutor.bind(links);
     toWasm.SkipRuntime_deleteExecutor = links.deleteExecutor.bind(links);
 

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -241,6 +241,9 @@ export interface FromWasm {
 
   // closeClose
   SkipRuntime_closeService(): ptr<Internal.CJSON>;
+  SkipRuntime_invalidateCollections(
+    collections: ptr<Internal.CJArray<Internal.CJSON>>,
+  ): Handle<Error>;
 
   // Context
 
@@ -752,6 +755,12 @@ export class WasmFromBinding implements FromBinding {
 
   SkipRuntime_closeService(): Pointer<Internal.CJSON> {
     return this.fromWasm.SkipRuntime_closeService();
+  }
+
+  SkipRuntime_invalidateCollections(
+    collections: Pointer<Internal.CJArray<Internal.CJSON>>,
+  ): Handle<Error> {
+    return this.fromWasm.SkipRuntime_invalidateCollections(toPtr(collections));
   }
 
   SkipRuntime_Context__createLazyCollection(

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -320,6 +320,10 @@ interface ToWasm {
     skservice: Handle<ServiceDefinition>,
   ): ptr<Internal.CJArray<Internal.CJSON>>;
 
+  SkipRuntime_ServiceDefinition__from(
+    skservice: Handle<ServiceDefinition>,
+  ): Nullable<ptr<Internal.String>>;
+
   SkipRuntime_ServiceDefinition__resources(
     skservice: Handle<ServiceDefinition>,
   ): ptr<Internal.CJArray<Internal.CJSON>>;
@@ -942,6 +946,13 @@ class LinksImpl implements Links {
     );
   }
 
+  fromOfServiceDefinition(
+    skservice: Handle<ServiceDefinition>,
+  ): Nullable<ptr<Internal.String>> {
+    const from = this.tobinding.SkipRuntime_ServiceDefinition__from(skservice);
+    return from ? this.utils.exportString(from) : null;
+  }
+
   resourcesOfServiceDefinition(
     skservice: Handle<ServiceDefinition>,
   ): ptr<Internal.CJArray<Internal.CJSON>> {
@@ -1149,6 +1160,8 @@ class Manager implements ToWasmManager {
       links.createGraphOfServiceDefinition.bind(links);
     toWasm.SkipRuntime_ServiceDefinition__inputs =
       links.inputsOfServiceDefinition.bind(links);
+    toWasm.SkipRuntime_ServiceDefinition__from =
+      links.fromOfServiceDefinition.bind(links);
     toWasm.SkipRuntime_ServiceDefinition__resources =
       links.resourcesOfServiceDefinition.bind(links);
     toWasm.SkipRuntime_ServiceDefinition__initialData =

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -774,7 +774,7 @@ export class WasmFromBinding implements FromBinding {
   }
 
   SkipRuntime_invalidateCollections(
-    collections: Pointer<Internal.CJArray<Internal.CJSON>>,
+    collections: Pointer<Internal.CJArray<Internal.CJString>>,
   ): Handle<Error> {
     return this.fromWasm.SkipRuntime_invalidateCollections(toPtr(collections));
   }

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -184,6 +184,7 @@ export interface FromWasm {
   ): Handle<Error>;
 
   SkipRuntime_Runtime__replaceActiveResources(
+    service: ptr<Internal.String>,
     resources: ptr<Internal.CJArray<Internal.CJObject>>,
   ): Handle<Error>;
 
@@ -644,7 +645,7 @@ export class WasmFromBinding implements FromBinding {
   }
 
   SkipRuntime_Runtime__resourceInstances(
-    resources: ptr<Internal.CJArray<Internal.CJString>>,
+    resources: Pointer<Internal.CJArray<Internal.CJString>>,
   ): ptr<Internal.CJArray<Internal.CJObject>> {
     return this.fromWasm.SkipRuntime_Runtime__resourceInstances(
       toPtr(resources),
@@ -654,8 +655,8 @@ export class WasmFromBinding implements FromBinding {
   SkipRuntime_Runtime__reloadResource(
     service: string,
     resource: string,
-    params: ptr<Internal.CJObject>,
-    executor: ptr<Internal.Executor>,
+    params: Pointer<Internal.CJObject>,
+    executor: Pointer<Internal.Executor>,
   ): Handle<Error> {
     return this.fromWasm.SkipRuntime_Runtime__reloadResource(
       this.utils.exportString(service),
@@ -666,15 +667,17 @@ export class WasmFromBinding implements FromBinding {
   }
 
   SkipRuntime_Runtime__replaceActiveResources(
-    resources: ptr<Internal.CJArray<Internal.CJObject>>,
+    service: string,
+    resources: Pointer<Internal.CJArray<Internal.CJObject>>,
   ): Handle<Error> {
     return this.fromWasm.SkipRuntime_Runtime__replaceActiveResources(
+      this.utils.exportString(service),
       toPtr(resources),
     );
   }
 
   SkipRuntime_Runtime__destroyResources(
-    resources: ptr<Internal.CJArray<Internal.CJObject>>,
+    resources: Pointer<Internal.CJArray<Internal.CJObject>>,
   ): Handle<Error> {
     return this.fromWasm.SkipRuntime_Runtime__destroyResources(
       toPtr(resources),

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -165,6 +165,7 @@ export interface FromWasm {
   // Runtime
 
   SkipRuntime_Runtime__createResource(
+    service: ptr<Internal.String>,
     identifier: ptr<Internal.String>,
     resource: ptr<Internal.String>,
     params: ptr<Internal.CJSON>,
@@ -176,6 +177,7 @@ export interface FromWasm {
   ): ptr<Internal.CJArray<Internal.CJObject>>;
 
   SkipRuntime_Runtime__reloadResource(
+    service: ptr<Internal.String>,
     resource: ptr<Internal.String>,
     jsonParams: ptr<Internal.CJObject>,
     executor: ptr<Internal.Executor>,
@@ -190,11 +192,13 @@ export interface FromWasm {
   ): Handle<Error>;
 
   SkipRuntime_Runtime__getAll(
+    service: ptr<Internal.String>,
     resource: ptr<Internal.String>,
     params: ptr<Internal.CJSON>,
   ): ptr<Internal.CJObject | Internal.CJFloat>;
 
   SkipRuntime_Runtime__getForKey(
+    service: ptr<Internal.String>,
     resource: ptr<Internal.String>,
     params: ptr<Internal.CJSON>,
     key: ptr<Internal.CJSON>,
@@ -213,6 +217,7 @@ export interface FromWasm {
   SkipRuntime_Runtime__unsubscribe(id: bigint): Handle<Error>;
 
   SkipRuntime_Runtime__update(
+    service: ptr<Internal.String>,
     input: ptr<Internal.String>,
     values: ptr<Internal.CJArray<Internal.CJArray<Internal.CJSON>>>,
     executor: ptr<Internal.Executor>,
@@ -227,12 +232,15 @@ export interface FromWasm {
 
   // initService
   SkipRuntime_initService(
+    identifier: ptr<Internal.String>,
     service: ptr<Internal.Service>,
     executor: ptr<Internal.Executor>,
   ): Handle<Error>;
 
   // closeClose
-  SkipRuntime_closeService(): Handle<Error> | Handle<Promise<unknown>>;
+  SkipRuntime_closeService(
+    service: ptr<Internal.String>,
+  ): Handle<Error> | Handle<Promise<unknown>>;
   SkipRuntime_invalidateCollections(
     collections: ptr<Internal.CJArray<Internal.CJSON>>,
   ): Handle<Error>;
@@ -620,12 +628,14 @@ export class WasmFromBinding implements FromBinding {
   }
 
   SkipRuntime_Runtime__createResource(
+    service: string,
     identifier: string,
     resource: string,
     params: Pointer<Internal.CJSON>,
     executor: Pointer<Internal.Executor>,
   ): Handle<Error> {
     return this.fromWasm.SkipRuntime_Runtime__createResource(
+      this.utils.exportString(service),
       this.utils.exportString(identifier),
       this.utils.exportString(resource),
       toPtr(params),
@@ -642,11 +652,13 @@ export class WasmFromBinding implements FromBinding {
   }
 
   SkipRuntime_Runtime__reloadResource(
+    service: string,
     resource: string,
     params: ptr<Internal.CJObject>,
     executor: ptr<Internal.Executor>,
   ): Handle<Error> {
     return this.fromWasm.SkipRuntime_Runtime__reloadResource(
+      this.utils.exportString(service),
       this.utils.exportString(resource),
       toPtr(params),
       toPtr(executor),
@@ -670,21 +682,25 @@ export class WasmFromBinding implements FromBinding {
   }
 
   SkipRuntime_Runtime__getAll(
+    service: string,
     resource: string,
     params: Pointer<Internal.CJSON>,
   ): Pointer<Internal.CJObject | Internal.CJFloat> {
     return this.fromWasm.SkipRuntime_Runtime__getAll(
+      this.utils.exportString(service),
       this.utils.exportString(resource),
       toPtr(params),
     );
   }
 
   SkipRuntime_Runtime__getForKey(
+    service: string,
     resource: string,
     params: Pointer<Internal.CJSON>,
     key: Pointer<Internal.CJSON>,
   ): Pointer<Internal.CJObject | Internal.CJFloat> {
     return this.fromWasm.SkipRuntime_Runtime__getForKey(
+      this.utils.exportString(service),
       this.utils.exportString(resource),
       toPtr(params),
       toPtr(key),
@@ -714,11 +730,13 @@ export class WasmFromBinding implements FromBinding {
   }
 
   SkipRuntime_Runtime__update(
+    service: string,
     input: string,
     values: Pointer<Internal.CJArray<Internal.CJArray<Internal.CJSON>>>,
     executor: Pointer<Internal.Executor>,
   ): Handle<Error> {
     return this.fromWasm.SkipRuntime_Runtime__update(
+      this.utils.exportString(service),
       this.utils.exportString(input),
       toPtr(values),
       toPtr(executor),
@@ -733,17 +751,23 @@ export class WasmFromBinding implements FromBinding {
   }
 
   SkipRuntime_initService(
+    identifier: string,
     service: Pointer<Internal.Service>,
-    executor: ptr<Internal.Executor>,
+    executor: Pointer<Internal.Executor>,
   ): Handle<Error> {
     return this.fromWasm.SkipRuntime_initService(
+      this.utils.exportString(identifier),
       toPtr(service),
       toPtr(executor),
     );
   }
 
-  SkipRuntime_closeService(): Handle<Error> | Handle<Promise<unknown>> {
-    return this.fromWasm.SkipRuntime_closeService();
+  SkipRuntime_closeService(
+    identifier: string,
+  ): Handle<Error> | Handle<Promise<unknown>> {
+    return this.fromWasm.SkipRuntime_closeService(
+      this.utils.exportString(identifier),
+    );
   }
 
   SkipRuntime_invalidateCollections(

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -364,6 +364,10 @@ interface ToWasm {
 
   // Reducer
 
+  SkipRuntime_Reducer__init(
+    reducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
+  ): ptr<Internal.CJSON>;
+
   SkipRuntime_Reducer__add(
     reducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
     acc: ptr<Internal.CJSON>,
@@ -950,6 +954,10 @@ class LinksImpl implements Links {
 
   // Reducer
 
+  initOfReducer(skreducer: Handle<HandlerInfo<Reducer<Json, Json>>>) {
+    return toPtr(this.tobinding.SkipRuntime_Reducer__init(skreducer));
+  }
+
   addOfReducer(
     skreducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
     skacc: ptr<Internal.CJSON>,
@@ -1104,6 +1112,7 @@ class Manager implements ToWasmManager {
 
     // Reducer
 
+    toWasm.SkipRuntime_Reducer__init = links.initOfReducer.bind(links);
     toWasm.SkipRuntime_Reducer__add = links.addOfReducer.bind(links);
     toWasm.SkipRuntime_Reducer__remove = links.removeOfReducer.bind(links);
     toWasm.SkipRuntime_deleteReducer = links.deleteReducer.bind(links);

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -18,6 +18,7 @@ import type {
   Resource,
   Watermark,
   HandlerInfo,
+  ServiceDefinition,
 } from "@skipruntime/core";
 import {
   ServiceInstance,
@@ -27,10 +28,8 @@ import {
 } from "@skipruntime/core";
 
 import type {
-  Checker,
   FromBinding,
   Handle,
-  ResourceBuilder,
   Notifier,
   Executor,
 } from "@skipruntime/core/binding.js";
@@ -94,37 +93,11 @@ export interface FromWasm {
 
   SkipRuntime_createResource(ref: Handle<Resource>): ptr<Internal.Resource>;
 
-  // ResourceBuilder
-  SkipRuntime_createResourceBuilder(
-    ref: Handle<ResourceBuilder>,
-  ): ptr<Internal.ResourceBuilder>;
+  // Service
 
-  // ResourceBuilder
   SkipRuntime_createService(
-    ref: Handle<SkipService>,
-    jsInputs: ptr<Internal.CJObject>,
-    resources: ptr<Internal.ResourceBuilderMap>,
-    remotes: ptr<Internal.ExternalServiceMap>,
+    ref: Handle<ServiceDefinition>,
   ): ptr<Internal.Service>;
-
-  // ResourceBuilderMap
-
-  SkipRuntime_ResourceBuilderMap__create(): ptr<Internal.ResourceBuilderMap>;
-
-  SkipRuntime_ResourceBuilderMap__add(
-    map: ptr<Internal.ResourceBuilderMap>,
-    key: ptr<Internal.String>,
-    collection: ptr<Internal.ResourceBuilder>,
-  ): void;
-
-  // ExternalServiceMap
-
-  SkipRuntime_ExternalServiceMap__create(): ptr<Internal.ExternalServiceMap>;
-  SkipRuntime_ExternalServiceMap__add(
-    map: ptr<Internal.ExternalServiceMap>,
-    key: ptr<Internal.String>,
-    collection: ptr<Internal.ExternalService>,
-  ): void;
 
   // Collection
 
@@ -240,7 +213,7 @@ export interface FromWasm {
   ): Handle<Error>;
 
   // closeClose
-  SkipRuntime_closeService(): ptr<Internal.CJSON>;
+  SkipRuntime_closeService(): Handle<Error> | Handle<Promise<unknown>>;
   SkipRuntime_invalidateCollections(
     collections: ptr<Internal.CJArray<Internal.CJSON>>,
   ): Handle<Error>;
@@ -296,27 +269,6 @@ interface ToWasm {
     mapper: Handle<HandlerInfo<JSONLazyCompute>>,
   ): void;
 
-  // ExternalService
-
-  SkipRuntime_ExternalService__subscribe(
-    supplier: Handle<ExternalService>,
-    collection: ptr<Internal.String>,
-    instance: ptr<Internal.String>,
-    resource: ptr<Internal.String>,
-    params: ptr<Internal.CJSON>,
-  ): void;
-
-  SkipRuntime_ExternalService__unsubscribe(
-    supplier: Handle<ExternalService>,
-    instance: ptr<Internal.String>,
-  ): void;
-
-  SkipRuntime_ExternalService__shutdown(
-    supplier: Handle<ExternalService>,
-  ): Handle<Promise<void>>;
-
-  SkipRuntime_deleteExternalService(supplier: Handle<ExternalService>): void;
-
   // Resource
 
   SkipRuntime_Resource__instantiate(
@@ -326,23 +278,53 @@ interface ToWasm {
 
   SkipRuntime_deleteResource(resource: Handle<Resource>): void;
 
-  // ResourceBuilder
+  // ServiceDefinition
 
-  SkipRuntime_ResourceBuilder__build(
-    builder: Handle<ResourceBuilder>,
-    params: ptr<Internal.CJSON>,
-  ): ptr<Internal.Resource>;
-
-  SkipRuntime_deleteResourceBuilder(builder: Handle<ResourceBuilder>): void;
-
-  // Service
-
-  SkipRuntime_Service__createGraph(
-    resource: Handle<SkipService>,
+  SkipRuntime_ServiceDefinition__createGraph(
+    resource: Handle<ServiceDefinition>,
     collections: ptr<Internal.CJObject>,
   ): ptr<Internal.CJObject>;
 
-  SkipRuntime_deleteService(service: Handle<SkipService>): void;
+  SkipRuntime_ServiceDefinition__inputs(
+    skservice: Handle<ServiceDefinition>,
+  ): ptr<Internal.CJArray<Internal.CJSON>>;
+
+  SkipRuntime_ServiceDefinition__resources(
+    skservice: Handle<ServiceDefinition>,
+  ): ptr<Internal.CJArray<Internal.CJSON>>;
+
+  SkipRuntime_ServiceDefinition__initialData(
+    skservice: Handle<ServiceDefinition>,
+    name: ptr<Internal.String>,
+  ): ptr<Internal.CJArray<Internal.CJSON>>;
+
+  SkipRuntime_ServiceDefinition__buildResource(
+    skservice: Handle<ServiceDefinition>,
+    name: ptr<Internal.String>,
+    skparams: ptr<Internal.CJObject>,
+  ): ptr<Internal.Resource>;
+
+  SkipRuntime_ServiceDefinition__subscribe(
+    skservice: Handle<ServiceDefinition>,
+    external: ptr<Internal.String>,
+    writerId: ptr<Internal.String>,
+    instance: ptr<Internal.String>,
+    resource: ptr<Internal.String>,
+    skparams: ptr<Internal.CJObject>,
+  ): void;
+
+  SkipRuntime_ServiceDefinition__unsubscribe(
+    skservice: Handle<ServiceDefinition>,
+    external: ptr<Internal.String>,
+    instance: ptr<Internal.String>,
+  ): void;
+
+  SkipRuntime_ServiceDefinition__shutdown(
+    skservice: Handle<ServiceDefinition>,
+    external: ptr<Internal.String>,
+  ): Handle<Promise<unknown>>;
+
+  SkipRuntime_deleteService(service: Handle<ServiceDefinition>): void;
 
   // Notifier
 
@@ -386,15 +368,6 @@ interface ToWasm {
   SkipRuntime_deleteReducer(
     reducer: Handle<HandlerInfo<Reducer<Json, Json>>>,
   ): void;
-
-  // Checker
-
-  SkipRuntime_Checker__check(
-    checker: Handle<Checker>,
-    request: ptr<Internal.String>,
-  ): void;
-
-  SkipRuntime_deleteChecker(checker: Handle<Checker>): void;
 
   // Executor
 
@@ -485,56 +458,10 @@ export class WasmFromBinding implements FromBinding {
     return this.fromWasm.SkipRuntime_createResource(ref);
   }
 
-  SkipRuntime_createResourceBuilder(
-    ref: Handle<ResourceBuilder>,
-  ): Pointer<Internal.ResourceBuilder> {
-    return this.fromWasm.SkipRuntime_createResourceBuilder(ref);
-  }
-
   SkipRuntime_createService(
-    ref: Handle<SkipService>,
-    jsInputs: Pointer<Internal.CJObject>,
-    resources: Pointer<Internal.ResourceBuilderMap>,
-    remotes: Pointer<Internal.ExternalServiceMap>,
+    ref: Handle<ServiceDefinition>,
   ): Pointer<Internal.Service> {
-    return this.fromWasm.SkipRuntime_createService(
-      ref,
-      toPtr(jsInputs),
-      toPtr(resources),
-      toPtr(remotes),
-    );
-  }
-
-  SkipRuntime_ResourceBuilderMap__create(): Pointer<Internal.ResourceBuilderMap> {
-    return this.fromWasm.SkipRuntime_ResourceBuilderMap__create();
-  }
-
-  SkipRuntime_ResourceBuilderMap__add(
-    map: Pointer<Internal.ResourceBuilderMap>,
-    key: string,
-    collection: Pointer<Internal.ResourceBuilder>,
-  ): void {
-    this.fromWasm.SkipRuntime_ResourceBuilderMap__add(
-      toPtr(map),
-      this.utils.exportString(key),
-      toPtr(collection),
-    );
-  }
-
-  SkipRuntime_ExternalServiceMap__create(): Pointer<Internal.ExternalServiceMap> {
-    return this.fromWasm.SkipRuntime_ExternalServiceMap__create();
-  }
-
-  SkipRuntime_ExternalServiceMap__add(
-    map: Pointer<Internal.ExternalServiceMap>,
-    key: string,
-    collection: Pointer<Internal.ExternalService>,
-  ): void {
-    this.fromWasm.SkipRuntime_ExternalServiceMap__add(
-      toPtr(map),
-      this.utils.exportString(key),
-      toPtr(collection),
-    );
+    return this.fromWasm.SkipRuntime_createService(ref);
   }
 
   SkipRuntime_Collection__getArray(
@@ -753,7 +680,7 @@ export class WasmFromBinding implements FromBinding {
     );
   }
 
-  SkipRuntime_closeService(): Pointer<Internal.CJSON> {
+  SkipRuntime_closeService(): Handle<Error> | Handle<Promise<unknown>> {
     return this.fromWasm.SkipRuntime_closeService();
   }
 
@@ -898,33 +825,99 @@ class LinksImpl implements Links {
     this.tobinding.SkipRuntime_deleteResource(resource);
   }
 
-  // ResourceBuilder
+  // ServiceDefinition
 
-  buildOfResourceBuilder(
-    skbuilder: Handle<ResourceBuilder>,
-    skparams: ptr<Internal.CJSON>,
-  ): ptr<Internal.Resource> {
-    return toPtr(
-      this.tobinding.SkipRuntime_ResourceBuilder__build(skbuilder, skparams),
-    );
-  }
-
-  deleteResourceBuilder(builder: Handle<ResourceBuilder>) {
-    this.tobinding.SkipRuntime_deleteResourceBuilder(builder);
-  }
-
-  // Service
-
-  createGraphOfService(
-    skservice: Handle<SkipService>,
+  createGraphOfServiceDefinition(
+    skservice: Handle<ServiceDefinition>,
     skcollections: ptr<Internal.CJObject>,
   ) {
     return toPtr(
-      this.tobinding.SkipRuntime_Service__createGraph(skservice, skcollections),
+      this.tobinding.SkipRuntime_ServiceDefinition__createGraph(
+        skservice,
+        skcollections,
+      ),
     );
   }
 
-  deleteService(service: Handle<SkipService>) {
+  inputsOfServiceDefinition(
+    skservice: Handle<ServiceDefinition>,
+  ): ptr<Internal.CJArray<Internal.CJSON>> {
+    return toPtr(
+      this.tobinding.SkipRuntime_ServiceDefinition__inputs(skservice),
+    );
+  }
+
+  resourcesOfServiceDefinition(
+    skservice: Handle<ServiceDefinition>,
+  ): ptr<Internal.CJArray<Internal.CJSON>> {
+    return toPtr(
+      this.tobinding.SkipRuntime_ServiceDefinition__resources(skservice),
+    );
+  }
+
+  initialDataOfServiceDefinition(
+    skservice: Handle<ServiceDefinition>,
+    name: ptr<Internal.String>,
+  ): ptr<Internal.CJArray<Internal.CJSON>> {
+    return toPtr(
+      this.tobinding.SkipRuntime_ServiceDefinition__initialData(
+        skservice,
+        this.utils.importString(name),
+      ),
+    );
+  }
+
+  buildResourceOfServiceDefinition(
+    skservice: Handle<ServiceDefinition>,
+    name: ptr<Internal.String>,
+    skparams: ptr<Internal.CJObject>,
+  ): ptr<Internal.Resource> {
+    return toPtr(
+      this.tobinding.SkipRuntime_ServiceDefinition__buildResource(
+        skservice,
+        this.utils.importString(name),
+        skparams,
+      ),
+    );
+  }
+
+  subscribeOfServiceDefinition(
+    skservice: Handle<ServiceDefinition>,
+    external: ptr<Internal.String>,
+    writerId: ptr<Internal.String>,
+    instance: ptr<Internal.String>,
+    resource: ptr<Internal.String>,
+    skparams: ptr<Internal.CJObject>,
+  ): void {
+    this.tobinding.SkipRuntime_ServiceDefinition__subscribe(
+      skservice,
+      this.utils.importString(external),
+      this.utils.importString(writerId),
+      this.utils.importString(instance),
+      this.utils.importString(resource),
+      skparams,
+    );
+  }
+
+  unsubscribeOfServiceDefinition(
+    skservice: Handle<ServiceDefinition>,
+    external: ptr<Internal.String>,
+    instance: ptr<Internal.String>,
+  ): void {
+    this.tobinding.SkipRuntime_ServiceDefinition__unsubscribe(
+      skservice,
+      this.utils.importString(external),
+      this.utils.importString(instance),
+    );
+  }
+
+  shutdownOfServiceDefinition(
+    skservice: Handle<ServiceDefinition>,
+  ): Handle<Promise<unknown>> {
+    return this.tobinding.SkipRuntime_ServiceDefinition__shutdown(skservice);
+  }
+
+  deleteService(service: Handle<ServiceDefinition>) {
     this.tobinding.SkipRuntime_deleteService(service);
   }
 
@@ -991,42 +984,6 @@ class LinksImpl implements Links {
     this.tobinding.SkipRuntime_deleteReducer(reducer);
   }
 
-  // ExternalService
-
-  subscribeOfExternalService(
-    sksupplier: Handle<ExternalService>,
-    skwriter: ptr<Internal.String>,
-    skinstance: ptr<Internal.String>,
-    skresource: ptr<Internal.String>,
-    skparams: ptr<Internal.CJSON>,
-  ) {
-    return this.tobinding.SkipRuntime_ExternalService__subscribe(
-      sksupplier,
-      this.utils.importString(skwriter),
-      this.utils.importString(skinstance),
-      this.utils.importString(skresource),
-      skparams,
-    );
-  }
-
-  unsubscribeOfExternalService(
-    sksupplier: Handle<ExternalService>,
-    skinstance: ptr<Internal.String>,
-  ) {
-    this.tobinding.SkipRuntime_ExternalService__unsubscribe(
-      sksupplier,
-      this.utils.importString(skinstance),
-    );
-  }
-
-  shutdownOfExternalService(sksupplier: Handle<ExternalService>) {
-    return this.tobinding.SkipRuntime_ExternalService__shutdown(sksupplier);
-  }
-
-  deleteExternalService(supplier: Handle<ExternalService>) {
-    this.tobinding.SkipRuntime_deleteExternalService(supplier);
-  }
-
   // Executor
   resolveOfExecutor(skexecutor: Handle<Executor>) {
     this.tobinding.SkipRuntime_Executor__resolve(skexecutor);
@@ -1081,34 +1038,30 @@ class Manager implements ToWasmManager {
       links.computeOfLazyCompute.bind(links);
     toWasm.SkipRuntime_deleteLazyCompute = links.deleteLazyCompute.bind(links);
 
-    // ExternalService
-
-    toWasm.SkipRuntime_ExternalService__unsubscribe =
-      links.unsubscribeOfExternalService.bind(links);
-    toWasm.SkipRuntime_ExternalService__subscribe =
-      links.subscribeOfExternalService.bind(links);
-    toWasm.SkipRuntime_ExternalService__shutdown =
-      links.shutdownOfExternalService.bind(links);
-    toWasm.SkipRuntime_deleteExternalService =
-      links.deleteExternalService.bind(links);
-
     // Resource
 
     toWasm.SkipRuntime_Resource__instantiate =
       links.instantiateOfResource.bind(links);
     toWasm.SkipRuntime_deleteResource = links.deleteResource.bind(links);
 
-    // ResourceBuilder
+    // ServiceDefinition
 
-    toWasm.SkipRuntime_ResourceBuilder__build =
-      links.buildOfResourceBuilder.bind(links);
-    toWasm.SkipRuntime_deleteResourceBuilder =
-      links.deleteResourceBuilder.bind(links);
-
-    // Service
-
-    toWasm.SkipRuntime_Service__createGraph =
-      links.createGraphOfService.bind(links);
+    toWasm.SkipRuntime_ServiceDefinition__createGraph =
+      links.createGraphOfServiceDefinition.bind(links);
+    toWasm.SkipRuntime_ServiceDefinition__inputs =
+      links.inputsOfServiceDefinition.bind(links);
+    toWasm.SkipRuntime_ServiceDefinition__resources =
+      links.resourcesOfServiceDefinition.bind(links);
+    toWasm.SkipRuntime_ServiceDefinition__initialData =
+      links.initialDataOfServiceDefinition.bind(links);
+    toWasm.SkipRuntime_ServiceDefinition__buildResource =
+      links.buildResourceOfServiceDefinition.bind(links);
+    toWasm.SkipRuntime_ServiceDefinition__subscribe =
+      links.subscribeOfServiceDefinition.bind(links);
+    toWasm.SkipRuntime_ServiceDefinition__unsubscribe =
+      links.unsubscribeOfServiceDefinition.bind(links);
+    toWasm.SkipRuntime_ServiceDefinition__shutdown =
+      links.shutdownOfServiceDefinition.bind(links);
     toWasm.SkipRuntime_deleteService = links.deleteService.bind(links);
 
     // Notifier


### PR DESCRIPTION
No reuse in this version.

For Mapper/Reducer/LazyCompute:
- Replace the corresponding constructor, then invalidate the dependent collections.

For Resource:
- Load a new instance for each existing resource instance and, if everything is correct, replace the old resources with the new ones.

For the service:
- Load a new instance of the service and, if everything is correct, reload all the resources that exist in the service.