### PR TITLE
Fix skdb-wasm test flakiness caused by port mismatch

### DIFF
--- a/sql/ts/tests/apitests.ts
+++ b/sql/ts/tests/apitests.ts
@@ -659,7 +659,7 @@ COMMIT;
     const res = (await waitSynch(
       root,
       "select count(*) from has_constraint where i = 2",
-      (rows) => rows.length > 0,
+      (rows) => rows.scalarValue() === 1,
       {},
       true,
     )) as SKDBTable;

--- a/sql/ts/tests/node.play.server.ts
+++ b/sql/ts/tests/node.play.server.ts
@@ -13,6 +13,7 @@ function runServer(
   suffix: string = "",
 ) {
   test(t.name, async () => {
+    test.setTimeout(60000);
     const skdb = await setup(8110, crypto as Crypto, asWorker, suffix);
     const res = await t.fun(skdb);
     t.check(res);

--- a/sql/ts/tests/service_server.sh
+++ b/sql/ts/tests/service_server.sh
@@ -33,6 +33,8 @@ fi
 [ -e "$4/test_chrome.db" ] && rm "$4/test_chrome.db" 1>&2
 [ -e "$4/test_chrome_worker.db" ] && rm "$4/test_chrome_worker.db" 1>&2
 
+skdb_port=3586
+
 # shellcheck disable=SC2034 # value indirectly referenced just below
 while IFS='=' read -r key value
 do
@@ -72,8 +74,6 @@ run_server () {
         return 1
     fi
 }
-
-skdb_port=3586
 
 pid1=""
 i=0

--- a/sql/ts/tests/service_server.sh
+++ b/sql/ts/tests/service_server.sh
@@ -65,6 +65,8 @@ run_server () {
         echo "Gave up waiting for server $pid1 to start at $host" 1>&2;
         echo "Config:" 1>&2
         cat "$2" 1>&2
+        kill $pid1 2>/dev/null
+        return 1
     fi
 
     exists=$(kill -0 $pid1);


### PR DESCRIPTION
## Summary

Fixes #615 — the long-standing flakiness of the `[server_nodejs] › node.play.server.ts:15:3 › API` test in the `skdb-wasm` CI job.

## Root cause (layered issues)

### 1. Port mismatch (shellcheck regression, Jan 2025 — most impactful)

Commit `414d5c3f7` ("Make shellcheck happy") added `skdb_port=3586` **after** the config read loop, overwriting the correct value (`8110`). The Java server listens on 8110 (from config), but the health check curls 3586 — always fails. Combined with issue #2, the script always proceeds without confirming the server is ready.

### 2. Health check doesn't fail properly

`service_server.sh` starts the Java server and waits up to 10s for a health check response. If the check times out, it prints "Gave up waiting" but **falls through** to a `kill -0` check, which succeeds as long as the process exists — regardless of whether it's accepting connections. Tests proceed against a potentially unready server.

### 3. Tight test timeout

The "API" test runs 12 sequential server operations (queries, mirroring, tailing, privacy, constraints, schema changes, reboot) in a single Playwright test with the default 30s timeout. On CI, this is borderline. This was identified early: `fac170883` bumped it to 60s but `d9fcc48ae` dropped it back.

### 4. Race condition in testConstraints

The `waitSynch` check for a `SELECT count(*)` query used `(rows) => rows.length > 0`, which is always true since `count(*)` always returns exactly one row (with value 0 or 1). This caused `waitSynch` to resolve immediately without waiting for replication, making the assertion a race condition.

### How they compound

On retry after a failure, the server is running but the database has stale state from the first attempt, causing `Duplicate element` errors (Skip's `Map.add` on an existing key). So the test fails all 3 attempts with different errors.

## Fix (four commits)

1. **Fix port mismatch**: Move the `skdb_port=3586` default before the config read loop so the config value wins. Keeps shellcheck happy.

2. **Fail on health check timeout**: Kill the server and return failure so the outer retry loop starts a fresh instance, instead of silently proceeding with an unready server.

3. **Increase test timeout to 60s**: 30s is too tight for 12 sequential server round-trips on CI.

4. **Fix waitSynch check in testConstraints**: Use `(rows) => rows.scalarValue() === 1` to match the pattern used by all other count-based `waitSynch` calls in the file.

## Test plan

- [ ] CI `skdb-wasm` job passes on this branch
- [ ] CI logs show `Server is running on port 8110` instead of `Gave up waiting`
- [ ] Monitor subsequent CI runs to confirm the flakiness is resolved


🤖 Generated with [Claude Code](https://claude.com/claude-code)