### PR TITLE
skargo: merge bin and test into a single binary in dev mode

### DIFF
--- a/skiplang/skargo/Skargo.toml
+++ b/skiplang/skargo/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skargo"
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/skargo/src/build_context.sk
+++ b/skiplang/skargo/src/build_context.sk
@@ -93,6 +93,11 @@ private class BuildContext{
   target_data: SkcTargetData,
 }
 
+// In dev mode with bins, all targets are merged into a single binary.
+fun should_merge(profile: String, manifest: Manifest): Bool {
+  profile == "dev" && manifest.has_bins()
+}
+
 // TODO: Return Result<...>
 fun create_bctx(
   gctx: GlobalContext,
@@ -170,8 +175,7 @@ private fun generate_root_units(
   // In dev mode with binaries, merge all bin+test targets into a single
   // __merged binary. Each original bin/test becomes a HardlinkTarget.
   !targets = if (
-    build_config.requested_profile == "dev" &&
-    targets.any(t -> t.is_bin())
+    should_merge(build_config.requested_profile, package.manifest)
   ) {
     merged = Target(BinTarget("SkipInternal.dispatch"), "__merged", Array[]);
 
@@ -347,8 +351,7 @@ private fun compute_deps(
     | BinTarget _ -> false
     | LibTarget _ ->
       dep.kind is NormalDep _ ||
-        (unit.profile == "dev" &&
-          unit.pkg.manifest.targets.any(t -> t.is_bin()) &&
+        (should_merge(unit.profile, unit.pkg.manifest) &&
           dep.kind is DevelopmentDep _)
     | TestTarget _ -> dep.kind is DevelopmentDep _
     | CustomBuildTarget _ -> dep.kind is BuildDep _

--- a/skiplang/skargo/src/build_context.sk
+++ b/skiplang/skargo/src/build_context.sk
@@ -184,12 +184,7 @@ private fun generate_root_units(
       }
     );
 
-    // If any hardlink was created, ensure __merged is also a root.
-    if (replaced.any(t -> t.kind is HardlinkTarget _)) {
-      Array[merged].concat(replaced)
-    } else {
-      replaced
-    }
+    Array[merged].concat(replaced)
   } else {
     targets
   };

--- a/skiplang/skargo/src/build_context.sk
+++ b/skiplang/skargo/src/build_context.sk
@@ -283,6 +283,9 @@ private fun compute_deps(
   unit_deps = mutable Vector[];
 
   unit.target.kind match {
+  | HardlinkTarget _ ->
+    // Hardlink targets have no compilation deps; they just link.
+    return Array[]
   | BinTarget _
   | TestTarget _
   | LibTarget(LibraryTypeCdylib _) ->
@@ -323,6 +326,7 @@ private fun compute_deps(
     | LibTarget _ -> dep.kind is NormalDep _
     | TestTarget _ -> dep.kind is DevelopmentDep _
     | CustomBuildTarget _ -> dep.kind is BuildDep _
+    | HardlinkTarget _ -> false
     }
   );
   for (dep in deps) {

--- a/skiplang/skargo/src/build_context.sk
+++ b/skiplang/skargo/src/build_context.sk
@@ -167,6 +167,33 @@ private fun generate_root_units(
     );
     res.collect(Array)
   };
+  // In dev mode with binaries, merge all bin+test targets into a single
+  // __merged binary. Each original bin/test becomes a HardlinkTarget.
+  !targets = if (
+    build_config.requested_profile == "dev" &&
+    targets.any(t -> t.is_bin())
+  ) {
+    merged = Target(BinTarget("SkipInternal.dispatch"), "__merged", Array[]);
+
+    // Replace bin/test targets with hardlinks; keep lib and others as-is.
+    replaced = targets.map(t ->
+      if (t.is_bin() || t.is_test()) {
+        t with {kind => HardlinkTarget("__merged")}
+      } else {
+        t
+      }
+    );
+
+    // If any hardlink was created, ensure __merged is also a root.
+    if (replaced.any(t -> t.kind is HardlinkTarget _)) {
+      Array[merged].concat(replaced)
+    } else {
+      replaced
+    }
+  } else {
+    targets
+  };
+
   targets
     .map(target -> {
       Unit(
@@ -323,7 +350,11 @@ private fun compute_deps(
     // Binary targets always depend on the lib target, which pulls in the
     // dependencies transitively.
     | BinTarget _ -> false
-    | LibTarget _ -> dep.kind is NormalDep _
+    | LibTarget _ ->
+      dep.kind is NormalDep _ ||
+        (unit.profile == "dev" &&
+          unit.pkg.manifest.targets.any(t -> t.is_bin()) &&
+          dep.kind is DevelopmentDep _)
     | TestTarget _ -> dep.kind is DevelopmentDep _
     | CustomBuildTarget _ -> dep.kind is BuildDep _
     | HardlinkTarget _ -> false

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -181,8 +181,19 @@ mutable class BuildRunner(
 
       // Hardlink targets don't compile — just create the link.
       if (unit.target.kind is HardlinkTarget _) {
-        this.prepare_unit(unit);
-        this.link_targets(unit);
+        if (!check) {
+          this.prepare_unit(unit);
+          this.link_targets(unit)
+        };
+        continue
+      };
+
+      // In check mode, skip bin roots — the lib check covers all code.
+      if (
+        check &&
+        unit.target.kind is BinTarget _ &&
+        this.bctx.roots.contains(unit)
+      ) {
         continue
       };
 

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -600,6 +600,66 @@ mutable class BuildRunner(
     }
   }
 
+  private mutable fun generate_dispatcher(unit: Unit): String {
+    dir = Path.join(this.layout_for(unit).build, "dispatch");
+    this.create_dir(dir);
+    dispatcher_path = Path.join(dir, "__skargo_dispatch.sk");
+
+    bins = unit.pkg.manifest.targets.filter(t -> t.is_bin()).collect(Array);
+    test_entry_opt = unit.pkg.manifest.test_target().map(t ->
+      t.kind match {
+      | TestTarget(e) -> e
+      | _ -> invariant_violation("expected TestTarget")
+      }
+    );
+
+    lines = mutable Vector[];
+    lines.push("module SkipInternal;");
+    lines.push("untracked fun dispatch(): void {");
+    lines.push("  name = Environ.varOpt(\"SKARGO_BIN\") match {");
+    lines.push("  | Some(n) -> n");
+    lines.push("  | None() -> Path.basename(Environ.args().next().fromSome())");
+    lines.push("  };");
+    lines.push("  name match {");
+    for (bin in bins) {
+      bin.kind match {
+      | BinTarget(entry) -> lines.push(`  | "${bin.name}" -> ${entry}()`)
+      | _ -> invariant_violation("expected BinTarget")
+      }
+    };
+    test_entry_opt.each(test_entry ->
+      lines.push(`  | "test" -> ${test_entry}()`)
+    );
+    if (bins.size() == 1 && test_entry_opt.isNone()) {
+      bins[0].kind match {
+      | BinTarget(entry) -> lines.push(`  | _ -> ${entry}()`)
+      | _ -> invariant_violation("expected BinTarget")
+      }
+    } else if (bins.size() == 1) {
+      bins[0].kind match {
+      | BinTarget(entry) -> lines.push(`  | _ -> ${entry}()`)
+      | _ -> invariant_violation("expected BinTarget")
+      }
+    } else {
+      names = bins.map(b -> b.name);
+      if (test_entry_opt.isSome()) !names = names.concat(Array["test"]);
+      lines.push(`  | unknown ->`);
+      lines.push(
+        `    print_error("Unknown binary '" + unknown + "'. Set SKARGO_BIN to one of: ${names.join(
+          ", ",
+        )}");`,
+      );
+      lines.push("    skipExit(1)")
+    };
+    lines.push("  }");
+    lines.push("}");
+    lines.push("module end;");
+
+    content = lines.join("\n");
+    FileSystem.writeTextFile(dispatcher_path, content);
+    dispatcher_path
+  }
+
   private readonly fun build_dir_for(unit: Unit): String {
     assert(unit.target.is_build_script());
 

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -617,7 +617,7 @@ mutable class BuildRunner(
     this.create_dir(dir);
     dispatcher_path = Path.join(dir, "__skargo_dispatch.sk");
 
-    bins = unit.pkg.manifest.targets.filter(t -> t.is_bin()).collect(Array);
+    bins = unit.pkg.manifest.targets.filter(t -> t.is_bin());
     test_entry_opt = unit.pkg.manifest.test_target().map(t ->
       t.kind match {
       | TestTarget(e) -> e
@@ -642,12 +642,7 @@ mutable class BuildRunner(
     test_entry_opt.each(test_entry ->
       lines.push(`  | "test" -> ${test_entry}()`)
     );
-    if (bins.size() == 1 && test_entry_opt.isNone()) {
-      bins[0].kind match {
-      | BinTarget(entry) -> lines.push(`  | _ -> ${entry}()`)
-      | _ -> invariant_violation("expected BinTarget")
-      }
-    } else if (bins.size() == 1) {
+    if (bins.size() == 1) {
       bins[0].kind match {
       | BinTarget(entry) -> lines.push(`  | _ -> ${entry}()`)
       | _ -> invariant_violation("expected BinTarget")
@@ -657,7 +652,7 @@ mutable class BuildRunner(
       if (test_entry_opt.isSome()) !names = names.concat(Array["test"]);
       lines.push(`  | unknown ->`);
       lines.push(
-        `    print_error("Unknown binary '" + unknown + "'. Set SKARGO_BIN to one of: ${names.join(
+        `    print_error("Unknown binary '\`\${unknown}\`'. Set SKARGO_BIN to one of: ${names.join(
           ", ",
         )}");`,
       );

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -187,11 +187,7 @@ mutable class BuildRunner(
       };
 
       if (this.unit_is_dirty(unit)) {
-        if (
-          check &&
-          this.bctx.roots.contains(unit) &&
-          (this.bctx.roots.size() == 1 || unit.target.kind is TestTarget _)
-        ) {
+        if (check && this.bctx.roots.contains(unit)) {
           this.bctx.gctx.console.status("Checking", unit_name);
           this.create_dir(this.layout_for(unit).build);
           this.skc(unit, /* check = */ true)

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -396,8 +396,7 @@ mutable class BuildRunner(
     // __merged (and all hardlinked bins/test) can link against it.
     if (
       unit.target.kind is LibTarget(LibraryTypeSklib _) &&
-      unit.profile == "dev" &&
-      unit.pkg.manifest.targets.any(t -> t.is_bin())
+      should_merge(unit.profile, unit.pkg.manifest)
     ) {
       unit.pkg.manifest.test_target().each(t -> skc.args(t.srcs));
       dispatcher_path = this.generate_dispatcher(unit);

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -396,6 +396,18 @@ mutable class BuildRunner(
 
     skc.args(unit.target.srcs);
 
+    // In dev mode, the lib includes test sources and the dispatcher so that
+    // __merged (and all hardlinked bins/test) can link against it.
+    if (
+      unit.target.kind is LibTarget(LibraryTypeSklib _) &&
+      unit.profile == "dev" &&
+      unit.pkg.manifest.targets.any(t -> t.is_bin())
+    ) {
+      unit.pkg.manifest.test_target().each(t -> skc.args(t.srcs));
+      dispatcher_path = this.generate_dispatcher(unit);
+      skc.arg(dispatcher_path)
+    };
+
     if (!unit.target.is_build_script()) {
       // TODO: Once we have namespaced packages, we can share the state.db
       // across architectures.

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -178,6 +178,14 @@ mutable class BuildRunner(
       unit_name = `${unit.pkg.name()} v${unit.pkg.version()} [${
         unit.target.name
       }] (${unit.pkg.root()})`;
+
+      // Hardlink targets don't compile — just create the link.
+      if (unit.target.kind is HardlinkTarget _) {
+        this.prepare_unit(unit);
+        this.link_targets(unit);
+        continue
+      };
+
       if (this.unit_is_dirty(unit)) {
         if (
           check &&
@@ -416,7 +424,9 @@ mutable class BuildRunner(
     | BinTarget(e)
     | TestTarget(e) ->
       skc.args(Array["--export-function-as", `${e}=skip_main`])
-    | CustomBuildTarget() -> void
+    | CustomBuildTarget()
+    | HardlinkTarget _ ->
+      void
     };
 
     // TODO: Proper Profile class.
@@ -525,6 +535,17 @@ mutable class BuildRunner(
           export_path => export_dir.map(d ->
             Path.join(d, unit.target.name + suffix)
           ),
+        }
+      };
+      res.push(file)
+    | HardlinkTarget(source) ->
+      // Link from the source binary (e.g., __merged) to this target's name.
+      source_path = Path.join(layout.dest, source);
+      file = OutputFile(source_path, None(), None());
+      if (is_root) {
+        !file = file with {
+          hardlink => Some(Path.join(layout.dest, unit.target.name)),
+          export_path => export_dir.map(d -> Path.join(d, unit.target.name)),
         }
       };
       res.push(file)

--- a/skiplang/skargo/src/commands/check.sk
+++ b/skiplang/skargo/src/commands/check.sk
@@ -33,8 +33,7 @@ fun execCheck(gctx: GlobalContext, args: Cli.ParseResults): void {
   opts = compile_options(args);
   // In dev mode with bins, use the default filter to trigger merged mode.
   // Otherwise, check lib + tests only.
-  has_bins = ws.package.manifest.targets.any(t -> t.is_bin());
-  if (opts.build_config.requested_profile != "dev" || !has_bins) {
+  if (!should_merge(opts.build_config.requested_profile, ws.package.manifest)) {
     !opts.filter = CompileFilterOnly{
       lib => LibRuleTrue(),
       bins => FilterRule::none(),

--- a/skiplang/skargo/src/commands/check.sk
+++ b/skiplang/skargo/src/commands/check.sk
@@ -30,12 +30,16 @@ fun check(): (Cli.Command, (GlobalContext, Cli.ParseResults) ~> void) {
 
 fun execCheck(gctx: GlobalContext, args: Cli.ParseResults): void {
   ws = workspace(args, gctx);
-  opts = compile_options(args) with {
-    filter => CompileFilterOnly{
+  opts = compile_options(args);
+  // In dev mode with bins, use the default filter to trigger merged mode.
+  // Otherwise, check lib + tests only.
+  has_bins = ws.package.manifest.targets.any(t -> t.is_bin());
+  if (opts.build_config.requested_profile != "dev" || !has_bins) {
+    !opts.filter = CompileFilterOnly{
       lib => LibRuleTrue(),
       bins => FilterRule::none(),
       tests => FilterRuleAll(),
-    },
+    }
   };
   bctx = create_bctx(gctx, ws, opts);
   withTimer(

--- a/skiplang/skargo/src/commands/run.sk
+++ b/skiplang/skargo/src/commands/run.sk
@@ -70,8 +70,8 @@ fun execRun(gctx: GlobalContext, args: Cli.ParseResults): void {
     opts.build_config.requested_profile,
   );
   binary = Path.join(path, bin_name);
-  // In merged mode (dev), set SKARGO_BIN so the dispatcher routes correctly.
-  if (opts.build_config.requested_profile == "dev") {
+  // In merged mode, set SKARGO_BIN so the dispatcher routes correctly.
+  if (should_merge(opts.build_config.requested_profile, ws.package.manifest)) {
     Environ.set_var("SKARGO_BIN", bin_name)
   };
   gctx.console.status("Running", `\`${binary}\``);

--- a/skiplang/skargo/src/commands/run.sk
+++ b/skiplang/skargo/src/commands/run.sk
@@ -70,6 +70,10 @@ fun execRun(gctx: GlobalContext, args: Cli.ParseResults): void {
     opts.build_config.requested_profile,
   );
   binary = Path.join(path, bin_name);
+  // In merged mode (dev), set SKARGO_BIN so the dispatcher routes correctly.
+  if (opts.build_config.requested_profile == "dev") {
+    Environ.set_var("SKARGO_BIN", bin_name)
+  };
   gctx.console.status("Running", `\`${binary}\``);
   cmd_args = Array[binary].concat(args.extra);
   Posix.execvp(cmd_args)

--- a/skiplang/skargo/src/commands/test.sk
+++ b/skiplang/skargo/src/commands/test.sk
@@ -89,7 +89,7 @@ fun execTest(gctx: GlobalContext, args: Cli.ParseResults): void {
   // Find the test unit: a TestTarget (normal mode) or a HardlinkTarget
   // named "test" (merged mode).
   test_unit = bctx.roots.find(r -> r.target.kind is TestTarget _) match {
-  | Some(u) -> Some(u)
+  | some @ Some _ -> some
   | None() ->
     bctx.roots.find(r ->
       r.target.kind is HardlinkTarget _ && r.target.name == "test"
@@ -109,11 +109,12 @@ fun execTest(gctx: GlobalContext, args: Cli.ParseResults): void {
         "host",
         opts.build_config.requested_profile,
       );
-      Some(Path.join(path, unit.target.name))
+      setSkargoBinEnv = unit.target.kind is HardlinkTarget _;
+      Some((Path.join(path, unit.target.name), setSkargoBinEnv))
     }
   };
   optBinary match {
-  | Some(binary) ->
+  | Some((binary, setSkargoBinEnv)) ->
     if (!FileSystem.exists(binary)) {
       gctx.console.error(
         `\`skargo test\` could not find test binary ${binary}.`,
@@ -121,7 +122,7 @@ fun execTest(gctx: GlobalContext, args: Cli.ParseResults): void {
       skipExit(1)
     };
     // In merged mode, set SKARGO_BIN=test so the dispatcher routes to tests.
-    if (test_unit.fromSome().target.kind is HardlinkTarget _) {
+    if (setSkargoBinEnv) {
       Environ.set_var("SKARGO_BIN", "test")
     };
     cmd_args = Array[binary].concat(

--- a/skiplang/skargo/src/commands/test.sk
+++ b/skiplang/skargo/src/commands/test.sk
@@ -60,7 +60,12 @@ fun test(): (Cli.Command, (GlobalContext, Cli.ParseResults) ~> void) {
 fun execTest(gctx: GlobalContext, args: Cli.ParseResults): void {
   ws = workspace(args, gctx);
   opts = compile_options(args);
-  !opts.filter = CompileFilter::all_tests();
+  // In dev mode with bins, use the default filter to trigger merged mode
+  // (all bins+test->__merged). Otherwise, build just the test target.
+  has_bins = ws.package.manifest.targets.any(t -> t.is_bin());
+  if (opts.build_config.requested_profile != "dev" || !has_bins) {
+    !opts.filter = CompileFilter::all_tests()
+  };
   bctx = create_bctx(gctx, ws, opts);
   withTimer(
     () -> {
@@ -81,14 +86,21 @@ fun execTest(gctx: GlobalContext, args: Cli.ParseResults): void {
   jobs = args.getInt("jobs");
   list = if (args.getBool("list")) Some("--list") else None();
 
-  optBinary = if (
-    bctx.roots.size() != 1 ||
-    !(bctx.roots[0].target.kind is TestTarget _)
-  ) {
+  // Find the test unit: a TestTarget (normal mode) or a HardlinkTarget
+  // named "test" (merged mode).
+  test_unit = bctx.roots.find(r -> r.target.kind is TestTarget _) match {
+  | Some(u) -> Some(u)
+  | None() ->
+    bctx.roots.find(r ->
+      r.target.kind is HardlinkTarget _ && r.target.name == "test"
+    )
+  };
+
+  optBinary = test_unit match {
+  | None() ->
     gctx.console.error("`skargo test` could not find test target.");
     skipExit(1)
-  } else {
-    unit = bctx.roots[0];
+  | Some(unit) ->
     unit.arch match {
     | TargetArchTriple(t) if (t.isWasm32()) -> None()
     | _ -> // TODO: Expose common API with BuildRunner.
@@ -107,6 +119,10 @@ fun execTest(gctx: GlobalContext, args: Cli.ParseResults): void {
         `\`skargo test\` could not find test binary ${binary}.`,
       );
       skipExit(1)
+    };
+    // In merged mode, set SKARGO_BIN=test so the dispatcher routes to tests.
+    if (test_unit.fromSome().target.kind is HardlinkTarget _) {
+      Environ.set_var("SKARGO_BIN", "test")
     };
     cmd_args = Array[binary].concat(
       Array[junitxml, filter, list, Some(`-j${jobs}`)].filterNone(),

--- a/skiplang/skargo/src/commands/test.sk
+++ b/skiplang/skargo/src/commands/test.sk
@@ -60,10 +60,9 @@ fun test(): (Cli.Command, (GlobalContext, Cli.ParseResults) ~> void) {
 fun execTest(gctx: GlobalContext, args: Cli.ParseResults): void {
   ws = workspace(args, gctx);
   opts = compile_options(args);
-  // In dev mode with bins, use the default filter to trigger merged mode
-  // (all bins+test->__merged). Otherwise, build just the test target.
-  has_bins = ws.package.manifest.targets.any(t -> t.is_bin());
-  if (opts.build_config.requested_profile != "dev" || !has_bins) {
+  // In merged mode, use the default filter (all bins+test->__merged).
+  // Otherwise, build just the test target.
+  if (!should_merge(opts.build_config.requested_profile, ws.package.manifest)) {
     !opts.filter = CompileFilter::all_tests()
   };
   bctx = create_bctx(gctx, ws, opts);

--- a/skiplang/skargo/src/manifest.sk
+++ b/skiplang/skargo/src/manifest.sk
@@ -233,6 +233,10 @@ class Manifest(
   fun test_target(): ?Target {
     this.targets.find(t -> t.is_test())
   }
+
+  fun has_bins(): Bool {
+    this.targets.any(t -> t.is_bin())
+  }
 }
 
 class PackageId(

--- a/skiplang/skargo/src/manifest.sk
+++ b/skiplang/skargo/src/manifest.sk
@@ -278,6 +278,7 @@ base class TargetKind uses Equality, Hashable {
   | BinTarget(entry_point: String)
   | TestTarget(entry_point: String)
   | CustomBuildTarget()
+  | HardlinkTarget(source: String)
 }
 
 private fun manifest_targets(


### PR DESCRIPTION
## Summary

Closes #1121.

In dev mode, when a package has `[[bin]]` targets, all binaries and the test target are merged into a **single compiled binary** (`__merged`) with a dispatcher that routes to the correct entry point at runtime. Other binaries and the test binary become hardlinks to `__merged`.

### How it works

- A new `HardlinkTarget(source)` target kind is added — it creates a copy of another binary without compilation
- In dev mode with bins, `generate_root_units()` creates a synthetic `__merged` `BinTarget` and replaces all bin/test targets with `HardlinkTarget("__merged")`
- The **lib** is augmented with test sources and a generated dispatcher function (`SkipInternal.dispatch`), so `__merged` links against it like any normal bin
- The dispatcher checks `SKARGO_BIN` env var (or falls back to `argv[0]` basename) to route to the correct entry point
- `skargo test` / `skargo run` / `skargo check` all use the default filter in dev mode to trigger merged compilation
- Release mode and lib-only packages are unaffected

### Key design decisions

- **Augmented lib approach**: the lib is the single compilation unit containing src/ + tests/ + dispatcher in dev mode. `__merged` is a normal empty-source bin that links against it, matching how regular bins work
- **Dev deps on lib**: in dev mode, the root package's lib pulls `DevelopmentDep` dependencies (e.g., sktest) since it now includes test sources
- **Multi-bin support**: dispatcher handles any number of bins + optional test target

## Files changed

- **manifest.sk** — Added `HardlinkTarget(source: String)` to `TargetKind`
- **build_context.sk** — `generate_root_units()` creates `__merged` + hardlinks in dev mode; `compute_deps()` handles `HardlinkTarget` (no deps) and lib dev deps
- **build_runner.sk** — `generate_dispatcher()` method; `skc()` augments lib with test sources + dispatcher in dev mode; `compile()` and `outputs_for()` handle `HardlinkTarget`
- **commands/test.sk** — Uses default filter in merged mode, finds test as `HardlinkTarget`, sets `SKARGO_BIN=test`
- **commands/run.sk** — Sets `SKARGO_BIN` in dev mode for dispatcher routing
- **commands/check.sk** — Uses default filter in merged mode

## Test plan

- [x] `skargo check` on skargo itself passes at each commit
- [x] `skargo build` on a bin+tests project produces `__merged` + hardlinked `hello` and `test`
- [x] `skargo run` routes to user's `main()` via dispatcher
- [x] `skargo test` runs tests via dispatcher (shows "Fresh", ~0.1s on subsequent runs)
- [x] `skargo check` in dev mode checks everything in a single merged pass
- [x] No dependency cycles (dev deps restricted to root package's lib)
- [ ] Release mode falls back to separate binaries
- [ ] Compiler tests pass

Generated with [Claude Code](https://claude.com/claude-code)