### PR TITLE
Rename dot-prefix declarations to unique names

### DIFF
--- a/skiplang/compiler/tests/Expand/ExpandModulePrecedence.sk
+++ b/skiplang/compiler/tests/Expand/ExpandModulePrecedence.sk
@@ -1,6 +1,6 @@
 module ExpandExpandModulePrecedenceBar;
 
-class .Bar() {
+class .EMP_Bar() {
   fun foo(): String {
     "Pa"
   }
@@ -15,7 +15,7 @@ module end;
 module ExpandExpandModulePrecedence;
 
 fun main(): void {
-  print_raw(Bar().foo() + ExpandExpandModulePrecedenceBar.foo())
+  print_raw(EMP_Bar().foo() + ExpandExpandModulePrecedenceBar.foo())
 }
 
 module end;

--- a/skiplang/compiler/tests/Expand/ExtensionClassAndModule1.sk
+++ b/skiplang/compiler/tests/Expand/ExtensionClassAndModule1.sk
@@ -1,10 +1,10 @@
 module ExpandExtensionClassAndModule1X;
-class .X() {}
+class .ECAM1_X() {}
 module end;
 
 module ExpandExtensionClassAndModule1;
 
-extension class .X
+extension class .ECAM1_X
 
 fun main(): void {
   print_string("Pass")

--- a/skiplang/compiler/tests/Expand/ExtensionGenerics.sk
+++ b/skiplang/compiler/tests/Expand/ExtensionGenerics.sk
@@ -1,17 +1,17 @@
 module ExpandExtensionGenericsX;
-value class .X<T0>() {}
+value class .EG_X<T0>() {}
 module end;
 
 module ExpandExtensionGenerics;
 
-extension class .X {
+extension class .EG_X {
   fun f(_: T0): void {
     print_string("Pass")
   }
 }
 
 fun main(): void {
-  X<void>().f(void)
+  EG_X<void>().f(void)
 }
 
 module end;

--- a/skiplang/compiler/tests/Expand/FlippedGlobalModule.sk
+++ b/skiplang/compiler/tests/Expand/FlippedGlobalModule.sk
@@ -1,12 +1,12 @@
 module ExpandFlippedGlobalModuleM1;
 
-class .M2()
+class .FGM_M2()
 
 module end;
 
 module ExpandFlippedGlobalModuleM2;
 
-class .M1()
+class .FGM_M1()
 
 module end;
 

--- a/skiplang/compiler/tests/Expand/GlobalAccessPrivate.sk
+++ b/skiplang/compiler/tests/Expand/GlobalAccessPrivate.sk
@@ -1,7 +1,7 @@
 module ExpandGlobalAccessPrivate;
 fun main(): void {
-  _ = GAP_x;
-  _ = GAP_bar();
+  _ = gap_x;
+  _ = gap_bar();
   _: GAP_Tglobal = 42;
   c = GAP_Cglobal();
   _ = c.make();
@@ -15,8 +15,8 @@ module ExpandGlobalAccessPrivateZ;
 private fun foo(): void {
   void
 }
-const .GAP_x: void = void;
-fun .GAP_bar(): void {
+const .gap_x: void = void;
+fun .gap_bar(): void {
   foo()
 }
 

--- a/skiplang/compiler/tests/Expand/GlobalAccessPrivate.sk
+++ b/skiplang/compiler/tests/Expand/GlobalAccessPrivate.sk
@@ -1,9 +1,9 @@
 module ExpandGlobalAccessPrivate;
 fun main(): void {
-  _ = x;
-  _ = bar();
-  _: Tglobal = 42;
-  c = Cglobal();
+  _ = GAP_x;
+  _ = GAP_bar();
+  _: GAP_Tglobal = 42;
+  c = GAP_Cglobal();
   _ = c.make();
   print_string("Pass")
 }
@@ -15,19 +15,19 @@ module ExpandGlobalAccessPrivateZ;
 private fun foo(): void {
   void
 }
-const .x: void = void;
-fun .bar(): void {
+const .GAP_x: void = void;
+fun .GAP_bar(): void {
   foo()
 }
 
 private type Tpriv = Int;
-type .Tglobal = Tpriv;
+type .GAP_Tglobal = Tpriv;
 
 private base class Bpriv
-private class .Cpriv() extends Bpriv
-class .Cglobal() extends Bpriv {
+private class .GAP_Cpriv() extends Bpriv
+class .GAP_Cglobal() extends Bpriv {
   fun make(): Bpriv {
-    Cpriv()
+    GAP_Cpriv()
   }
 }
 

--- a/skiplang/compiler/tests/Expand/GlobalIdentifiers.sk
+++ b/skiplang/compiler/tests/Expand/GlobalIdentifiers.sk
@@ -1,10 +1,10 @@
 module ExpandGlobalIdentifiers;
 fun main(): void {
-  _: GI_TInt = GI_x;
-  //  _ : GI_TInt = GI_Y;
+  _: GI_TInt = gi_x;
+  //  _ : GI_TInt = gi_Y;
   _ = GI_Foo();
   _ = GI_BarChild();
-  print_raw(GI_pass())
+  print_raw(gi_pass())
 }
 
 module end;
@@ -12,14 +12,14 @@ module end;
 module ExpandGlobalIdentifiersM;
 
 type .GI_TInt = Int;
-const .GI_x: Int = 42;
-const .GI_Y: Int = 0;
+const .gi_x: Int = 42;
+const .gi_Y: Int = 0;
 class .GI_Foo()
 base class Bar {
   children =
   | .GI_BarChild()
 }
-fun .GI_pass(): String {
+fun .gi_pass(): String {
   "Pass\n"
 }
 

--- a/skiplang/compiler/tests/Expand/GlobalIdentifiers.sk
+++ b/skiplang/compiler/tests/Expand/GlobalIdentifiers.sk
@@ -1,25 +1,25 @@
 module ExpandGlobalIdentifiers;
 fun main(): void {
-  _: TInt = x;
-  //  _ : TInt = Y;
-  _ = Foo();
-  _ = BarChild();
-  print_raw(pass())
+  _: GI_TInt = GI_x;
+  //  _ : GI_TInt = GI_Y;
+  _ = GI_Foo();
+  _ = GI_BarChild();
+  print_raw(GI_pass())
 }
 
 module end;
 
 module ExpandGlobalIdentifiersM;
 
-type .TInt = Int;
-const .x: Int = 42;
-const .Y: Int = 0;
-class .Foo()
+type .GI_TInt = Int;
+const .GI_x: Int = 42;
+const .GI_Y: Int = 0;
+class .GI_Foo()
 base class Bar {
   children =
-  | .BarChild()
+  | .GI_BarChild()
 }
-fun .pass(): String {
+fun .GI_pass(): String {
   "Pass\n"
 }
 

--- a/skiplang/compiler/tests/Expand/ModuleBaseClassExtend.sk
+++ b/skiplang/compiler/tests/Expand/ModuleBaseClassExtend.sk
@@ -1,17 +1,17 @@
 module ExpandModuleBaseClassExtend;
-base class I1 extends M
+base class I1 extends MBCE_M
 
 module end;
 
 module ExpandModuleBaseClassExtendM;
 
-base class .M
+base class .MBCE_M
 
 module end;
 
 module ExpandModuleBaseClassExtend;
 
-base class I2 extends M
+base class I2 extends MBCE_M
 
 fun main(): void {
   print_string("Pass")

--- a/skiplang/compiler/tests/Expand/ModuleType2.sk
+++ b/skiplang/compiler/tests/Expand/ModuleType2.sk
@@ -1,7 +1,7 @@
 module ExpandModuleType2M;
 
 type T = String;
-class .M() {
+class .MT2_M() {
   type T = String;
 }
 

--- a/skiplang/compiler/tests/Expand/ModuleType3.sk
+++ b/skiplang/compiler/tests/Expand/ModuleType3.sk
@@ -1,7 +1,7 @@
 module ExpandModuleType3M;
 
 type T = String;
-class .M() {
+class .MT3_M() {
   type T2 = String;
 }
 
@@ -9,7 +9,7 @@ module end;
 
 module ExpandModuleType3;
 
-fun pass(): M::T2 {
+fun pass(): MT3_M::T2 {
   "Pass\n"
 }
 

--- a/skiplang/compiler/tests/Runtime/MacroThisClassName.exp
+++ b/skiplang/compiler/tests/Runtime/MacroThisClassName.exp
@@ -1,3 +1,3 @@
 RuntimeMacroThisClassNameM.C
-G
+RMTCN_G
 RuntimeMacroThisClassName.V

--- a/skiplang/compiler/tests/Runtime/MacroThisClassName.sk
+++ b/skiplang/compiler/tests/Runtime/MacroThisClassName.sk
@@ -8,7 +8,7 @@ module end;
 
 module RuntimeMacroThisClassNameM;
 class C() uses RuntimeMacroThisClassName.ClassName {}
-class .G() uses RuntimeMacroThisClassName.ClassName {}
+class .RMTCN_G() uses RuntimeMacroThisClassName.ClassName {}
 module end;
 
 module RuntimeMacroThisClassName;
@@ -16,7 +16,7 @@ value class V() uses ClassName {}
 
 fun main(): void {
   print_string(RuntimeMacroThisClassNameM.C().className());
-  print_string(.G().className());
+  print_string(.RMTCN_G().className());
   print_string(V().className());
 }
 module end;

--- a/skiplang/compiler/tests/Syntax/ExplicityTargs2.sk
+++ b/skiplang/compiler/tests/Syntax/ExplicityTargs2.sk
@@ -1,8 +1,8 @@
 module TestList;
-base class .TestList<T> {
+base class .ET2_TestList<T> {
   children =
   | TestNil()
-  | TestCons(head: T, tail: TestList<T>)
+  | TestCons(head: T, tail: ET2_TestList<T>)
 
   fun getHead(): T
   | TestCons(value, _) -> value

--- a/skiplang/compiler/tests/Syntax/Factory.sk
+++ b/skiplang/compiler/tests/Syntax/Factory.sk
@@ -8,15 +8,15 @@ module end;
 
 module SyntaxFactoryFoo;
 
-class .Foo{private attr: Int} {
+class .SF_Foo{private attr: Int} {
   fun getAttr(): Int {
     this.attr
   }
 }
 
 class Factory() {
-  fun get(attr: Int): Foo {
-    Foo{attr => attr}
+  fun get(attr: Int): SF_Foo {
+    SF_Foo{attr => attr}
   }
 }
 

--- a/skiplang/compiler/tests/Syntax/Module.sk
+++ b/skiplang/compiler/tests/Syntax/Module.sk
@@ -1,6 +1,6 @@
 module SyntaxModule;
 fun main(): void {
-  value = SyntaxModuleX.get() + X().get() + SyntaxModuleX.Y().get();
+  value = SyntaxModuleX.get() + SM_X().get() + SyntaxModuleX.Y().get();
   print_raw(if (value == 11) "Pass\n" else "FAILED")
 }
 
@@ -8,7 +8,7 @@ module end;
 
 module SyntaxModuleX;
 
-class .X() {
+class .SM_X() {
   fun get(): Int {
     1
   }

--- a/skiplang/compiler/tests/Typechecking/UnknownPattern6.sk
+++ b/skiplang/compiler/tests/Typechecking/UnknownPattern6.sk
@@ -7,13 +7,13 @@ module end;
 
 module TypecheckingUnknownPattern6List;
 
-base class .List_<T> {
+base class .UP6_List_<T> {
   children =
   | Nil()
-  | Cell{head: T, tail: List_<T>}
+  | Cell{head: T, tail: UP6_List_<T>}
 }
 
-fun test(x: List_<_>): Int {
+fun test(x: UP6_List_<_>): Int {
   x match {
   | Nil() -> 1
   | Cell _ -> 0


### PR DESCRIPTION
## Summary

Stacked on #1159 (merged).

Dot-prefix names (e.g., `class .X()`) create top-level globals that collide when all tests are compiled into one binary. This renames each dot-prefix declaration with a short unique prefix derived from the test name, so they can coexist.

**14 files modified**, all in `tests/`:
- `Expand/`: ExtensionClassAndModule1, ExtensionGenerics, ExpandModulePrecedence, FlippedGlobalModule, GlobalAccessPrivate, GlobalIdentifiers, ModuleBaseClassExtend, ModuleType2, ModuleType3
- `Syntax/`: ExplicityTargs2, Factory, Module
- `Typechecking/`: UnknownPattern6
- `Runtime/`: MacroThisClassName (+ `.exp` update for `#thisClassName` output)

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)