### PR TITLE
skc/skargo: bump versions and update bootstrap

### DIFF
--- a/skiplang/compiler/Skargo.toml
+++ b/skiplang/compiler/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skc"
-version = "0.3.0"
+version = "0.3.1"
 tests = ["tests/tests.sk"]
 test-harness = "SkcTests.main"
 

--- a/skiplang/skargo/Skargo.toml
+++ b/skiplang/skargo/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skargo"
-version = "0.3.2"
+version = "0.3.3"
 
 [dependencies]
 std = { path = "../prelude" }


### PR DESCRIPTION
## Summary
- Bump skc version to 0.3.1 (includes `--no-link` flag from #1115)
- Bump skargo version to 0.3.3 (includes wasm32 fix from #1175)
- Update bootstrap with new stage 1 binaries

## Test plan
- [ ] CI passes with new bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)