### PR TITLE
Bump Skargo package versions to reflect accumulated changes

### DIFF
--- a/skiplang/cli/Skargo.toml
+++ b/skiplang/cli/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/compiler/Skargo.toml
+++ b/skiplang/compiler/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skc"
-version = "0.2.0"
+version = "0.3.0"
 tests = ["tests/tests.sk"]
 test-harness = "SkcTests.main"
 

--- a/skiplang/prelude/Skargo.toml
+++ b/skiplang/prelude/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "std"
-version = "0.2.0"
+version = "0.3.0"
 
 [dev-dependencies]
 sktest = { path = "../sktest" }

--- a/skiplang/skargo/Skargo.toml
+++ b/skiplang/skargo/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skargo"
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
 std = { path = "../prelude" }


### PR DESCRIPTION
## Summary
- Bump version fields in 4 Skargo.toml files to reflect code changes since PR #1095 (merged 2026-02-17)

## Minor bumps (API/feature changes)

| Package | Version | Key changes |
|---------|---------|-------------|
| **std** | 0.2.0 → 0.3.0 | 4 commits: time_ns()/sleep_ms(), FileSystem.stat, tuple iteration, XXHashable for FlagOption |
| **skc** | 0.2.0 → 0.3.0 | 8 commits: `#env()` invalidation fix, extension modifier on children, pattern binding changes |

## Patch bumps (bugfixes)

| Package | Version | Key changes |
|---------|---------|-------------|
| **skargo** | 0.3.0 → 0.3.1 | 1 commit: skip target/node_modules in `skargo fmt` |
| **cli** | 0.1.1 → 0.1.2 | 1 commit: explicit binding for underscore-prefixed fields |

## Unchanged (no source changes) — 12 packages
arparser, cc, semver, skdate, skjson, sktest, skipruntime-core, skipruntime, sql, pkg-config, toml, sqlparser

## Test plan
- [ ] CI passes — versions are metadata embedded by skargo, no build logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)