### PR TITLE
Implement XXHashable for FlagOption

### DIFF
--- a/skiplang/prelude/src/stdlib/other/XXHash64.sk
+++ b/skiplang/prelude/src/stdlib/other/XXHash64.sk
@@ -19,6 +19,19 @@ extension class SentinelOption uses XXHashable[T: XXHashable] {
   }
 }
 
+extension class FlagOption uses XXHashable[T: XXHashable] {
+  fun xxhash[T: XXHashable](): XXHash {
+    XXHash(
+      if (this.isSome()) {
+        this.unsafeFromSome().xxhash().value + 1
+      } else {
+        // Arbitrary hash value for None(), copied from Option.sk.
+        1027410261
+      },
+    )
+  }
+}
+
 module end;
 
 module XXHash64;

--- a/skiplang/prelude/tests/XXHash.sk
+++ b/skiplang/prelude/tests/XXHash.sk
@@ -1,0 +1,23 @@
+module alias T = SKTest;
+
+module XXHashTest;
+
+@test
+fun testOptionBoolXXHash(): void {
+  someTrueHash = Some(true).xxhash();
+  someFalseHash = Some(false).xxhash();
+  noneHash = (None() : ?Bool).xxhash();
+
+  // Some(true) and Some(false) should produce different hashes
+  T.expectTrue(someTrueHash != someFalseHash);
+
+  // Some(_) and None should produce different hashes
+  T.expectTrue(someTrueHash != noneHash);
+  T.expectTrue(someFalseHash != noneHash);
+
+  // Same input should produce same hash (deterministic)
+  T.expectEq(Some(true).xxhash(), someTrueHash);
+  T.expectEq((None() : ?Bool).xxhash(), noneHash);
+}
+
+module end;


### PR DESCRIPTION
## Summary
- Add `XXHashable` extension for `FlagOption` in the `FastOption` module, mirroring the existing `SentinelOption` extension
- Add test verifying xxhash works correctly with `?Bool` (distinct hashes for `Some(true)`, `Some(false)`, and `None`)

## Test plan
- [x] `skargo test` passes (48/48 tests, including new `XXHashTest.testOptionBoolXXHash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)