### PR TITLE
skargo: skip --no-link for wasm32 targets

### DIFF
--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -462,9 +462,14 @@ mutable class BuildRunner(
       assert(outputs.size() == 1);
       output_file = outputs[0].path;
       skc.args(Array["-o", output_file]);
-      unit.target.kind is BinTarget _ ||
-        unit.target.kind is TestTarget _ ||
-        unit.target.kind is LibTarget(LibraryTypeCdylib())
+      is_wasm = unit.arch match {
+      | TargetArchTriple(t) -> t.isWasm32()
+      | _ -> false
+      };
+      !is_wasm &&
+        (unit.target.kind is BinTarget _ ||
+          unit.target.kind is TestTarget _ ||
+          unit.target.kind is LibTarget(LibraryTypeCdylib()))
     };
 
     if (separate_link) {


### PR DESCRIPTION
## Summary
- Fix wasm32 cdylib builds broken by #1115's `--no-link` flag
- wasm32 linking runs inline inside skc (`getLinkArgs()` returns `None()`), so the link args markers are never printed — skargo then fails with "Missing link args"
- Skip `separate_link` when the target is wasm32

## Test plan
- [x] Reproduced: `skargo build -r --target wasm32-unknown-unknown --lib --manifest-path=sql/Skargo.toml` fails without fix
- [x] Verified: same command succeeds with fix
- [x] Verified: native builds still use separate linking

🤖 Generated with [Claude Code](https://claude.com/claude-code)