### PR TITLE
Add recommended VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,10 @@
     "docker.docker",
     "ecmel.vscode-html-css",
     "esbenp.prettier-vscode",
+    "fwcd.kotlin",
+    "hashicorp.hcl",
     "ms-azuretools.vscode-containers",
+    "ms-playwright.playwright",
     "ms-azuretools.vscode-docker",
     "ms-python.debugpy",
     "ms-python.python",
@@ -18,6 +21,8 @@
     "skiplabs.skip",
     "streetsidesoftware.code-spell-checker",
     "tamasfe.even-better-toml",
+    "timonwong.shellcheck",
+    "vscjava.vscode-gradle",
     "valmack.circleci-config-validator",
     "yzhang.markdown-all-in-one"
   ]


### PR DESCRIPTION
## Summary
- Add 5 recommended VS Code extensions: Kotlin, HCL, Playwright, ShellCheck, and Gradle

## Test plan
- [x] Verify extensions appear in VS Code recommendations when opening the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)