### PR TITLE
Skip target and node_modules in skargo fmt

### DIFF
--- a/skiplang/skargo/src/commands/fmt.sk
+++ b/skiplang/skargo/src/commands/fmt.sk
@@ -16,8 +16,13 @@ fun format(): (Cli.Command, (GlobalContext, Cli.ParseResults) ~> void) {
 fun execFmt(gctx: GlobalContext, args: Cli.ParseResults): void {
   ws = workspace(args, gctx);
 
-  files = FileSystem.readFilesRecursive(ws.package.root(), f ->
-    f.endsWith(".sk")
+  files = FileSystem.readFilesRecursive(
+    ws.package.root(),
+    f -> f.endsWith(".sk"),
+    d -> {
+      base = Path.basename(d);
+      base != "target" && base != "node_modules"
+    },
   ).toArray();
 
   p = System.subprocess(Array["skfmt", "-i"].concat(files)).fromSuccess();


### PR DESCRIPTION
readFilesRecursive scanned the entire package root including node_modules
trees, causing effectively unbounded memory growth. Add a directoryFilter to
skip target and node_modules directories.