### PR TITLE
Avoid libbacktrace source directory pollution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,12 @@ build/init.sql: sql/privacy/init.sql
 update-js-deps:
 	find . -name node_modules -not -prune -or -name target -not -prune -or -name package.json -exec sh -c 'cd $$(dirname "$$0"); bun update --latest' {} \;
 
+.PHONY: libbacktrace
+libbacktrace:
+	$(MAKE) -C skiplang/prelude libbacktrace
+
 .PHONY: check
-check:
+check: libbacktrace
 	find * -name Skargo.toml -exec sh -c 'bin/cd_sh $$(dirname {}) "skargo check"' \;
 
 .PHONY: check-ts
@@ -163,7 +167,7 @@ setup-git-hooks: .git/hooks/pre-commit
 # test targets
 
 .PHONY: test
-test:
+test: libbacktrace
 	$(MAKE) --keep-going SKARGO_PROFILE=dev SKDB_WASM=sql/target/wasm32-unknown-unknown/dev/skdb.wasm SKDB_BIN=sql/target/host/dev/skdb test-prelude test-skjson test-skipruntime-ts test-native test-wasm
 
 .PHONY: test-prelude

--- a/skiplang/prelude/Makefile
+++ b/skiplang/prelude/Makefile
@@ -41,16 +41,21 @@ $(OUT_DIR)/libbacktrace.a:
 	@[ -d $(OUT_DIR) ] || mkdir -p $(OUT_DIR)
 	cp $(LIB_DIR)/libbacktrace.a $@
 else
-CFLAGS += -I$(realpath libbacktrace)
+LBT_SOURCE=$(realpath libbacktrace)
+LBT_BUILD=$(OUT_DIR)/libbacktrace-build
 
-libbacktrace/Makefile:
+CFLAGS += -I$(LBT_SOURCE)
+
+$(OUT_DIR)/libbacktrace.a:
 	test -f libbacktrace/configure || (echo "Warning: libbacktrace submodule not initialized" && false)
-	(cd libbacktrace && CC=clang ./configure)
-
-$(OUT_DIR)/libbacktrace.a: libbacktrace/Makefile
+	@rm -f libbacktrace/config.status libbacktrace/config.h libbacktrace/config.log \
+	       libbacktrace/Makefile libbacktrace/libtool libbacktrace/stamp-h1 \
+	       libbacktrace/*.lo libbacktrace/*.o
+	@rm -rf libbacktrace/.libs libbacktrace/.deps
+	@if [ ! -f $(LBT_BUILD)/Makefile ]; then mkdir -p $(LBT_BUILD) && cd $(LBT_BUILD) && CC=clang $(LBT_SOURCE)/configure; fi
 	@[ -d $(OUT_DIR) ] || mkdir -p $(OUT_DIR)
-	$(MAKE) -C libbacktrace
-	cp libbacktrace/.libs/libbacktrace.a $@
+	$(MAKE) -C $(LBT_BUILD)
+	cp $(LBT_BUILD)/.libs/libbacktrace.a $@
 endif
 
 .PHONY: $(OUT_DIR)/libskip_runtime64.a
@@ -76,9 +81,16 @@ $(OUT_DIR)/libskip_runtime32.a: $(OUT_DIR)/libskip_runtime32.o
 $(OUT_DIR)/libstd.sklib: $(OUT_DIR)/libskip_runtime64.a $(OUT_DIR)/libbacktrace.a $(SKIP_SRC)
 	SKC_PREAMBLE=./preamble/preamble64.ll skc -o $@ --sklib-name std --no-std $(OLEVEL) --link-args '-lpthread' $^
 
+.PHONY: libbacktrace
+libbacktrace: $(OUT_DIR)/libbacktrace.a
+
 .PHONY: clean
 clean:
 	rm -f $(OUT_DIR)/libbacktrace.a $(OUT_DIR)/libskip_runtime64.a $(OUT_DIR)/libstd.sklib
+	rm -rf $(OUT_DIR)/libbacktrace-build
 	$(MAKE) -C runtime clean
-	(test ! -f libbacktrace/Makefile && echo "Warning: libbacktrace submodule or Makefile not initialized") || $(MAKE) -C libbacktrace distclean
+	rm -f libbacktrace/config.status libbacktrace/config.h libbacktrace/config.log \
+	      libbacktrace/Makefile libbacktrace/libtool libbacktrace/stamp-h1 \
+	      libbacktrace/*.lo libbacktrace/*.o
+	rm -rf libbacktrace/.libs libbacktrace/.deps
 	find . -name 'Skargo.toml' -print0 | sed 's|Skargo.toml|target|g' | xargs -0 rm -rf

--- a/skiplang/prelude/build.sk
+++ b/skiplang/prelude/build.sk
@@ -92,6 +92,14 @@ fun build_libbacktrace(
     }
   };
 
+  // Try using Makefile-built libbacktrace (e.g. from `make libbacktrace`).
+  prebuilt = "./build/libbacktrace.a";
+  if (FileSystem.exists(prebuilt)) {
+    prebuilt_abs = FileSystem.realpath(prebuilt);
+    print_string(`skargo:skc-link-lib=${prebuilt_abs}`);
+    return FileSystem.realpath("./libbacktrace")
+  };
+
   // Resort to building libbacktrace from source.
   if (!FileSystem.exists("./libbacktrace/configure")) {
     print_error(
@@ -100,13 +108,18 @@ fun build_libbacktrace(
     );
     skipExit(1)
   };
+  // Build out-of-tree to avoid races when multiple packages build concurrently.
+  source_dir = FileSystem.realpath("./libbacktrace");
+  _ = System.popen{args => Array["mkdir", "-p", out_dir]}.fromSuccess();
   p = System.popen{
-    args => Array["./configure", "--prefix", out_dir].concat(
-      if (pic) Array["--with-pic"] else Array[],
-    ),
+    args => Array[
+      Path.join(source_dir, "configure"),
+      "--prefix",
+      out_dir,
+    ].concat(if (pic) Array["--with-pic"] else Array[]),
     stdout => print_error_raw,
     stderr => print_error_raw,
-    cwd => Some("./libbacktrace"),
+    cwd => Some(out_dir),
   }.fromSuccess();
   if (!p.success()) {
     skipExit(1)
@@ -116,7 +129,7 @@ fun build_libbacktrace(
     args => Array["make", "install"],
     stdout => print_error_raw,
     stderr => print_error_raw,
-    cwd => Some("./libbacktrace"),
+    cwd => Some(out_dir),
   }.fromSuccess();
   if (!p.success()) {
     skipExit(1)


### PR DESCRIPTION
The prelude Makefile configured libbacktrace in-tree, leaving
config.status and .lo files in the source directory. The compiler
Makefile invokes the prelude Makefile with a different OUT_DIR, so the
.a goes to the compiler's build dir while the source dir stays dirty.
When skargo later runs build.sk, the out-of-tree configure fails
because autoconf detects the dirty source directory.

Three fixes, each addressing a different build path:

- Prelude Makefile: configure and build in $(OUT_DIR)/libbacktrace-build/
  instead of in-tree, so the source directory stays clean regardless of
  which OUT_DIR is passed (bootstrap, compiler, or prelude); clean any
  stale in-tree artifacts before configuring
- build.sk: before building from source, check for a pre-built
  ./build/libbacktrace.a from the Makefile and reuse it; the fallback
  source build also uses out-of-tree configure
- Top-level Makefile: add a libbacktrace target and make check/test
  depend on it, so libbacktrace is built once before skargo runs
